### PR TITLE
adds code-quality check and closes #45

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.12"
         cache: 'pip'
         
     - name: Install dependencies
@@ -37,4 +37,4 @@ jobs:
         pre-commit install
 
     - name: Run code-quality checks
-      run: pre-commit run --all-files 
+      run: SKIP=black pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 files: shapiq
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.5.0
     hooks:
       - id: check-json
       - id: check-yaml


### PR DESCRIPTION
Adds a new CI action that runs some code-style checks. Notably the workflow skips the `black` code formatter, as this is too much to enforce in the whole repo as it varies from python version to version.