### PR TITLE
add baseline value to InteractionValues and Explainers. Fixes #82.

### DIFF
--- a/shapiq/approximator/_base.py
+++ b/shapiq/approximator/_base.py
@@ -143,6 +143,7 @@ class Approximator(ABC):
             max_order=self.max_order,
             n_players=self.n,
             interaction_lookup=self._interaction_lookup,
+            baseline_value=0.0,  # Approximator are always normalized/centered games
         )
 
     @staticmethod

--- a/shapiq/approximator/k_sii.py
+++ b/shapiq/approximator/k_sii.py
@@ -78,6 +78,7 @@ def transforms_sii_to_ksii(
             interaction_lookup=sii_values.interaction_lookup,
             estimated=sii_values.estimated,
             estimation_budget=sii_values.estimation_budget,
+            baseline_value=sii_values.baseline_value,
         )
     elif approximator is not None:
         return _calculate_ksii_from_sii(

--- a/shapiq/explainer/tabular.py
+++ b/shapiq/explainer/tabular.py
@@ -53,6 +53,7 @@ class TabularExplainer(Explainer):
     Attributes:
         index: The Shapley interaction index to use.
         background_data: The background data to use for the explainer.
+        baseline_value: The baseline value of the explainer.
     """
 
     def __init__(
@@ -97,8 +98,14 @@ class TabularExplainer(Explainer):
 
         # explain
         interaction_values = self._approximator.approximate(budget=budget, game=imputer)
+        interaction_values.baseline_value = self.baseline_value
 
         return interaction_values
+
+    @property
+    def baseline_value(self) -> float:
+        """Returns the baseline value of the explainer."""
+        return self._imputer.empty_prediction
 
     def _init_approximator(
         self, approximator: Union[Approximator, str], index: str, max_order: int

--- a/shapiq/explainer/tree/explainer.py
+++ b/shapiq/explainer/tree/explainer.py
@@ -43,6 +43,11 @@ class TreeExplainer(Explainer):
             for _tree in self._trees
         ]
 
+        # TODO: for the current implementation this is correct for other trees this may vary
+        self.baseline_value = sum(
+            [treeshapiq.empty_prediction for treeshapiq in self._treeshapiq_explainers]
+        )
+
     def explain(self, x_explain: np.ndarray) -> InteractionValues:
         # run treeshapiq for all trees
         interaction_values: list[InteractionValues] = []

--- a/shapiq/explainer/tree/treeshapiq.py
+++ b/shapiq/explainer/tree/treeshapiq.py
@@ -155,6 +155,7 @@ class TreeSHAPIQ:
             n_players=n_players,
             estimated=False,
             interaction_lookup=self._interactions_lookup_relevant,
+            baseline_value=self.empty_prediction,
         )
 
         if self._interaction_type == "k-SII":

--- a/shapiq/interaction_values.py
+++ b/shapiq/interaction_values.py
@@ -29,6 +29,10 @@ class InteractionValues:
             `min_order`, and `max_order` parameters. Defaults to `None`.
         estimated: Whether the interaction values are estimated or not. Defaults to `True`.
         estimation_budget: The budget used for the estimation. Defaults to `None`.
+        baseline_value: The value of the baseline interaction also known as 'empty prediction' or
+            'empty value' since it denotes the value of the empty coalition (empty set). If not
+            provided it is searched for in the values vector (raising an Error if not found).
+            Defaults to `None`.
     """
 
     values: np.ndarray[float]
@@ -39,6 +43,7 @@ class InteractionValues:
     interaction_lookup: dict[tuple[int], int] = None
     estimated: bool = True
     estimation_budget: Optional[int] = None
+    baseline_value: Optional[float] = None
 
     def __post_init__(self) -> None:
         """Checks if the index is valid."""
@@ -50,6 +55,11 @@ class InteractionValues:
             self.interaction_lookup = generate_interaction_lookup(
                 self.n_players, self.min_order, self.max_order
             )
+        if self.baseline_value is None:
+            try:
+                self.baseline_value = float(self.values[self.interaction_lookup[tuple()]])
+            except KeyError:
+                raise ValueError("Baseline value is not provided and cannot be computed.")
 
     def __repr__(self) -> str:
         """Returns the representation of the InteractionValues object."""
@@ -57,6 +67,7 @@ class InteractionValues:
         representation += (
             f"    index={self.index}, max_order={self.max_order}, min_order={self.min_order}"
             f", estimated={self.estimated}, estimation_budget={self.estimation_budget},\n"
+            f"    n_players={self.n_players}, baseline_value={self.baseline_value},\n"
         ) + "    values={\n"
         for interaction in powerset(
             set(range(self.n_players)), min_size=1, max_size=self.max_order
@@ -93,6 +104,8 @@ class InteractionValues:
         if isinstance(item, int):
             return float(self.values[item])
         item = tuple(sorted(item))
+        if item == tuple():
+            return self.baseline_value
         try:
             return float(self.values[self.interaction_lookup[item]])
         except KeyError:
@@ -114,6 +127,7 @@ class InteractionValues:
             or self.max_order != other.max_order
             or self.min_order != other.min_order
             or self.n_players != other.n_players
+            or self.baseline_value != other.baseline_value
         ):
             return False
         if not np.allclose(self.values, other.values):
@@ -154,6 +168,7 @@ class InteractionValues:
             n_players=self.n_players,
             interaction_lookup=copy.deepcopy(self.interaction_lookup),
             min_order=self.min_order,
+            baseline_value=self.baseline_value,
         )
 
     def __deepcopy__(self, memo) -> "InteractionValues":
