### PR TITLE
Tests and Efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 # SHAP-IQ: SHAP Interaction Quantification
 > An interaction may speak more than a thousand main effects.
 
-SHAP Interaction Quantification (short SHAP-IQ) is a **xai framework** extending on the well-known `shap` explanations by introducing interactions to the equation.
+SHAP Interaction Quantification (short SHAP-IQ) is an **XAI framework** extending on the well-known `shap` explanations by introducing interactions to the equation.
 Shapley interactions extend on indivdual Shapley values by quantifying the **synergy** effect between machine learning entities such as features, data points, or weak learners in ensemble models.
 Synergies between these entities (also called players in game theory jargon) allows for a more intricate evaluation of your **black-box** models!
 

--- a/setup.py
+++ b/setup.py
@@ -18,36 +18,27 @@ with open(os.path.join(work_directory, NAME, "__version__.py")) as f:
 with io.open(os.path.join(work_directory, "README.md"), encoding="utf-8") as f:
     long_description = "\n" + f.read()
 
-base_packages = [
-    "shap",
-    "numpy",
-    "scipy"
-]
+base_packages = ["shap", "numpy", "scipy"]
 
-plotting_packages = [
-    "matplotlib",
-    "colour",
-    "networkx"
-]
+plotting_packages = ["matplotlib", "colour", "networkx"]
 
 doc_packages = [
     "sphinx",
     "sphinx-autodoc-typehints",
     "sphinx_rtd_theme",
     "sphinx_toolbox",
-    #"myst_nb",
+    # "myst_nb",
     "nbsphinx",  # for rendering jupyter notebooks
     "pandoc",  # for rendering jupyter notebooks
     "furo",  # theme of the docs
     "sphinx-copybutton",  # easier copy-pasting of code snippets from docs
-    "myst-parser"  # parse md and rst files
+    "myst-parser",  # parse md and rst files
 ]
 
 dev_packages = [
     "build",
     "black",
-    "pytest"
-
+    "pytest" "coverage",
 ]
 
 setuptools.setup(
@@ -62,13 +53,13 @@ setuptools.setup(
     url=URL,
     project_urls={
         "Tracker": "https://github.com/mmschlk/shapiq/issues?q=is%3Aissue+label%3Abug",
-        "Source": "https://github.com/mmschlk/shapiq"
+        "Source": "https://github.com/mmschlk/shapiq",
     },
-    packages=setuptools.find_packages(exclude=('tests', 'examples', 'docs')),
+    packages=setuptools.find_packages(exclude=("tests", "examples", "docs")),
     install_requires=base_packages + plotting_packages,
     extras_require={
         "docs": base_packages + plotting_packages + doc_packages,
-        "dev": base_packages + plotting_packages + doc_packages + dev_packages
+        "dev": base_packages + plotting_packages + doc_packages + dev_packages,
     },
     include_package_data=True,
     license="MIT",
@@ -82,8 +73,8 @@ setuptools.setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11"
+        "Programming Language :: Python :: 3.11",
     ],
     keywords=["python", "machine learning", "shap", "xai", "interaction"],
-    zip_safe=True
+    zip_safe=True,
 )

--- a/shapiq/approximator/_base.py
+++ b/shapiq/approximator/_base.py
@@ -85,6 +85,7 @@ class InteractionValues:
         Returns:
             The interaction value.
         """
+        item = tuple(sorted(item))
         return float(self.values[self.interaction_lookup[item]])
 
     def __eq__(self, other: object) -> bool:

--- a/shapiq/approximator/_base.py
+++ b/shapiq/approximator/_base.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional
 import numpy as np
 from scipy.special import binom
 
-from utils import powerset, split_subsets_budget
+from utils import powerset, split_subsets_budget, get_explicit_subsets
 
 AVAILABLE_INDICES = {"SII", "nSII", "STI", "FSI"}
 
@@ -491,7 +491,7 @@ class ShapleySamplingMixin:
             order=1, n=self.n, budget=budget, sampling_weights=sampling_weights
         )
         # enumerate all explicit subsets
-        explicit_subsets: np.ndarray[bool] = self._get_explicit_subsets(self.n, explicit_sizes)
+        explicit_subsets: np.ndarray[bool] = get_explicit_subsets(self.n, explicit_sizes)
         n_explicit_subsets = explicit_subsets.shape[0]
         all_subsets[:n_explicit_subsets] = explicit_subsets
         n_subsets += n_explicit_subsets

--- a/shapiq/approximator/_base.py
+++ b/shapiq/approximator/_base.py
@@ -178,9 +178,8 @@ class Approximator(ABC):
             False, the approximation is performed for all orders up to the specified order.
         min_order: The minimum order of the approximation. If top_order is True, min_order is equal
             to max_order. Otherwise, min_order is equal to 1.
+        iteration_cost: The cost of a single iteration of the approximator.
 
-    Properties:
-        iteration_cost: The cost of a single iteration of the approximation.
     """
 
     @abstractmethod
@@ -213,7 +212,6 @@ class Approximator(ABC):
         }
         self._random_state: Optional[int] = random_state
         self._rng: Optional[np.random.Generator] = np.random.default_rng(seed=self._random_state)