@@ -167,6 +182,7 @@ class InteractionValues:
             n_players=self.n_players,
             interaction_lookup=copy.deepcopy(self.interaction_lookup),
             min_order=self.min_order,
+            baseline_value=self.baseline_value,
         )
 
     def __add__(self, other: Union["InteractionValues", int, float]) -> "InteractionValues":
@@ -205,12 +221,15 @@ class InteractionValues:
                 n_players = max(self.n_players, other.n_players)
                 min_order = min(self.min_order, other.min_order)
                 max_order = max(self.max_order, other.max_order)
+                baseline_value = self.baseline_value + other.baseline_value
             else:  # basic case with same interactions
                 added_values = self.values + other.values
                 interaction_lookup = self.interaction_lookup
+                baseline_value = self.baseline_value + other.baseline_value
         elif isinstance(other, (int, float)):
             added_values = self.values.copy() + other
             interaction_lookup = self.interaction_lookup.copy()
+            baseline_value = self.baseline_value + other
         else:
             raise TypeError("Cannot add InteractionValues with object of type " f"{type(other)}.")
         return InteractionValues(
@@ -222,6 +241,7 @@ class InteractionValues:
             interaction_lookup=interaction_lookup,
             estimated=self.estimated,
             estimation_budget=self.estimation_budget,
+            baseline_value=baseline_value,
         )
 
     def __radd__(self, other: Union["InteractionValues", int, float]) -> "InteractionValues":
@@ -239,6 +259,7 @@ class InteractionValues:
             interaction_lookup=self.interaction_lookup,
             estimated=self.estimated,
             estimation_budget=self.estimation_budget,
+            baseline_value=-self.baseline_value,
         )
 
     def __sub__(self, other: Union["InteractionValues", int, float]) -> "InteractionValues":
@@ -260,6 +281,7 @@ class InteractionValues:
             interaction_lookup=self.interaction_lookup,
             estimated=self.estimated,
             estimation_budget=self.estimation_budget,
+            baseline_value=self.baseline_value * other,
         )
 
     def __rmul__(self, other: Union[int, float]) -> "InteractionValues":

--- a/tests/test_base_interaction_values.py
+++ b/tests/test_base_interaction_values.py
@@ -24,6 +24,7 @@ def test_initialization(index, n, min_order, max_order, estimation_budget, estim
     """Tests the initialization of the InteractionValues dataclass."""
     interaction_lookup = {interaction: i for i, interaction in enumerate(powerset(range(n), 1, 2))}
     values = np.random.rand(len(interaction_lookup))
+    baseline_value = 2.0
     try:
         interaction_values = InteractionValues(
             values=values,
@@ -34,6 +35,7 @@ def test_initialization(index, n, min_order, max_order, estimation_budget, estim
             interaction_lookup=interaction_lookup,
             estimation_budget=estimation_budget,
             estimated=estimated,
+            baseline_value=baseline_value,
         )
     except ValueError:
         if index == "something":
@@ -55,6 +57,7 @@ def test_initialization(index, n, min_order, max_order, estimation_budget, estim
         n_players=n,
         min_order=min_order,
         max_order=max_order,
+        baseline_value=baseline_value,
     )
     assert interaction_values_2.estimation_budget is None  # default value is None
     assert interaction_values_2.estimated is True  # default value is True
@@ -97,6 +100,22 @@ def test_initialization(index, n, min_order, max_order, estimation_budget, estim
     # test __len__
     assert len(interaction_values) == len(interaction_values.values)
 
+    # test baseline value
+    assert interaction_values.baseline_value == baseline_value
+    assert interaction_values[()] == baseline_value
+    with pytest.raises(ValueError):
+        InteractionValues(
+            values=values,
+            index=index,
+            n_players=n,
+            min_order=min_order,
+            max_order=max_order,
+            interaction_lookup=interaction_lookup,
+            estimation_budget=estimation_budget,
+            estimated=estimated,
+            baseline_value=None,
+        )
+
 
 def test_add():
     """Tests the __add__ method of the InteractionValues dataclass."""
@@ -116,6 +135,7 @@ def test_add():
         min_order=min_order,
         max_order=max_order,
         interaction_lookup=interaction_lookup,
+        baseline_value=0.0,
     )
 
     # test adding scalar values
@@ -139,6 +159,7 @@ def test_add():
         min_order=min_order,
         max_order=max_order,
         interaction_lookup=interaction_lookup,
+        baseline_value=0.0,
     )
     with pytest.raises(ValueError):
         interaction_values_first + interaction_values_second
@@ -157,6 +178,7 @@ def test_add():
         min_order=min_order,
         max_order=max_order + 1,
         interaction_lookup=interaction_lookup_second,
+        baseline_value=0.0,
     )
     with pytest.warns(UserWarning):
         interaction_values_added = interaction_values_first + interaction_values_second
@@ -194,6 +216,7 @@ def test_sub():
         min_order=min_order,
         max_order=max_order,
         interaction_lookup=interaction_lookup,
+        baseline_value=0.0,
     )
 
     # test subtracting scalar values
@@ -225,6 +248,7 @@ def test_mul():
         min_order=min_order,
         max_order=max_order,
         interaction_lookup=interaction_lookup,
+        baseline_value=0.0,
     )
 
     # test adding scalar values
@@ -253,6 +277,7 @@ def test_sum():
         min_order=min_order,
         max_order=max_order,
         interaction_lookup=interaction_lookup,
+        baseline_value=0.0,
     )
 
     assert np.isclose(sum(interaction_values), np.sum(interaction_values.values))

--- a/tests/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -28,7 +28,12 @@ def test_decision_tree_classifier(dt_clf_model, background_clf_data):
 
     explainer = _ = TreeExplainer(model=dt_clf_model, max_order=1, min_order=1, class_label=1)
     explanation = explainer.explain(x_explain)
-    print(explanation)
+
+    # compare baseline_value with empty_predictions
+    assert explainer.baseline_value == sum(
+        [treeshapiq.empty_prediction for treeshapiq in explainer._treeshapiq_explainers]
+    )
+    assert explanation.baseline_value == explainer.baseline_value
 
 
 def test_decision_tree_regression(dt_reg_model, background_reg_data):
@@ -40,6 +45,12 @@ def test_decision_tree_regression(dt_reg_model, background_reg_data):
 
     assert type(explanation).__name__ == "InteractionValues"  # check correct return type
 
+    # compare baseline_value with empty_predictions
+    assert explainer.baseline_value == sum(
+        [treeshapiq.empty_prediction for treeshapiq in explainer._treeshapiq_explainers]
+    )
+    assert explanation.baseline_value == explainer.baseline_value
+
 
 def test_random_forrest_regression(rf_reg_model, background_reg_data):
     """Test TreeExplainer with a simple decision tree regressor."""
@@ -50,6 +61,12 @@ def test_random_forrest_regression(rf_reg_model, background_reg_data):
 
     assert type(explanation).__name__ == "InteractionValues"  # check correct return type
 
+    # compare baseline_value with empty_predictions
+    assert explainer.baseline_value == sum(
+        [treeshapiq.empty_prediction for treeshapiq in explainer._treeshapiq_explainers]
+    )
+    assert explanation.baseline_value == explainer.baseline_value
+
 
 def test_random_forrest_classification(rf_clf_model, background_clf_data):
     """Test TreeExplainer with a simple decision tree regressor."""
@@ -59,6 +76,12 @@ def test_random_forrest_classification(rf_clf_model, background_clf_data):
     explanation = explainer.explain(x_explain)
 
     assert type(explanation).__name__ == "InteractionValues"  # check correct return type
+
+    # compare baseline_value with empty_predictions
+    assert explainer.baseline_value == sum(
+        [treeshapiq.empty_prediction for treeshapiq in explainer._treeshapiq_explainers]
+    )
+    assert explanation.baseline_value == explainer.baseline_value
 
 
 def test_against_shap_implementation():

--- a/tests/tests_plots/test_network_plot.py
+++ b/tests/tests_plots/test_network_plot.py
@@ -42,6 +42,7 @@ def test_network_plot():
         n_players=n_players,
         min_order=1,
         max_order=2,
+        baseline_value=0.0,
     )
     fig, axes = network_plot(interaction_values=iv)
     assert fig is not None


### PR DESCRIPTION
This PR incorporates the notion of the empty value into the `InteractionValues` class and makes this visible to the two explainer objects.