-        self._iteration_cost: Optional[int] = None
 
     @abstractmethod
     def approximate(
@@ -233,20 +231,6 @@ class Approximator(ABC):
             NotImplementedError: If the method is not implemented.
         """
         raise NotImplementedError("The approximate method needs to be implemented.")
-
-    @property
-    def iteration_cost(self) -> int:
-        """Returns the cost of a single iteration of the approximation.
-
-        Returns:
-            The cost of a single iteration.
-        """
-        if self._iteration_cost is None:
-            if hasattr(self, "_compute_iteration_cost"):
-                self._iteration_cost = self._compute_iteration_cost()
-            else:
-                return 1
-        return self._iteration_cost
 
     def _init_result(self, dtype=float) -> np.ndarray:
         """Initializes the result array. The result array is a 1D array of size n_interactions as

--- a/shapiq/approximator/_base.py
+++ b/shapiq/approximator/_base.py
@@ -316,26 +316,6 @@ class Approximator(ABC):
             n_iterations += 1
         return n_iterations, last_batch_size
 
-    @staticmethod
-    def _get_explicit_subsets(n: int, subset_sizes: list[int]) -> np.ndarray[bool]:
-        """Enumerates all subsets of the given sizes and returns a one-hot matrix.
-
-        Args:
-            n: number of players.
-            subset_sizes: list of subset sizes.
-
-        Returns:
-            one-hot matrix of all subsets of certain sizes.
-        """
-        total_subsets = int(sum(binom(n, size) for size in subset_sizes))
-        subset_matrix = np.zeros(shape=(total_subsets, n), dtype=bool)
-        subset_index = 0
-        for subset_size in subset_sizes:
-            for subset in itertools.combinations(range(n), subset_size):
-                subset_matrix[subset_index, subset] = True
-                subset_index += 1
-        return subset_matrix
-
     def __repr__(self) -> str:
         """Returns the representation of the Approximator object."""
         return (

--- a/shapiq/approximator/_base.py
+++ b/shapiq/approximator/_base.py
@@ -271,14 +271,6 @@ class Approximator(ABC):
         Returns:
             The interaction values.
         """
-        # transform FSI representation into the interaction values
-        if self.index == "FSI":
-            result_fsi = self._init_result()
-            fsi_index = 0
-            for interaction in powerset(self.N, min_size=1, max_size=self.max_order):
-                result_fsi[len(interaction)][interaction] = result[fsi_index]
-                fsi_index += 1
-            result = result_fsi
         # create InteractionValues object
         return InteractionValues(
             values=result,

--- a/shapiq/approximator/_base.py
+++ b/shapiq/approximator/_base.py
@@ -46,8 +46,6 @@ class InteractionValues:
                 f"Index {self.index} is not valid. "
                 f"Available indices are 'SII', 'nSII', 'STI', and 'FSI'."
             )
-        if self.n_players is None:
-            raise ValueError("n_players must be specified.")
         if self.interaction_lookup is None:
             self.interaction_lookup = {
                 interaction: i

--- a/shapiq/approximator/permutation/sii.py
+++ b/shapiq/approximator/permutation/sii.py
@@ -36,12 +36,21 @@ class PermutationSamplingSII(Approximator):
         InteractionValues(
             index=SII, order=2, estimated=True, estimation_budget=988,
             values={
-                1: [0.2 0.7 0.7 0.2 0.2]
-                2: [[ 0.  0.  0.  0.  0.]
-                    [ 0.  0.  1.  0.  0.]
-                    [ 0.  0.  0.  0.  0.]
-                    [ 0.  0.  0.  0.  0.]
-                    [ 0.  0.  0.  0.  0.]]
+                (0,): 0.2,
+                (1,): 0.7,
+                (2,): 0.7,
+                (3,): 0.2,
+                (4,): 0.2,
+                (0, 1): 0,
+                (0, 2): 0,
+                (0, 3): 0,
+                (0, 4): 0,
+                (1, 2): 1.0,
+                (1, 3): 0,
+                (1, 4): 0,
+                (2, 3): 0,
+                (2, 4): 0,
+                (3, 4): 0
             }
         )
     """
@@ -88,8 +97,8 @@ class PermutationSamplingSII(Approximator):
         batch_size = 1 if batch_size is None else batch_size
         used_budget = 0
 
-        result = self._init_result()
-        counts = self._init_result(dtype=int)
+        result: np.ndarray[float] = self._init_result()
+        counts: np.ndarray[int] = self._init_result(dtype=int)
 
         # compute the number of iterations and size of the last batch (can be smaller than original)
         n_iterations, last_batch_size = self._calc_iteration_count(
@@ -128,22 +137,23 @@ class PermutationSamplingSII(Approximator):
             for permutation_id in range(n_permutations):
                 for order in self._order_iterator:
                     for k in range(self.n - order + 1):
-                        subset = permutations[permutation_id, k : k + order]
-                        counts[order][tuple(sorted(subset))] += 1
+                        interaction = permutations[permutation_id, k : k + order]
+                        interaction = tuple(sorted(interaction))
+                        interaction_index = self._interaction_lookup[interaction]
+                        counts[interaction_index] += 1
                         # update the discrete derivative given the subset
-                        for subset_ in powerset(subset, min_size=0):
+                        for subset_ in powerset(interaction, min_size=0):
                             game_value = game_values[subset_index]
                             update = game_value * (-1) ** (order - len(subset_))
-                            result[order][tuple(sorted(subset))] += update
+                            result[interaction_index] += update
                             subset_index += 1
 
             used_budget += self._iteration_cost * batch_size
 
         # compute mean of interactions
-        for s in self._order_iterator:
-            result[s] = np.divide(result[s], counts[s], out=result[s], where=counts[s] != 0)
+        result = np.divide(result, counts, out=result, where=counts != 0)
 
-        return self._finalize_result(result, budget=used_budget)
+        return self._finalize_result(result, budget=used_budget, estimated=True)
 
 
 if __name__ == "__main__":

--- a/shapiq/approximator/permutation/sii.py
+++ b/shapiq/approximator/permutation/sii.py
@@ -23,8 +23,6 @@ class PermutationSamplingSII(Approximator):
         top_order: Whether to approximate only the top order interactions (`True`) or all orders up
             to the specified order (`False`).
         min_order: The minimum order to approximate.
-
-    Properties:
         iteration_cost: The cost of a single iteration of the permutation sampling.
 
     Example:
@@ -63,7 +61,7 @@ class PermutationSamplingSII(Approximator):
         random_state: Optional[int] = None,
     ) -> None:
         super().__init__(n, max_order, "SII", top_order, random_state)
-        self._iteration_cost: int = self._compute_iteration_cost()
+        self.iteration_cost: int = self._compute_iteration_cost()
 
     def _compute_iteration_cost(self) -> int:
         """Computes the cost of performing a single iteration of the permutation sampling given
@@ -102,7 +100,7 @@ class PermutationSamplingSII(Approximator):
 
         # compute the number of iterations and size of the last batch (can be smaller than original)
         n_iterations, last_batch_size = self._calc_iteration_count(
-            budget, batch_size, self._iteration_cost
+            budget, batch_size, self.iteration_cost
         )
 
         # main permutation sampling loop
@@ -114,7 +112,7 @@ class PermutationSamplingSII(Approximator):
             permutations = np.tile(np.arange(self.n), (batch_size, 1))
             self._rng.permuted(permutations, axis=1, out=permutations)
             n_permutations = permutations.shape[0]
-            n_subsets = n_permutations * self._iteration_cost
+            n_subsets = n_permutations * self.iteration_cost
 
             # get all subsets to evaluate per iteration
             subsets = np.zeros(shape=(n_subsets, self.n), dtype=bool)
@@ -148,7 +146,7 @@ class PermutationSamplingSII(Approximator):
                             result[interaction_index] += update
                             subset_index += 1
 
-            used_budget += self._iteration_cost * batch_size
+            used_budget += self.iteration_cost * batch_size
 
         # compute mean of interactions
         result = np.divide(result, counts, out=result, where=counts != 0)

--- a/shapiq/approximator/permutation/sti.py
+++ b/shapiq/approximator/permutation/sti.py
@@ -21,8 +21,6 @@ class PermutationSamplingSTI(Approximator):
         n: The number of players.
         max_order: The interaction order of the approximation.
         min_order: The minimum order to approximate.
-
-    Properties:
         iteration_cost: The cost of a single iteration of the permutation sampling.
 
     Example:
@@ -55,7 +53,7 @@ class PermutationSamplingSTI(Approximator):
 
     def __init__(self, n: int, max_order: int, random_state: Optional[int] = None) -> None:
         super().__init__(n, max_order, index="STI", top_order=False, random_state=random_state)
-        self._iteration_cost: int = self._compute_iteration_cost()
+        self.iteration_cost: int = self._compute_iteration_cost()
 
     def approximate(
         self, budget: int, game: Callable[[np.ndarray], np.ndarray], batch_size: int = 1
@@ -100,7 +98,7 @@ class PermutationSamplingSTI(Approximator):
         if n_iterations == 0:
             warnings.warn(
                 message=f"The budget {budget} is too small to perform a single iteration, which "
-                f"requires {self._iteration_cost + lower_order_cost} evaluations. Consider "
+                f"requires {self.iteration_cost + lower_order_cost} evaluations. Consider "
                 f"increasing the budget.",
                 category=UserWarning,
             )
@@ -115,7 +113,7 @@ class PermutationSamplingSTI(Approximator):
             permutations = np.tile(np.arange(self.n), (batch_size, 1))
             self._rng.permuted(permutations, axis=1, out=permutations)
             n_permutations = permutations.shape[0]
-            n_subsets = n_permutations * self._iteration_cost
+            n_subsets = n_permutations * self.iteration_cost
 
             # get all subsets to evaluate per iteration
             subsets = np.zeros(shape=(n_subsets, self.n), dtype=bool)
@@ -148,7 +146,7 @@ class PermutationSamplingSTI(Approximator):
                         result[interaction_index] += update
                         subset_index += 1
 
-            used_budget += self._iteration_cost * batch_size
+            used_budget += self.iteration_cost * batch_size
 
         # compute mean of interactions
         result = np.divide(result, counts, out=result, where=counts != 0)

--- a/shapiq/approximator/permutation/sti.py
+++ b/shapiq/approximator/permutation/sti.py
@@ -6,7 +6,7 @@ import numpy as np
 from scipy.special import binom
 
 from approximator._base import Approximator, InteractionValues
-from utils import powerset
+from utils import powerset, get_explicit_subsets
 
 
 class PermutationSamplingSTI(Approximator):
@@ -179,7 +179,7 @@ class PermutationSamplingSTI(Approximator):
         """
         # get all game values on the whole powerset of players up to order max_order - 1
         lower_order_sizes = list(range(0, self.max_order))
-        subsets: np.ndarray[bool] = self._get_explicit_subsets(self.n, lower_order_sizes)
+        subsets: np.ndarray[bool] = get_explicit_subsets(self.n, lower_order_sizes)
         game_values = game(subsets)
         game_values_lookup = {
             tuple(np.where(subsets[index])[0]): float(game_values[index])

--- a/shapiq/approximator/regression/fsi.py
+++ b/shapiq/approximator/regression/fsi.py
@@ -34,12 +34,21 @@ class RegressionFSI(Approximator, ShapleySamplingMixin):
         InteractionValues(
             index=FSI, order=2, estimated=False, estimation_budget=32,
             values={
-                1: [0.2 0.2 0.2 0.2 0.2]
-                2: [[ 0.  0.  0.  0.  0.]
-                    [ 0.  0.  1.  0.  0.]
-                    [ 0.  0.  0.  0.  0.]
-                    [ 0.  0.  0.  0.  0.]
-                    [ 0.  0.  0.  0.  0.]]
+                (0,): 0.2,
+                (1,): 0.2,
+                (2,): 0.2,
+                (3,): 0.2,
+                (4,): 0.2,
+                (0, 1): 0,
+                (0, 2): 0,
+                (0, 3): 0,
+                (0, 4): 0,
+                (1, 2): 1.0,
+                (1, 3): 0,
+                (1, 4): 0,
+                (2, 3): 0,
+                (2, 4): 0,
+                (3, 4): 0
             }
         )
     """
@@ -127,8 +136,6 @@ class RegressionFSI(Approximator, ShapleySamplingMixin):
 
             used_budget += batch_size
 
-        fsi_values = self._transform_representation(fsi_values)
-
         return self._finalize_result(fsi_values, budget=used_budget, estimated=estimation_flag)
 
     def _get_fsi_subset_representation(
@@ -153,22 +160,6 @@ class RegressionFSI(Approximator, ShapleySamplingMixin):
         ):
             regression_subsets[:, interaction_index] = all_subsets[:, interaction].all(axis=1)
         return regression_subsets, num_players
-
-    def _transform_representation(self, result: np.ndarray[float]) -> dict[int, np.ndarray[float]]:
-        """Transforms the FSI representation into the interaction values representation.
-
-        Args:
-            result: The FSI representation of the interaction values.
-
-        Returns:
-            The interaction values.
-        """
-        result_fsi = self._init_result()
-        fsi_index = 0
-        for interaction in powerset(self.N, min_size=self.min_order, max_size=self.max_order):
-            result_fsi[len(interaction)][interaction] = result[fsi_index]
-            fsi_index += 1
-        return result_fsi
 
 
 if __name__ == "__main__":

--- a/shapiq/approximator/regression/fsi.py
+++ b/shapiq/approximator/regression/fsi.py
@@ -21,8 +21,6 @@ class RegressionFSI(Approximator, ShapleySamplingMixin):
         N: The set of players (starting from 0 to n - 1).
         max_order: The interaction order of the approximation.
         min_order: The minimum order of the approximation. For FSI, min_order is equal to 1.
-
-    Properties:
         iteration_cost: The cost of a single iteration of the regression FSI.
 
     Example:
@@ -62,7 +60,7 @@ class RegressionFSI(Approximator, ShapleySamplingMixin):
         super().__init__(
             n, max_order=max_order, index="FSI", top_order=False, random_state=random_state
         )
-        self._iteration_cost: int = 1
+        self.iteration_cost: int = 1
 
     def approximate(
         self,
@@ -104,7 +102,7 @@ class RegressionFSI(Approximator, ShapleySamplingMixin):
 
         # calculate the number of iterations and the last batch size
         n_iterations, last_batch_size = self._calc_iteration_count(
-            n_subsets, batch_size, iteration_cost=self._iteration_cost
+            n_subsets, batch_size, iteration_cost=self.iteration_cost
         )
 
         # get the fsi representation of the subsets

--- a/shapiq/approximator/shapiq/shapiq.py
+++ b/shapiq/approximator/shapiq/shapiq.py
@@ -27,8 +27,6 @@ class ShapIQ(Approximator, ShapleySamplingMixin):
         top_order: Whether to approximate only the top order interactions (`True`) or all orders up
             to the specified order (`False`).
         min_order: The minimum order to approximate.
-
-    Properties:
         iteration_cost: The cost of a single iteration of the permutation sampling.
 
     Example:
@@ -240,11 +238,11 @@ class ShapIQ(Approximator, ShapleySamplingMixin):
         """
         # init data structure
         weights = {}
-        for order in range(self.min_order, self.max_order + 1):
+        for order in self._order_iterator:
             weights[order] = np.zeros((self.n + 1, order + 1))
         # fill with values specific to each index
         for t in range(0, self.n + 1):
-            for order in range(self.min_order, self.max_order + 1):
+            for order in self._order_iterator:
                 for k in range(max(0, order + t - self.n), min(order, t) + 1):
                     weights[order][t, k] = (-1) ** (order - k) * self._weight_kernel(t - k, order)
         return weights

--- a/shapiq/utils/__init__.py
+++ b/shapiq/utils/__init__.py
@@ -1,12 +1,13 @@
 """This module contains utility functions for the shapiq package."""
 
-from .sets import powerset, pair_subset_sizes, split_subsets_budget
+from .sets import powerset, pair_subset_sizes, split_subsets_budget, get_explicit_subsets
 from .tree import get_parent_array, get_conditional_sample_weights
 
 __all__ = [
     "powerset",
     "pair_subset_sizes",
     "split_subsets_budget",
+    "get_explicit_subsets",
     # trees
     "get_parent_array",
     "get_conditional_sample_weights",

--- a/shapiq/utils/sets.py
+++ b/shapiq/utils/sets.py
@@ -11,6 +11,7 @@ __all__ = [
     "powerset",
     "pair_subset_sizes",
     "split_subsets_budget",
+    "get_explicit_subsets",
 ]
 
 
@@ -141,3 +142,42 @@ def split_subsets_budget(
             incomplete_subsets.remove(unpaired_subset)
             budget -= subset_budget
     return complete_subsets, incomplete_subsets, budget
+
+
+def get_explicit_subsets(n: int, subset_sizes: list[int]) -> np.ndarray[bool]:
+    """Enumerates all subsets of the given sizes and returns a one-hot matrix.
+
+    Args:
+        n: number of players.
+        subset_sizes: list of subset sizes.
+
+    Returns:
+        one-hot matrix of all subsets of certain sizes.
+
+    Examples:
+        >>> get_explicit_subsets(n=4, subset_sizes=[1, 2]).astype(int)
+        array([[1, 0, 0, 0],
+               [0, 1, 0, 0],
+               [0, 0, 1, 0],
+               [0, 0, 0, 1],
+               [1, 1, 0, 0],
+               [1, 0, 1, 0],
+               [1, 0, 0, 1],
+               [0, 1, 1, 0],
+               [0, 1, 0, 1],
+               [0, 0, 1, 1]])
+    """
+    total_subsets = int(sum(binom(n, size) for size in subset_sizes))
+    subset_matrix = np.zeros(shape=(total_subsets, n), dtype=bool)
+    subset_index = 0
+    for subset_size in subset_sizes:
+        for subset in combinations(range(n), subset_size):
+            subset_matrix[subset_index, subset] = True
+            subset_index += 1
+    return subset_matrix
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/tests/test_approximator_base_interaction_values.py
+++ b/tests/test_approximator_base_interaction_values.py
@@ -1,0 +1,86 @@
+"""This test module contains all tests regarding the InteractionValues dataclass."""
+from copy import copy, deepcopy
+
+import numpy as np
+import pytest
+
+from approximator._base import InteractionValues
+from utils import powerset
+
+
+@pytest.mark.parametrize(
+    "index, n, min_order, max_order, estimation_budget, estimated",
+    [
+        ("SII", 5, 1, 2, 100, True),
+        ("STI", 5, 1, 2, 100, True),
+        ("FSI", 5, 1, 2, 100, True),
+        ("nSII", 5, 1, 2, 100, True),
+        ("SII", 5, 1, 2, 100, False),
+        ("something", 5, 1, 2, 100, False),  # expected to fail with ValueError
+    ],
+)
+def test_initialization(index, n, min_order, max_order, estimation_budget, estimated):
+    """Tests the initialization of the InteractionValues dataclass."""
+    interaction_lookup = {interaction: i for i, interaction in enumerate(powerset(range(n), 1, 2))}
+    values = np.random.rand(len(interaction_lookup))
+    try:
+        interaction_values = InteractionValues(
+            values=values,
+            index=index,
+            n_players=n,
+            min_order=min_order,
+            max_order=max_order,
+            interaction_lookup=interaction_lookup,
+            estimation_budget=estimation_budget,
+            estimated=estimated,
+        )
+    except ValueError:
+        if index == "something":
+            return
+        raise
+    assert interaction_values.index == index
+    assert interaction_values.n_players == n
+    assert interaction_values.min_order == min_order
+    assert interaction_values.max_order == max_order
+    assert np.all(interaction_values.values == values)
+    assert interaction_values.estimation_budget == estimation_budget
+    assert interaction_values.estimated == estimated
+    assert interaction_values.interaction_lookup == interaction_lookup
+
+    # check that default values are set correctly
+    interaction_values_2 = InteractionValues(
+        values=np.random.rand(len(interaction_lookup)),
+        index=index,
+        n_players=n,
+        min_order=min_order,
+        max_order=max_order,
+    )
+    assert interaction_values_2.estimation_budget is None  # default value is None
+    assert interaction_values_2.estimated is True  # default value is True
+    assert interaction_values_2.interaction_lookup == interaction_lookup  # automatically generated
+
+    # check the string representations (not semantics)
+    str(interaction_values)
+    repr(interaction_values)
+
+    # check equality
+    interaction_values_copy = copy(interaction_values)
+    interaction_values_deepcopy = copy(interaction_values)
+    assert interaction_values == interaction_values_copy
+    assert interaction_values == interaction_values_deepcopy
+    assert interaction_values != interaction_values_2
+
+    try:
+        assert interaction_values == 1  # expected to fail with TypeError
+    except TypeError:
+        pass
+
+    # check that the hash is correct
+    assert hash(interaction_values) == hash(interaction_values_copy)
+    assert hash(interaction_values) == hash(interaction_values_deepcopy)
+    assert hash(interaction_values) != hash(interaction_values_2)
+
+    # check getitem
+    assert interaction_values[(0,)] == interaction_values.values[0]
+    assert interaction_values[(1,)] == interaction_values.values[1]
+    assert interaction_values[(0, 1)] == interaction_values.values[n]  # first 2nd order is at n

--- a/tests/test_approximator_base_interaction_values.py
+++ b/tests/test_approximator_base_interaction_values.py
@@ -84,3 +84,4 @@ def test_initialization(index, n, min_order, max_order, estimation_budget, estim
     assert interaction_values[(0,)] == interaction_values.values[0]
     assert interaction_values[(1,)] == interaction_values.values[1]
     assert interaction_values[(0, 1)] == interaction_values.values[n]  # first 2nd order is at n
+    assert interaction_values[(1, 0)] == interaction_values.values[n]  # order does not matter

--- a/tests/test_approximator_base_interaction_values.py
+++ b/tests/test_approximator_base_interaction_values.py
@@ -65,7 +65,7 @@ def test_initialization(index, n, min_order, max_order, estimation_budget, estim
 
     # check equality
     interaction_values_copy = copy(interaction_values)
-    interaction_values_deepcopy = copy(interaction_values)
+    interaction_values_deepcopy = deepcopy(interaction_values)
     assert interaction_values == interaction_values_copy
     assert interaction_values == interaction_values_deepcopy
     assert interaction_values != interaction_values_2

--- a/tests/test_approximator_permutation_sii.py
+++ b/tests/test_approximator_permutation_sii.py
@@ -29,42 +29,44 @@ def test_initialization(n, max_order, top_order, expected):
 
 
 @pytest.mark.parametrize(
-    "n, max_order, top_order, budget, batch_size, expected",
+    "n, max_order, top_order, budget, batch_size",
     [
-        (7, 2, False, 380, 10, {"iteration_cost": 38, "access_counter": 380}),
-        (7, 2, False, 500, 10, {"iteration_cost": 38, "access_counter": 494}),
+        (7, 2, False, 380, 10),
+        (7, 2, False, 500, 10),
+        (7, 2, False, 500, None),
+        (7, 2, True, 500, None),
     ],
 )
-def test_approximate(n, max_order, top_order, budget, batch_size, expected):
+def test_approximate(n, max_order, top_order, budget, batch_size):
     """Tests the approximation of the PermutationSamplingSII approximator."""
     interaction = (1, 2)
     game = DummyGame(n, interaction)
-    approximator = PermutationSamplingSII(n, max_order, top_order)
-    assert approximator._iteration_cost == expected["iteration_cost"]
+    approximator = PermutationSamplingSII(n, max_order, top_order, random_state=42)
     sii_estimates = approximator.approximate(budget, game, batch_size=batch_size)
     assert isinstance(sii_estimates, InteractionValues)
-    assert len(sii_estimates.values) == max_order
+    assert len(sii_estimates.values) == (max_order if not top_order else 1)
 
     # check that the budget is respected
     assert game.access_counter <= budget
-    assert game.access_counter == expected["access_counter"]
 
     # check that the estimates are correct
     # for order 1 player 1 and 2 are the most important the rest should be somewhat equal
     # for order 2 the interaction between player 1 and 2 is the most important
-    first_order: np.ndarray = sii_estimates.values[1]
-    # sort the players by their importance
-    sorted_players: np.ndarray = np.argsort(first_order)[::-1]
-    assert (sorted_players[0] == 1 or sorted_players[0] == 2) and (
-        sorted_players[1] == 1 or sorted_players[1] == 2
-    )
-    for player_one in sorted_players[2:]:
-        for player_two in sorted_players[2:]:
-            pytest.approx(player_one, player_two, 0.1)
+    if not top_order:
+        first_order: np.ndarray = sii_estimates.values[1]
+        # sort the players by their importance
+        sorted_players: np.ndarray = np.argsort(first_order)[::-1]
+        assert (sorted_players[0] == 1 or sorted_players[0] == 2) and (
+            sorted_players[1] == 1 or sorted_players[1] == 2
+        )
+        for player_one in sorted_players[2:]:
+            for player_two in sorted_players[2:]:
+                pytest.approx(player_one, player_two, 0.1)
+
+        # check efficiency
+        efficiency = np.sum(first_order)
+        assert efficiency == pytest.approx(2, 0.05)
 
     second_order: np.ndarray = sii_estimates.values[2]
-    pytest.approx(second_order[interaction], 1.0, 0.0001)
-
-    # check efficiency
-    efficiency = np.sum(first_order)
-    pytest.approx(efficiency, 2.0, 0.001)
+    interaction_estimate = second_order[interaction]
+    assert interaction_estimate == pytest.approx(1.0, 0.05)

--- a/tests/test_approximator_permutation_sii.py
+++ b/tests/test_approximator_permutation_sii.py
@@ -58,3 +58,8 @@ def test_approximate(n, max_order, top_order, budget, batch_size):
 
     # for order 2 the interaction between player 1 and 2 is the most important
     assert sii_estimates[(1, 2)] == pytest.approx(1.0, 0.2)
+
+    # check efficiency
+    if not top_order:
+        efficiency = np.sum(sii_estimates.values[:n])
+        assert efficiency == pytest.approx(2.0, 0.01)

--- a/tests/test_approximator_permutation_sti.py
+++ b/tests/test_approximator_permutation_sti.py
@@ -1,0 +1,61 @@
+"""This test module contains all tests regarding the STI permutation sampling approximator."""
+import numpy as np
+import pytest
+
+from approximator._base import InteractionValues
+from approximator.permutation import PermutationSamplingSTI
+from games import DummyGame
+
+
+@pytest.mark.parametrize(
+    "n, max_order, iteration_cost",
+    [
+        (3, 1, 6),
+        (3, 1, 6),
+        (3, 2, 12),
+        (3, 2, 12),
+        (7, 2, 84),  # used in subsequent tests
+        (10, 3, 960),
+    ],
+)
+def test_initialization(n, max_order, iteration_cost):
+    """Tests the initialization of the PermutationSamplingSTI approximator."""
+    approximator = PermutationSamplingSTI(n, max_order)
+    assert approximator.n == n
+    assert approximator.max_order == max_order
+    assert approximator.top_order is False
+    assert approximator.min_order == 1
+    assert approximator.iteration_cost == iteration_cost
+    assert approximator.index == "STI"
+
+
+@pytest.mark.parametrize(
+    "n, max_order, budget, batch_size",
+    [
+        (7, 2, 380, 2),
+        (7, 2, 500, 2),
+    ],
+)
+def test_approximate(n, max_order, budget, batch_size):
+    """Tests the approximation of the PermutationSamplingSTI approximator."""
+    interaction = (1, 2)
+    game = DummyGame(n, interaction)
+    approximator = PermutationSamplingSTI(n, max_order, random_state=42)
+    sti_estimates = approximator.approximate(budget, game, batch_size=batch_size)
+    assert isinstance(sti_estimates, InteractionValues)
+    assert sti_estimates.max_order == max_order
+    assert sti_estimates.min_order == 1
+
+    # check that the budget is respected
+    assert game.access_counter <= budget
+
+    # check that the estimates are correct
+    # for order 1 all players should be equal
+    first_order_values = np.asarray([sti_estimates[(i,)] for i in range(n)])
+    assert np.allclose(first_order_values, first_order_values[0])
+    # for order 2 the interaction between player 1 and 2 is the most important (1.0)
+    assert sti_estimates[(1, 2)] == pytest.approx(1.0, 0.2)
+
+    # check efficiency
+    efficiency = np.sum(sti_estimates.values)
+    assert efficiency == pytest.approx(2.0, 0.01)

--- a/tests/test_approximator_regression_fsi.py
+++ b/tests/test_approximator_regression_fsi.py
@@ -1,0 +1,60 @@
+"""This test module contains all tests regarding the FSI regression approximator."""
+import numpy as np
+import pytest
+
+from approximator._base import InteractionValues
+from approximator.regression import RegressionFSI
+from games import DummyGame
+
+
+@pytest.mark.parametrize(
+    "n, max_order",
+    [
+        (3, 1),
+        (3, 1),
+        (3, 2),
+        (3, 2),
+        (7, 2),  # used in subsequent tests
+        (10, 3),
+    ],
+)
+def test_initialization(n, max_order):
+    """Tests the initialization of the RegressionFSI approximator."""
+    approximator = RegressionFSI(n, max_order)
+    assert approximator.n == n
+    assert approximator.max_order == max_order
+    assert approximator.top_order is False
+    assert approximator.min_order == 1
+    assert approximator.iteration_cost == 1
+    assert approximator.index == "FSI"
+
+
+@pytest.mark.parametrize(
+    "n, max_order, budget, batch_size", [(7, 2, 380, 100), (7, 2, 380, None), (7, 2, 100, None)]
+)
+def test_approximate(n, max_order, budget, batch_size):
+    """Tests the approximation of the RegressionFSI approximator."""
+    interaction = (1, 2)
+    game = DummyGame(n, interaction)
+    approximator = RegressionFSI(n, max_order, random_state=42)
+    fsi_estimates = approximator.approximate(budget, game, batch_size=batch_size)
+    assert isinstance(fsi_estimates, InteractionValues)
+    assert fsi_estimates.max_order == max_order
+    assert fsi_estimates.min_order == 1
+
+    # check that the budget is respected
+    assert game.access_counter <= budget + 2
+
+    # check that the estimates are correct
+
+    # for order 1 all players should be equal
+    first_order: np.ndarray = fsi_estimates.values[:n]  # fist n values are first order
+    assert np.allclose(first_order, first_order[0])
+
+    # for order 2 the interaction between player 1 and 2 is the most important (1.0)
+    interaction_estimate = fsi_estimates[interaction]
+    assert interaction_estimate == pytest.approx(1.0, 0.01)
+
+    # check efficiency
+    efficiency = np.sum(fsi_estimates.values)
+    assert efficiency == pytest.approx(efficiency, 0.01)

--- a/tests/test_approximator_shapiq.py
+++ b/tests/test_approximator_shapiq.py
@@ -1,0 +1,109 @@
+"""This test module contains all tests regarding the shapiq approximator."""
+import numpy as np
+import pytest
+
+from approximator._base import InteractionValues
+from approximator.shapiq import ShapIQ
+from games import DummyGame
+
+
+@pytest.mark.parametrize(
+    "n, max_order, index, top_order",
+    [
+        (7, 2, "SII", False),
+        (7, 2, "SII", True),
+        (7, 2, "STI", False),
+        (7, 2, "STI", True),
+        (7, 2, "FSI", True),
+        (7, 2, "FSI", False),  # expected to fail
+    ],
+)
+def test_initialization(n, max_order, index, top_order):
+    """Tests the initialization of the ShapIQ approximator."""
+    try:
+        approximator = ShapIQ(n, max_order, index=index, top_order=top_order)
+    except ValueError:
+        if index == "FSI" and not top_order:
+            return
+        raise
+    assert approximator.n == n
+    assert approximator.max_order == max_order
+    assert approximator.top_order is top_order
+    assert approximator.min_order == (max_order if top_order else 1)
+    assert approximator.iteration_cost == 1
+    assert approximator.index == index
+
+
+@pytest.mark.parametrize("n, max_order, budget, batch_size", [(7, 2, 100, None), (7, 2, 100, 10)])
+def test_approximate_fsi(n, max_order, budget, batch_size):
+    """Tests the approximation of the ShapIQ FSI approximation."""
+    interaction = (1, 2)
+    game = DummyGame(n, interaction)
+    approximator = ShapIQ(n, max_order, index="FSI", top_order=True, random_state=42)
+    estimates = approximator.approximate(budget, game, batch_size=batch_size)
+    assert isinstance(estimates, InteractionValues)
+    assert estimates.max_order == max_order
+    assert estimates.min_order == max_order  # only top order for FSI
+
+    # check that the budget is respected
+    assert game.access_counter <= budget + 2
+
+    # for order 2 (max_order) the interaction between player 1 and 2 is the most important (1.0)
+    interaction_estimate = estimates[interaction]
+    assert interaction_estimate == pytest.approx(1.0, 0.4)  # large tolerance for FSI
+
+
+@pytest.mark.parametrize(
+    "n, max_order, top_order, budget, batch_size", [(7, 2, False, 100, None), (7, 2, True, 100, 10)]
+)
+def test_approximate_sii(n, max_order, top_order, budget, batch_size):
+    """Tests the approximation of the ShapIQ SII approximation."""
+    interaction = (1, 2)
+    game = DummyGame(n, interaction)
+    approximator = ShapIQ(n, max_order, index="SII", top_order=top_order, random_state=42)
+    estimates = approximator.approximate(budget, game, batch_size=batch_size)
+    assert isinstance(estimates, InteractionValues)
+    assert estimates.max_order == max_order
+    assert estimates.min_order == (max_order if top_order else 1)
+
+    # check that the budget is respected
+    assert game.access_counter <= budget + 2
+
+    # for order 2 (max_order) the interaction between player 1 and 2 is the most important (1.0)
+    assert estimates[interaction] == pytest.approx(1.0, 0.4)
+
+    if not top_order:
+        # for order 1 (min_order) the interaction between player 1 and 2 is the most important (0.7)
+        assert estimates[(1,)] == pytest.approx(0.7, 0.4)
+        assert estimates[(2,)] == pytest.approx(0.7, 0.4)
+
+        # check efficiency
+        assert np.sum(estimates.values[:n]) == pytest.approx(2.0, 0.4)
+
+
+@pytest.mark.parametrize(
+    "n, max_order, top_order, budget, batch_size", [(7, 2, False, 100, None), (7, 2, True, 100, 10)]
+)
+def test_approximate_sti(n, max_order, top_order, budget, batch_size):
+    """Tests the approximation of the ShapIQ STI approximation."""
+    interaction = (1, 2)
+    game = DummyGame(n, interaction)
+    approximator = ShapIQ(n, max_order, index="STI", top_order=top_order, random_state=42)
+    estimates = approximator.approximate(budget, game, batch_size=batch_size)
+    assert isinstance(estimates, InteractionValues)
+    assert estimates.max_order == max_order
+    assert estimates.min_order == (max_order if top_order else 1)
+
+    # check that the budget is respected
+    assert game.access_counter <= budget + 2
+
+    # for order 2 (max_order) the interaction between player 1 and 2 is the most important (1.0)
+    assert estimates[interaction] == pytest.approx(1.0, 0.5)
+
+    if not top_order:
+        # for order 1 (min_order) the interaction between player 1 and 2 is the most important (0.7)
+        assert estimates[(1,)] == pytest.approx(1 / 7, 0.4)
+        assert estimates[(2,)] == pytest.approx(1 / 7, 0.4)
+
+        # check efficiency
+        assert np.sum(estimates.values) == pytest.approx(2.0, 0.4)

--- a/tests/test_utils_sets.py
+++ b/tests/test_utils_sets.py
@@ -2,7 +2,7 @@
 import numpy as np
 import pytest
 
-from utils.sets import powerset, pair_subset_sizes, split_subsets_budget
+from utils.sets import powerset, pair_subset_sizes, split_subsets_budget, get_explicit_subsets
 
 
 @pytest.mark.parametrize(
@@ -50,3 +50,26 @@ def test_split_subsets_budget(budget, order, n, q, expected):
         split_subsets_budget(order=order, n=n, budget=budget, sampling_weights=sampling_weights)
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    "n, subset_sizes, expected",
+    [
+        (3, [1, 2], [(0,), (1,), (2,), (0, 1), (0, 2), (1, 2)]),
+        (3, [1, 2, 3], [(0,), (1,), (2,), (0, 1), (0, 2), (1, 2), (0, 1, 2)]),
+    ],
+)
+def test_get_explicit_subsets(n, subset_sizes, expected):
+    """Tests the get_explicit_subsets function."""
+
+    def check_correctness(subsets, expected):
+        assert len(subsets) == len(expected)
+        expected_array = np.zeros((len(expected), n), dtype=bool)
+        for i, subset in enumerate(expected):
+            expected_array[i, subset] = True
+        assert np.all(subsets == expected_array)
+
+    explicit_subsets = get_explicit_subsets(n, subset_sizes)  # without parameter names
+    check_correctness(explicit_subsets, expected)
+    explicit_subsets = get_explicit_subsets(n=n, subset_sizes=subset_sizes)  # with parameter names
+    check_correctness(explicit_subsets, expected)


### PR DESCRIPTION
# Tests
This PR adds tests to all approximators using the `DummyGame`. 
- tests for `InteractionValues`
- tests for `PermutationSamplingSTI`
- tests for `RegressionFSI`
- tests for `ShapIQ`

# Refactoring of InteractionValues
 Changed the internal representation of interaction scores to be a vector of length `n_interactions` instead of mostly empty arrays. This makes it easier to approximate interaction scores for higher player counts.