### PR TITLE
Add ExactComputer and new indices (closes #57)

### DIFF
--- a/shapiq/approximator/moebius_converter.py
+++ b/shapiq/approximator/moebius_converter.py
@@ -79,7 +79,9 @@ class MoebiusConverter:
                     )
                 transformed_values[i] = S_effect
 
-        transformed_index = "k-" + base_interactions.index
+        transformed_index = base_interactions.index
+        if transformed_index not in ["SV", "BV"]:
+            transformed_index = "k-" + transformed_index
 
         transformed_interactions = InteractionValues(
             values=transformed_values,
@@ -329,12 +331,12 @@ class MoebiusConverter:
         )
         return fsii
 
-    def moebius_to_shapley_interaction(self, order, index):
+    def moebius_to_shapley_interaction(self, index: str, order: int):
         """Converts the Möbius coefficients to Shapley Interactions up to order k
 
         Args:
-            order: The order of the explanation
             index: The Shapley Interaction index, e.g. k-SII, STII, FSII
+            order: The order of the explanation
 
         Returns:
             An InteractionValues object containing the Shapley interactions

--- a/shapiq/exact_computer.py
+++ b/shapiq/exact_computer.py
@@ -478,7 +478,9 @@ class ExactComputer:
                 transformed_values[i] = interaction_effect
 
         # setup interaction values
-        transformed_index = "k-" + base_interactions.index  # raname the index (e.g. SII -> k-SII)
+        transformed_index = base_interactions.index  # raname the index (e.g. SII -> k-SII)
+        if transformed_index not in ["SV", "BV"]:
+            transformed_index = "k-" + transformed_index
         transformed_interactions = InteractionValues(
             values=transformed_values,
             index=transformed_index,

--- a/shapiq/exact_computer.py
+++ b/shapiq/exact_computer.py
@@ -1,0 +1,734 @@
+import copy
+from typing import Callable
+
+import numpy as np
+import tqdm
+from scipy.special import bernoulli, binom
+
+from shapiq import powerset
+from shapiq.interaction_values import InteractionValues
+
+
+class ExactComputer:
+    """Computes exact Shapley Interactions for specified game by evaluating all 2^n coalitions
+
+    Args:
+        N: The set of players.
+        game_fun: A callable game
+
+
+    Attributes:
+        N: The set of players
+        n: The number of players.
+        big_M: The infinite weight for KernelSHAP
+        n_interactions: A pre-computed numpy array containing the number of interactions up to the size of the index, e.g. n_interactions[4] is the nuber of all interactions up to size 4
+        computed_interactions: A dictionary that stores computations of different indices
+        game_fun: The callable game
+        baseline_value: The baseline value, i.e. the emptyset prediction
+        game_values: A numpy array containing the game evaluations of all subsets
+        coalition_lookup: A dictionary containing the index of every coalition in game_values
+    """
+
+    def __init__(
+        self,
+        N: set,
+        game_fun: Callable,
+    ):
+        self.N = copy.copy(N)
+        self.n = len(N)
+        self.big_M = 10e7
+        self.n_interactions = self.get_n_interactions()
+        self.computed_interactions = {}
+        self.game_fun = game_fun
+        self.baseline_value, self.game_values, self.coalition_lookup = self.compute_game_values(
+            game_fun
+        )
+
+    def compute_game_values(self, game_fun: Callable):
+        """Evaluates the game on the powerset using game_fun
+
+        Args:
+            game_fun: A callable game
+
+        Returns:
+            The baseline value (empty prediction), all game values and the corresponding lookup dictionary
+        """
+        coalition_lookup = {}
+        # compute the game values
+        coalition_matrix = np.zeros((2**self.n, self.n))
+        for i, T in tqdm.tqdm(
+            enumerate(powerset(self.N, min_size=0, max_size=self.n)), total=2**self.n
+        ):
+            coalition_lookup[T] = i
+            coalition_matrix[i, T] = 1
+        game_values = game_fun(coalition_matrix)
+        # Ensures that game_values
+        baseline_value = game_values[0]
+        # Zero-centering of game values
+        # game_values -= baseline_value
+
+        return baseline_value, game_values, coalition_lookup
+
+    def moebius_transform(self):
+        """Computes the Moebius transform for all 2^n coalitions
+
+        Args:
+
+        Returns:
+            The Moebius transform for all coalitions stored in an InteractionValues object
+        """
+
+        moebius_transform = np.zeros(2**self.n)
+        # compute the Moebius transform
+        coalition_lookup = {}
+        for i, S in enumerate(powerset(self.N)):
+            coalition_lookup[S] = i
+        for i, S in tqdm.tqdm(enumerate(powerset(self.N)), total=2**self.n):
+            s = len(S)
+            S_pos = coalition_lookup[S]
+            for T in powerset(S):
+                pos = self.coalition_lookup[T]
+                moebius_transform[S_pos] += (-1) ** (s - len(T)) * self.game_values[pos]
+
+        self.computed_interactions["Moebius"] = InteractionValues(
+            values=moebius_transform,
+            index="Moebius",
+            max_order=self.n,
+            min_order=0,
+            n_players=self.n,
+            interaction_lookup=coalition_lookup,
+            estimated=False,
+        )
+        return copy.copy(self.computed_interactions["Moebius"])
+
+    def base_weights(self, coalition_size: int, interaction_size: int, index: str):
+        """Computes the weight of different indices in their common representation,
+        e.g. the weight of the discrete derivative of S given T in SII
+        e.g. the weight of the marginal contribution of S given T in SGV.
+
+        Args:
+            coalition_size: The size of the coalition from 0,...,n-interaction_size
+            interaction_size: The size of the interaction from 0,...,order
+            index: The computed index
+
+        Returns:
+            The base weight of the interaction index
+        """
+
+        if index in ["SII", "SGV"]:
+            return 1 / (
+                (self.n - interaction_size + 1) * binom(self.n - interaction_size, coalition_size)
+            )
+        if index in ["BII", "BGV"]:
+            return 1 / (2 ** (self.n - interaction_size))
+        if index in ["CHII", "CHGV"]:
+            return interaction_size / (
+                (interaction_size + coalition_size)
+                * binom(self.n, interaction_size + coalition_size)
+            )
+
+    def stii_weight(self, coalition_size: int, interaction_size: int, order: int):
+        """Sets the weight for the representation of STII as a CII (using discrete derivatives)
+
+        Args:
+            coalition_size: Size of the Discrete Derivative
+            interaction_size: Interaction size with s <= k
+            order: Interaction order
+
+        Returns:
+            The weight of STII
+        """
+
+        if interaction_size == order:
+            return order / ((self.n) * binom(self.n - 1, coalition_size))
+        else:
+            if coalition_size == 0:
+                return 1
+            else:
+                return 0
+
+    def get_fsii_weights(self):
+        """Pre-computes the kernel weight for the least square representation of FSII
+
+        Args:
+
+        Returns:
+            An array of the kernel weights for 0,...,n with "infinite weight on 0 and n using big_M
+        """
+        fsii_weights = np.zeros(self.n + 1)
+        fsii_weights[0] = self.big_M
+        fsii_weights[-1] = self.big_M
+        for coalition_size in range(1, self.n):
+            fsii_weights[coalition_size] = 1 / (self.n - 1) * binom(self.n - 2, coalition_size - 1)
+        return fsii_weights
+
+    def get_stii_weights(self, order: int):
+        """Pre-computes the STII weights for the CII representation (using discrete derivatives)
+
+        Args:
+            order: The interaction order
+
+        Returns:
+            An array with pre-computed weights for t=0,...,n-k
+        """
+
+        stii_weights = np.zeros(self.n - order + 1)
+        for t in range(self.n - order + 1):
+            stii_weights[t] = self.stii_weight(t, order, order)
+        return stii_weights
+
+    def get_discrete_derivative(self, interaction, coalition):
+        """Computes the discrete derivative of a coalition with respect to an interaction
+
+        Args:
+            interaction: Subset of N as set or tuple
+            coalition: Subset of N as set of tuple
+
+        Returns:
+            The discrete derivative of the coalition with respect to the interaction
+        """
+
+        rslt = 0
+        interaction_size = len(interaction)
+        for interaction_subset in powerset(interaction):
+            interaction_subset_size = len(interaction_subset)
+            pos = self.coalition_lookup[
+                tuple(sorted(set(coalition).union(set(interaction_subset))))
+            ]
+            rslt += (-1) ** (interaction_size - interaction_subset_size) * self.game_values[pos]
+        return rslt
+
+    def get_n_interactions(self):
+        """Pre-computes an array that contains the number of interactions up to the size of the index.
+
+        Args:
+
+        Returns:
+            A numpy array containing the number of interactions up to the size of the index, e.g. n_interactions[4] is the number of interactions up to size 4.
+        """
+        n_interactions = np.zeros(self.n + 1, dtype=int)
+        n_interaction = 0
+        for interaction_size in range(self.n + 1):
+            n_interaction += int(binom(self.n, interaction_size))
+            n_interactions[interaction_size] = n_interaction
+        return n_interactions
+
+    def get_base_weights(self, index: str, order: int):
+        """Pre-computes all base weights for all coalition_size=0,...,n-s and all interaction_size=1,...order
+
+        Args:
+            index: The interaction index
+            order: The interaction order
+
+        Returns:
+            A numpy array with all base interaction weights
+        """
+
+        base_weights = np.zeros((self.n + 1, order + 1))
+        for interaction_size in range(order + 1):
+            for coalition_size in range(self.n - interaction_size + 1):
+                base_weights[coalition_size, interaction_size] = self.base_weights(
+                    coalition_size, interaction_size, index
+                )
+        return base_weights
+
+    def base_interactions(self, index: str, order: int):
+        """Computes interactions based on representation with discrete derivatives, e.g. SII, BII
+
+        Args:
+            index: The interaction index
+            order: The interaction order
+
+        Returns:
+            An InteractionValues object containing the base interactions
+        """
+
+        base_interaction_values = np.zeros(self.n_interactions[order])
+        base_weights = self.get_base_weights(index, order)
+        for coalition in tqdm.tqdm(powerset(self.N), total=2**self.n):
+            coalition_size = len(coalition)
+            coalition_pos = self.coalition_lookup[coalition]
+            for j, interaction in enumerate(powerset(self.N, max_size=order)):
+                interaction_size = len(interaction)
+                coalition_cap_interaction = len(set(coalition).intersection(set(interaction)))
+                base_interaction_values[j] += (
+                    (-1) ** (interaction_size - coalition_cap_interaction)
+                    * base_weights[coalition_size - coalition_cap_interaction, interaction_size]
+                    * self.game_values[coalition_pos]
+                )
+
+        interaction_lookup = {}
+        for i, interaction in enumerate(powerset(self.N, max_size=order)):
+            interaction_lookup[interaction] = i
+
+        # Transform into InteractionValues object
+        self.computed_interactions[index] = InteractionValues(
+            values=base_interaction_values,
+            index=index,
+            max_order=order,
+            min_order=0,
+            n_players=self.n,
+            interaction_lookup=interaction_lookup,
+            estimated=False,
+            baseline_value=self.baseline_value,
+        )
+
+        return copy.copy(self.computed_interactions[index])
+
+    def base_generalized_values(self, index: str, order: int):
+        """Computes the Base Generalized Values according to the representation with marginal contributions, e.g. SGV, BGV, CGV
+
+        Args:
+            index: The interaction index
+            order: The interaction order
+
+        Returns:
+            An InteractionValues object containing the base generalized values
+        """
+
+        base_generalized_values = np.zeros(self.n_interactions[order])
+        base_weights = self.get_base_weights(index, order)
+
+        interaction_lookup = {}
+        for i, interaction in enumerate(powerset(self.N, max_size=order)):
+            interaction_lookup[interaction] = i
+
+        for i, coalition in enumerate(powerset(self.N, min_size=0, max_size=self.n - 1)):
+            coalition_val = self.game_values[i]
+            for j, interaction in enumerate(
+                powerset((self.N - set(coalition)), min_size=1, max_size=order)
+            ):
+                coalition_weight = base_weights[len(coalition), len(interaction)]
+                base_generalized_values[
+                    interaction_lookup[tuple(sorted(interaction))]
+                ] += coalition_weight * (
+                    self.game_values[self.coalition_lookup[tuple(sorted(coalition + interaction))]]
+                    - coalition_val
+                )
+
+        # Transform into InteractionValues object
+        self.computed_interactions[index] = InteractionValues(
+            values=base_generalized_values,
+            index=index,
+            max_order=order,
+            min_order=0,
+            n_players=self.n,
+            interaction_lookup=interaction_lookup,
+            estimated=False,
+        )
+
+        return self.computed_interactions[index].__copy__()
+
+    def base_aggregation(self, base_interactions: InteractionValues, order: int):
+        """Transform Base Interactions into Interactions satisfying efficiency, e.g. SII to k-SII
+
+        Args:
+            base_interactions: InteractionValues object containing interactions up to order "order"
+            order: The highest order of interactions considered
+
+        Returns:
+            InteractionValues object containing transformed base_interactions
+        """
+        transformed_values = np.zeros(self.get_n_interactions()[order])
+        transformed_lookup = {}
+        # Lookup Bernoulli numbers
+        bernoulli_numbers = bernoulli(order)
+
+        for i, interaction in enumerate(powerset(self.N, max_size=order)):
+            transformed_lookup[interaction] = i
+            if len(interaction) == 0:
+                # Initialize emptyset baseline value
+                transformed_values[i] = base_interactions.baseline_value
+            else:
+                S_effect = base_interactions[interaction]
+                subset_size = len(interaction)
+                # go over all subsets S_tilde of length |S| + 1, ..., n that contain S
+                for interaction_higher_order in powerset(
+                    self.N, min_size=subset_size + 1, max_size=order
+                ):
+                    if not set(interaction).issubset(interaction_higher_order):
+                        continue
+                    # get the effect of T
+                    S_tilde_effect = base_interactions[interaction_higher_order]
+                    # normalization with bernoulli numbers
+                    S_effect += (
+                        bernoulli_numbers[len(interaction_higher_order) - subset_size]
+                        * S_tilde_effect
+                    )
+                transformed_values[i] = S_effect
+
+        transformed_index = "k-" + base_interactions.index
+
+        transformed_interactions = InteractionValues(
+            values=transformed_values,
+            index=transformed_index,
+            min_order=0,
+            max_order=order,
+            interaction_lookup=transformed_lookup,
+            n_players=self.n,
+        )
+
+        return transformed_interactions
+
+    def compute_stii(self, order: int):
+        """Computes the STII index up to order "order"
+
+        Args:
+            order: The highest order of interactions
+
+        Returns:
+            InteractionValues object containing STII
+        """
+
+        stii_values = np.zeros(self.n_interactions[order])
+
+        # Set baseline value
+        stii_values[0] = self.baseline_value
+
+        # Create interaction lookup
+        interaction_lookup = {}
+        for interaction_pos, interaction in enumerate(powerset(self.N, max_size=order)):
+            interaction_lookup[interaction] = interaction_pos
+
+        # Lower-order interactions (size < order) are the Möbius transform, i.e. discrete derivative with empty set
+        for interaction in powerset(self.N, max_size=order - 1):
+            stii_values[interaction_lookup[interaction]] = self.get_discrete_derivative(
+                interaction, ()
+            )
+
+        # Pre-compute STII weights
+        stii_weights = self.get_stii_weights(order)
+
+        # Top-order STII interactions
+        for interaction in powerset(self.N, min_size=order, max_size=order):
+            interaction_pos = interaction_lookup[interaction]
+            for coalition_pos, coalition in enumerate(powerset(self.N)):
+                coalition_size = len(coalition)
+                intersection_size = len(set(coalition).intersection(set(interaction)))
+                stii_values[interaction_pos] += (
+                    (-1) ** (order - intersection_size)
+                    * stii_weights[coalition_size - intersection_size]
+                    * self.game_values[coalition_pos]
+                )
+
+        # Transform into InteractionValues object
+        stii = InteractionValues(
+            values=stii_values,
+            index="STII",
+            max_order=order,
+            min_order=0,
+            n_players=self.n,
+            interaction_lookup=interaction_lookup,
+            estimated=False,
+        )
+
+        return stii
+
+    def compute_fsii(self, order: int):
+        """Computes the FSII index up to order "order"
+        According to https://jmlr.org/papers/v24/22-0202.html
+        Args:
+            order: The highest order of interactions
+
+        Returns:
+            InteractionValues object containing STII
+        """
+        fsii_weights = self.get_fsii_weights()
+        lstsq_weights = np.zeros(2**self.n)
+        coalition_matrix = np.zeros((2**self.n, self.n_interactions[order]))
+
+        # Create interaction lookup
+        interaction_lookup = {}
+        for interaction_pos, interaction in enumerate(powerset(self.N, max_size=order)):
+            interaction_lookup[interaction] = interaction_pos
+
+        coalition_store = {}
+        # Set LSTSQ matrices
+        for coalition_pos, coalition in enumerate(powerset(self.N)):
+            lstsq_weights[coalition_pos] = fsii_weights[len(coalition)]
+            for interaction in powerset(coalition, max_size=order):
+                pos = interaction_lookup[interaction]
+                coalition_matrix[coalition_pos, pos] = 1
+            coalition_store[coalition] = coalition_pos
+        weight_matrix_sqrt = np.sqrt(np.diag(lstsq_weights))
+        coalition_matrix_weighted_sqrt = np.dot(weight_matrix_sqrt, coalition_matrix)
+        game_value_weighted_sqrt = np.dot(self.game_values, weight_matrix_sqrt)
+        # Solve WLSQ problem
+        fsii_values, residuals, rank, singular_values = np.linalg.lstsq(
+            coalition_matrix_weighted_sqrt, game_value_weighted_sqrt, rcond=None
+        )
+
+        # Set baseline value
+        fsii_values[0] = self.baseline_value
+
+        # Transform into InteractionValues object
+        fsii = InteractionValues(
+            values=fsii_values,
+            index="FSII",
+            max_order=order,
+            min_order=0,
+            n_players=self.n,
+            interaction_lookup=interaction_lookup,
+            estimated=False,
+        )
+
+        return fsii
+
+    def get_jointsv_weights(self, order):
+        """Pre-compute JointSV weights for coalition_size=0,...,n-order
+
+        Args:
+            order: The highest order of interactions
+
+        Returns:
+            An array of pre-computed weights
+        """
+        weights = np.zeros(self.n, dtype=np.longdouble)
+        q0den = sum([binom(self.n, s) for s in range(1, order + 1)])
+        weights[0] = 1 / q0den
+        # Carry out recursion
+        for r in range(1, self.n):
+            limd = min(order, (self.n - r))
+            limn = max((r - order), 0)
+            qden = sum([binom(self.n - r, s) for s in range(1, limd + 1)])
+            qnum = sum([binom(r, s) * weights[s] for s in range(limn, r)])
+            weights[r] = qnum / qden
+        # Check that the checksum is satisfied
+        checksum = sum([binom(self.n, i) * weights[i] for i in range((self.n - order), self.n)])
+        assert np.isclose(checksum, 1.0)
+        return weights
+
+    def get_bernoulli_weights(self, order):
+        """Returns the bernoulli weights in the k-additive approximation via SII, e.g. used in kADD-SHAP
+
+        Args:
+            order: The highest order of interactions
+
+        Returns:
+            An array containing the bernoulli weights
+        """
+
+        bernoulli_numbers = bernoulli(order)
+        weights = np.zeros((order + 1, order + 1))
+        for interaction_size in range(1, order + 1):
+            for intersection_size in range(interaction_size + 1):
+                for sum_index in range(1, intersection_size + 1):
+                    weights[interaction_size, intersection_size] += (
+                        binom(intersection_size, sum_index)
+                        * bernoulli_numbers[interaction_size - sum_index]
+                    )
+        return weights
+
+    def compute_kadd_shap(self, order: int):
+        """Computes the kADD-SHAP index up to order "order". This is similar to FSII except that the coalition matrix contains the Bernoulli weights
+        According to https://doi.org/10.1016/j.artint.2023.104014
+
+        Args:
+            order: The highest order of interactions
+
+        Returns:
+            An InteractionValues object containing kADD-SHAP values
+        """
+
+        weights = self.get_fsii_weights()
+        lstsq_weights = np.zeros(2**self.n)
+        coalition_matrix = np.zeros((2**self.n, self.n_interactions[order]))
+        bernoulli_weights = self.get_bernoulli_weights(order)
+
+        interaction_lookup = {}
+        for i, interaction in enumerate(powerset(self.N, max_size=order)):
+            interaction_lookup[interaction] = i
+
+        for coalition_pos, coalition in enumerate(powerset(self.N)):
+            lstsq_weights[coalition_pos] = weights[len(coalition)]
+            for interaction in powerset(self.N, min_size=1, max_size=order):
+                intersection_size = len(set(coalition).intersection(interaction))
+                interaction_size = len(interaction)
+                # This is different from FSII
+                coalition_matrix[
+                    coalition_pos, interaction_lookup[interaction]
+                ] = bernoulli_weights[interaction_size, intersection_size]
+
+        weight_matrix_sqrt = np.sqrt(np.diag(lstsq_weights))
+        coalition_matrix_weighted_sqrt = np.dot(weight_matrix_sqrt, coalition_matrix)
+        game_value_weighted_sqrt = np.dot(self.game_values, weight_matrix_sqrt)
+        kADD_shap_values, residuals, rank, singular_values = np.linalg.lstsq(
+            coalition_matrix_weighted_sqrt, game_value_weighted_sqrt, rcond=None
+        )
+
+        # Set baseline value
+        kADD_shap_values[0] = self.baseline_value
+
+        # Transform into InteractionValues object
+        kADD_shap = InteractionValues(
+            values=kADD_shap_values,
+            index="kADD-SHAP",
+            max_order=order,
+            min_order=0,
+            n_players=self.n,
+            interaction_lookup=interaction_lookup,
+            estimated=False,
+        )
+
+        return kADD_shap
+
+    def compute_jointSV(self, order):
+        """
+        Computes the JointSV index up to order "order"
+        According to https://openreview.net/forum?id=vcUmUvQCloe
+
+        Args:
+            order: The highest order of interactions
+
+        Returns:
+            An InteractionValues object containing kADD-SHAP values
+
+        """
+        jointSV_values = np.zeros(self.n_interactions[order])
+        # Set baseline value
+        jointSV_values[0] = self.baseline_value
+        coalition_weights = self.get_jointsv_weights(order)
+
+        interaction_lookup = {}
+        for i, interaction in enumerate(powerset(self.N, max_size=order)):
+            interaction_lookup[interaction] = i
+
+        for coalition_pos, coalition in enumerate(
+            powerset(self.N, min_size=0, max_size=self.n - 1)
+        ):
+            coalition_val = self.game_values[coalition_pos]
+            coalition_weight = coalition_weights[len(coalition)]
+            for interaction in powerset(self.N - set(coalition), min_size=1, max_size=order):
+                jointSV_values[interaction_lookup[interaction]] += coalition_weight * (
+                    self.game_values[self.coalition_lookup[tuple(sorted(coalition + interaction))]]
+                    - coalition_val
+                )
+
+        # Transform into InteractionValues object
+        jointSV = InteractionValues(
+            values=jointSV_values,
+            index="JointSV",
+            max_order=order,
+            min_order=0,
+            n_players=self.n,
+            interaction_lookup=interaction_lookup,
+            estimated=False,
+        )
+        return jointSV
+
+    def shapley_generalized_values(self, order: int, index: str) -> InteractionValues:
+        """
+        Computes Shapley Generalized Values, i.e. Generalized Values that satisfy efficiency
+        According to the underlying representation in https://doi.org/10.1016/j.dam.2006.05.002
+        Currently covers:
+            - JointSV: https://openreview.net/forum?id=vcUmUvQCloe
+        Args:
+            order: The highest order of interactions
+            index: The generalized value index
+
+        Returns:
+            An InteractionValues object containing generalized values
+
+        """
+        if index == "JointSV":
+            shapley_generalized_value = self.compute_jointSV(order)
+
+        self.computed_interactions[index] = shapley_generalized_value
+        return copy.copy(shapley_generalized_value)
+
+    def shapleygeneralized_values(self, order: int, index: str) -> InteractionValues:
+        """
+        Computes Shapley Generalized Values, i.e. probabilistic generalized values that do not depend on the order
+        According to the underlying representation using marginal contributions from https://doi.org/10.1016/j.dam.2006.05.002
+        Currently covers:
+            - SGV: Shapley Generalized Value https://doi.org/10.1016/S0166-218X(00)00264-X
+            - BGV: Banzhaf Generalized Value https://doi.org/10.1016/S0166-218X(00)00264-X
+            - CHGV: Chaining Generalized Value https://doi.org/10.1016/j.dam.2006.05.002
+        Args:
+            order: The highest order of interactions
+            index: The generalized value index
+
+        Returns:
+            An InteractionValues object containing generalized values
+
+        """
+        if index == "JointSV":
+            shapley_generalized_value = self.compute_jointSV(order)
+
+        self.computed_interactions[index] = shapley_generalized_value
+        return copy.copy(shapley_generalized_value)
+
+    def shapley_interaction(self, order: int, index: str = "k-SII") -> InteractionValues:
+        """
+        Computes k-additive Shapley Interactions, i.e. probabilistic interaction indices that depend on the order k
+        According to the underlying representation using discrete derivatives from https://doi.org/10.1016/j.geb.2005.03.002
+        Currently covers:
+            - k-SII: k-Shapley Values https://proceedings.mlr.press/v206/bordt23a.html
+            - STII:  Shapley-Taylor Interaction Index https://proceedings.mlr.press/v119/sundararajan20a.html
+            - FSII: Faithful Shapley Interaction Index https://jmlr.org/papers/v24/22-0202.html
+            - kADD-SHAP: k-additive Shapley Values https://doi.org/10.1016/j.artint.2023.104014
+
+        Args:
+            order: The highest order of interactions
+            index: The interaction index
+
+        Returns:
+            An InteractionValues object containing interaction values
+
+        """
+        if index == "k-SII":
+            sii = self.base_interactions("SII", order)
+            self.computed_interactions["SII"] = sii
+            shapley_interactions = self.base_aggregation(sii, order)
+        if index == "STII":
+            shapley_interactions = self.compute_stii(order)
+        if index == "FSII":
+            shapley_interactions = self.compute_fsii(order)
+        if index == "kADD-SHAP":
+            shapley_interactions = self.compute_kadd_shap(order)
+
+        self.computed_interactions[index] = shapley_interactions
+
+        return copy.copy(shapley_interactions)
+
+    def shapley_base_interaction(self, order: int, index: str) -> InteractionValues:
+        """
+        Computes Shapley Base Interactions, i.e. probabilistic interaction indices that do not depend on the order
+        According to the underlying representation using discrete derivatives from https://doi.org/10.1016/j.geb.2005.03.002
+        Currently covers:
+            - SII: Shapley Interaction Index https://link.springer.com/article/10.1007/s001820050125
+            - CHII: Chaining Interaction Index https://link.springer.com/chapter/10.1007/978-94-017-0647-6_5
+            - BII: Banzhaf Interaction Index https://link.springer.com/article/10.1007/s001820050125
+
+        Args:
+            order: The highest order of interactions
+            index: The interaction index
+
+        Returns:
+            An InteractionValues object containing interaction values
+
+        """
+        base_interactions = self.base_interactions(index, order)
+        self.computed_interactions[index] = base_interactions
+        return copy.copy(base_interactions)
+
+    def probabilistic_values(self, index: str) -> InteractionValues:
+        """Computes common semi-values or probabilistic values, i.e. shapley values without efficiency axiom. These are special of interaction indices and generalized values for order = 1.
+        According to the underlying representation using marginal contributions, cf.
+            - semi-values https://doi.org/10.1287/moor.6.1.122
+            - probabilistic values https://doi.org/10.1017/CBO9780511528446.008
+
+        Currently covers:
+            - SV: Shapley Value https://doi.org/10.1515/9781400881970-018
+            - BV: Banzhaf https://doi.org/10.1515/9781400881970-018
+
+        Args:
+            index: The interaction index
+
+        Returns:
+            An InteractionValues object containing probabilistic values
+        """
+
+        probabilistic_value = self.base_interactions(index, 1)
+        self.computed_interactions[index] = probabilistic_value
+        return copy.copy(probabilistic_value)

--- a/shapiq/exact_computer.py
+++ b/shapiq/exact_computer.py
@@ -2,7 +2,6 @@ import copy
 from typing import Callable
 
 import numpy as np
-import tqdm
 from scipy.special import bernoulli, binom
 
 from shapiq import powerset
@@ -56,9 +55,7 @@ class ExactComputer:
         coalition_lookup = {}
         # compute the game values
         coalition_matrix = np.zeros((2**self.n, self.n))
-        for i, T in tqdm.tqdm(
-            enumerate(powerset(self.N, min_size=0, max_size=self.n)), total=2**self.n
-        ):
+        for i, T in enumerate(powerset(self.N, min_size=0, max_size=self.n)):
             coalition_lookup[T] = i
             coalition_matrix[i, T] = 1
         game_values = game_fun(coalition_matrix)
@@ -83,7 +80,7 @@ class ExactComputer:
         coalition_lookup = {}
         for i, S in enumerate(powerset(self.N)):
             coalition_lookup[S] = i
-        for i, S in tqdm.tqdm(enumerate(powerset(self.N)), total=2**self.n):
+        for i, S in enumerate(powerset(self.N)):
             s = len(S)
             S_pos = coalition_lookup[S]
             for T in powerset(S):
@@ -159,7 +156,9 @@ class ExactComputer:
         fsii_weights[0] = self.big_M
         fsii_weights[-1] = self.big_M
         for coalition_size in range(1, self.n):
-            fsii_weights[coalition_size] = 1 / (self.n - 1) * binom(self.n - 2, coalition_size - 1)
+            fsii_weights[coalition_size] = 1 / (
+                (self.n - 1) * binom(self.n - 2, coalition_size - 1)
+            )
         return fsii_weights
 
     def get_stii_weights(self, order: int):
@@ -245,7 +244,7 @@ class ExactComputer:
 
         base_interaction_values = np.zeros(self.n_interactions[order])
         base_weights = self.get_base_weights(index, order)
-        for coalition in tqdm.tqdm(powerset(self.N), total=2**self.n):
+        for coalition in powerset(self.N):
             coalition_size = len(coalition)
             coalition_pos = self.coalition_lookup[coalition]
             for j, interaction in enumerate(powerset(self.N, max_size=order)):

--- a/shapiq/exact_computer.py
+++ b/shapiq/exact_computer.py
@@ -1,5 +1,8 @@
+"""This module contains the exact computation mechanisms for a plethora of game theoretic concepts
+like interaction indices or generalized values."""
+
 import copy
-from typing import Callable
+from typing import Callable, Union
 
 import numpy as np
 from scipy.special import bernoulli, binom
@@ -7,21 +10,50 @@ from scipy.special import bernoulli, binom
 from shapiq import powerset
 from shapiq.interaction_values import InteractionValues
 
+__all__ = ["ExactComputer", "get_bernoulli_weights"]
+
+
+ALL_AVAILABLE_CONCEPTS: dict[str, str] = {
+    "Moebius": "Moebius Transformation",
+    # Base Interactions
+    "SII": "Shapley Interaction Index",
+    "BII": "Banzhaf Interaction Index",
+    "CHII": "Chaining Interaction Index",
+    # Base Generalized Values
+    "SGV": "Shapley Generalized Value",
+    "BGV": "Banzhaf Generalized Value",
+    "CHGV": "Chaining Generalized Value",
+    # Shapley Interactions
+    "k-SII": "k-Shapley Interaction Index",
+    "STII": "Shapley-Taylor Interaction Index",
+    "FSII": "Faithful Shapley Interaction Index",
+    "kADD-SHAP": "k-additive Shapley Values",
+    # Probabilistic Values
+    "SV": "Shapley Value",
+    "BV": "Banzhaf Value",
+    # Shapley Generalized Values
+    "JointSV": "JointSV",
+}
+
+ALL_AVAILABLE_INDICES: set[str] = set(ALL_AVAILABLE_CONCEPTS.keys())
+
 
 class ExactComputer:
-    """Computes exact Shapley Interactions for specified game by evaluating all 2^n coalitions
+    """Computes exact Shapley Interactions for specified game by evaluating the powerset of all
+        $2^n$ coalitions.
+
+    The ExactComputer class computes a variety of game theoretic concepts like interaction indices
+    or generalized values. Currently, the following indices and values are supported:
+        - The Moebius Transform (Moebius)
+        - Shapley Interaction Index (SII)
 
     Args:
-        N: The set of players.
-        game_fun: A callable game
-
+        n_players: The number of players in the game.
+        game_fun: A callable game that takes a binary matrix of shape (n_coalitions, n_players)
+            and returns a numpy array of shape (n_coalitions,) containing the game values.
 
     Attributes:
-        N: The set of players
         n: The number of players.
-        big_M: The infinite weight for KernelSHAP
-        n_interactions: A pre-computed numpy array containing the number of interactions up to the size of the index, e.g. n_interactions[4] is the nuber of all interactions up to size 4
-        computed: A dictionary that stores computations of different indices
         game_fun: The callable game
         baseline_value: The baseline value, i.e. the emptyset prediction
         game_values: A numpy array containing the game evaluations of all subsets
@@ -30,66 +62,128 @@ class ExactComputer:
 
     def __init__(
         self,
-        N: set,
-        game_fun: Callable,
-    ):
-        self.N = copy.copy(N)
-        self.n = len(N)
-        self.big_M = 10e7
-        self.n_interactions = self.get_n_interactions()
-        self.computed = {}
+        n_players: int,
+        game_fun: Callable[[np.ndarray], np.ndarray[float]],
+    ) -> None:
+        # set parameter attributes
+        self.n: int = n_players
         self.game_fun = game_fun
-        self.baseline_value, self.game_values, self.coalition_lookup = self.compute_game_values(
-            game_fun
-        )
 
-    def compute_game_values(self, game_fun: Callable):
-        """Evaluates the game on the powerset using game_fun
+        # set object attributes
+        self._grand_coalition_tuple: tuple[int] = tuple(range(self.n))
+        self._grand_coalition_set: set[int] = set(self._grand_coalition_tuple)
+        self._big_M: float = 10e7
+        self._n_interactions: np.ndarray = self.get_n_interactions(self.n)
+        self._computed = {}  # will store all computed indices
+
+        # evaluate the game on the powerset
+        computed_game = self.compute_game_values(game_fun)
+        self.baseline_value: float = computed_game[0]
+        self.game_values: np.ndarray[float] = computed_game[1]
+        self.coalition_lookup: dict[tuple[int], int] = computed_game[2]
+
+        # setup callable mapping from index to computation
+        self._index_mapping: dict[str, Callable[[], InteractionValues]] = {
+            "Moebius": self.moebius_transform,
+            # shapley_interaction
+            "k-SII": self.shapley_interaction,
+            "STII": self.shapley_interaction,
+            "FSII": self.shapley_interaction,
+            "kADD-SHAP": self.shapley_interaction,
+            # base_generalized_value
+            "SGV": self.base_generalized_value,
+            "BGV": self.base_generalized_value,
+            "CHGV": self.base_generalized_value,
+            # shapley_base_interaction
+            "SII": self.shapley_base_interaction,
+            "BII": self.shapley_base_interaction,
+            "CHII": self.shapley_base_interaction,
+            # probabilistic_value
+            "SV": self.probabilistic_value,
+            "BV": self.probabilistic_value,
+            # shapley_generalized_value
+            "JointSV": self.shapley_generalized_value,
+        }
+        self.available_indices: set[str] = set(self._index_mapping.keys())
+        self.available_concepts: dict[str, str] = ALL_AVAILABLE_CONCEPTS
+
+    def __repr__(self) -> str:
+        return f"ExactComputer(n_players={self.n}, game_fun={self.game_fun})"
+
+    def __str__(self) -> str:
+        return f"ExactComputer(n_players={self.n})"
+
+    def __call__(self, index: str, order: int = None) -> InteractionValues:
+        """Calls the computation of the specified index or value.
+
+        Args:
+            index: The index or value to compute
+            order: The order of the interaction index. If not specified the maximum order
+                (i.e. n_players) is used. Defaults to None.
+
+        Returns:
+            The desired interaction values or generalized values.
+
+        Raises:
+            ValueError: If the index is not supported.
+        """
+        if order is None:
+            order = self.n
+
+        if index in self._computed:
+            return copy.deepcopy(self._computed[index])
+        elif index in self.available_indices:
+            computation_function = self._index_mapping[index]
+            computed_index: InteractionValues = computation_function(index=index, order=order)
+            self._computed[index] = computed_index
+            return copy.deepcopy(computed_index)
+        else:
+            raise ValueError(f"Index {index} not supported.")
+
+    def compute_game_values(
+        self, game_fun: Callable[[np.ndarray], np.ndarray[float]]
+    ) -> tuple[float, np.ndarray[float], dict[tuple[int], int]]:
+        """Evaluates the game on the powerset of all coalitions.
 
         Args:
             game_fun: A callable game
 
         Returns:
-            The baseline value (empty prediction), all game values and the corresponding lookup dictionary
+            baseline value (empty prediction), all game values, and the lookup dictionary
         """
-        coalition_lookup = {}
-        # compute the game values
-        coalition_matrix = np.zeros((2**self.n, self.n))
-        for i, T in enumerate(powerset(self.N, min_size=0, max_size=self.n)):
-            coalition_lookup[T] = i
-            coalition_matrix[i, T] = 1
-        game_values = game_fun(coalition_matrix)
-        # Ensures that game_values
-        baseline_value = game_values[0]
-        # Zero-centering of game values
-        # game_values -= baseline_value
 
+        coalition_lookup = {}
+        coalition_matrix = np.zeros((2**self.n, self.n), dtype=bool)
+        for i, T in enumerate(powerset(self._grand_coalition_set, min_size=0, max_size=self.n)):
+            coalition_lookup[T] = i  # set lookup for the coalition
+            coalition_matrix[i, T] = True  # one-hot-encode the coalition
+        game_values = game_fun(coalition_matrix)  # compute the game values
+        baseline_value = float(game_values[0])  # set the baseline value
         return baseline_value, game_values, coalition_lookup
 
-    def moebius_transform(self):
-        """Computes the Moebius transform for all 2^n coalitions
+    def moebius_transform(self, *args, **kwargs) -> InteractionValues:
+        """Computes the Moebius transform for all 2^n coalitions of the game.
 
         Args:
+            args and kwargs: Additional arguments and keyword arguments (not used)
 
         Returns:
             The Moebius transform for all coalitions stored in an InteractionValues object
         """
-
-        moebius_transform = np.zeros(2**self.n)
         # compute the Moebius transform
+        moebius_transform = np.zeros(2**self.n)
         coalition_lookup = {}
-        for interaction_pos, interaction in enumerate(powerset(self.N)):
+        for interaction_pos, interaction in enumerate(powerset(self._grand_coalition_set)):
             coalition_lookup[interaction] = interaction_pos
-        for interaction in powerset(self.N):
             interaction_size = len(interaction)
-            interaction_pos = coalition_lookup[interaction]
             for coalition in powerset(interaction):
                 coalition_pos = self.coalition_lookup[coalition]
                 moebius_transform[interaction_pos] += (-1) ** (
                     interaction_size - len(coalition)
                 ) * self.game_values[coalition_pos]
 
-        self.computed["Moebius"] = InteractionValues(
+        # fill result into InteractionValues object and storage dictionary
+        interaction_values = InteractionValues(
             values=moebius_transform,
             index="Moebius",
             max_order=self.n,
@@ -98,12 +192,13 @@ class ExactComputer:
             interaction_lookup=coalition_lookup,
             estimated=False,
         )
-        return copy.copy(self.computed["Moebius"])
+        self._computed["Moebius"] = copy.deepcopy(interaction_values)
+        return copy.deepcopy(interaction_values)
 
-    def base_weights(self, coalition_size: int, interaction_size: int, index: str):
-        """Computes the weight of different indices in their common representation,
-        e.g. the weight of the discrete derivative of S given T in SII
-        e.g. the weight of the marginal contribution of S given T in SGV.
+    def _base_weights(self, coalition_size: int, interaction_size: int, index: str) -> float:
+        """Computes the weight of different indices in their common representation. For example, the
+            weight of the discrete derivative of S given T in SII or the weight of the marginal
+            contribution of S given T in SGV.
 
         Args:
             coalition_size: The size of the coalition from 0,...,n-interaction_size
@@ -112,22 +207,27 @@ class ExactComputer:
 
         Returns:
             The base weight of the interaction index
+
+        Raises:
+            ValueError: If the index is not supported
         """
 
         if index in ["SII", "SGV"]:
             return 1 / (
                 (self.n - interaction_size + 1) * binom(self.n - interaction_size, coalition_size)
             )
-        if index in ["BII", "BGV"]:
+        elif index in ["BII", "BGV"]:
             return 1 / (2 ** (self.n - interaction_size))
-        if index in ["CHII", "CHGV"]:
+        elif index in ["CHII", "CHGV"]:
             return interaction_size / (
                 (interaction_size + coalition_size)
                 * binom(self.n, interaction_size + coalition_size)
             )
+        else:
+            raise ValueError(f"Index {index} not supported")
 
-    def stii_weight(self, coalition_size: int, interaction_size: int, order: int):
-        """Sets the weight for the representation of STII as a CII (using discrete derivatives)
+    def _stii_weight(self, coalition_size: int, interaction_size: int, order: int) -> float:
+        """Sets the weight for the representation of STII as a CII (using discrete derivatives).
 
         Args:
             coalition_size: Size of the Discrete Derivative
@@ -139,31 +239,29 @@ class ExactComputer:
         """
 
         if interaction_size == order:
-            return order / ((self.n) * binom(self.n - 1, coalition_size))
+            return float(order / (self.n * binom(self.n - 1, coalition_size)))
         else:
             if coalition_size == 0:
-                return 1
+                return 1.0
             else:
-                return 0
+                return 0.0
 
-    def get_fsii_weights(self):
+    def _get_fsii_weights(self) -> np.ndarray:
         """Pre-computes the kernel weight for the least square representation of FSII
 
-        Args:
-
         Returns:
-            An array of the kernel weights for 0,...,n with "infinite weight on 0 and n using big_M
+            An array of the kernel weights for 0,...,n with "infinite weight" on 0 and n.
         """
-        fsii_weights = np.zeros(self.n + 1)
-        fsii_weights[0] = self.big_M
-        fsii_weights[-1] = self.big_M
+        fsii_weights = np.zeros(self.n + 1, dtype=float)
+        fsii_weights[0] = self._big_M
+        fsii_weights[-1] = self._big_M
         for coalition_size in range(1, self.n):
             fsii_weights[coalition_size] = 1 / (
                 (self.n - 1) * binom(self.n - 2, coalition_size - 1)
             )
         return fsii_weights
 
-    def get_stii_weights(self, order: int):
+    def _get_stii_weights(self, order: int) -> np.ndarray:
         """Pre-computes the STII weights for the CII representation (using discrete derivatives)
 
         Args:
@@ -173,49 +271,61 @@ class ExactComputer:
             An array with pre-computed weights for t=0,...,n-k
         """
 
-        stii_weights = np.zeros(self.n - order + 1)
+        stii_weights = np.zeros(self.n - order + 1, dtype=float)
         for t in range(self.n - order + 1):
-            stii_weights[t] = self.stii_weight(t, order, order)
+            stii_weights[t] = self._stii_weight(t, order, order)
         return stii_weights
 
-    def get_discrete_derivative(self, interaction, coalition):
-        """Computes the discrete derivative of a coalition with respect to an interaction
+    def _get_discrete_derivative(
+        self, interaction: Union[set[int], tuple[int]], coalition: Union[set[int], tuple[int]]
+    ) -> float:
+        """Computes the discrete derivative of a coalition with respect to an interaction.
 
         Args:
-            interaction: Subset of N as set or tuple
+            interaction: A subset of the grand coalition as a set or tuple
             coalition: Subset of N as set of tuple
 
         Returns:
             The discrete derivative of the coalition with respect to the interaction
         """
 
-        rslt = 0
+        discrete_derivative = 0.0
         interaction_size = len(interaction)
         for interaction_subset in powerset(interaction):
             interaction_subset_size = len(interaction_subset)
             pos = self.coalition_lookup[
                 tuple(sorted(set(coalition).union(set(interaction_subset))))
             ]
-            rslt += (-1) ** (interaction_size - interaction_subset_size) * self.game_values[pos]
-        return rslt
+            discrete_derivative += (-1) ** (
+                interaction_size - interaction_subset_size
+            ) * self.game_values[pos]
+        return discrete_derivative
 
-    def get_n_interactions(self):
-        """Pre-computes an array that contains the number of interactions up to the size of the index.
+    @staticmethod
+    def get_n_interactions(n_players: int) -> np.ndarray:
+        """Pre-computes an array that contains the number of interactions up to the size of the
+            index (e.g. n_interactions[4] is the number of interactions up to size 4).
 
         Args:
+            n_players: The number of players
 
         Returns:
-            A numpy array containing the number of interactions up to the size of the index, e.g. n_interactions[4] is the number of interactions up to size 4.
+            A numpy array containing the number of interactions up to the size of the index
+
+        Examples:
+            >>> ExactComputer.get_n_interactions(3)
+            array([1, 4, 7, 8])  # binom(3, 0), binom(3, 0) + binom(3, 1), etc. ...
         """
-        n_interactions = np.zeros(self.n + 1, dtype=int)
+        n_interactions = np.zeros(n_players + 1, dtype=int)
         n_interaction = 0
-        for interaction_size in range(self.n + 1):
-            n_interaction += int(binom(self.n, interaction_size))
+        for interaction_size in range(n_players + 1):
+            n_interaction += int(binom(n_players, interaction_size))
             n_interactions[interaction_size] = n_interaction
         return n_interactions
 
-    def get_base_weights(self, index: str, order: int):
-        """Pre-computes all base weights for all coalition_size=0,...,n-s and all interaction_size=1,...order
+    def _get_base_weights(self, index: str, order: int) -> np.ndarray:
+        """Pre-computes all base weights for all coalition sizes (i.e. 0, ..., n-s) and all
+            interaction sizes (i.e. 1, ..., order).
 
         Args:
             index: The interaction index
@@ -225,31 +335,31 @@ class ExactComputer:
             A numpy array with all base interaction weights
         """
 
-        base_weights = np.zeros((self.n + 1, order + 1))
+        base_weights = np.zeros((self.n + 1, order + 1), dtype=float)
         for interaction_size in range(order + 1):
             for coalition_size in range(self.n - interaction_size + 1):
-                base_weights[coalition_size, interaction_size] = self.base_weights(
+                base_weights[coalition_size, interaction_size] = self._base_weights(
                     coalition_size, interaction_size, index
                 )
         return base_weights
 
-    def base_interaction(self, index: str, order: int):
-        """Computes interactions based on representation with discrete derivatives, e.g. SII, BII
+    def base_interaction(self, index: str, order: int) -> InteractionValues:
+        """Computes interactions based on representation with discrete derivatives, e.g. SII, BII.
 
         Args:
             index: The interaction index
             order: The interaction order
 
         Returns:
-            An InteractionValues object containing the base interactions
+            An InteractionValues object containing the base interactions.
         """
 
-        base_interaction_values = np.zeros(self.n_interactions[order])
-        base_weights = self.get_base_weights(index, order)
-        for coalition in powerset(self.N):
+        base_interaction_values = np.zeros(self._n_interactions[order])
+        base_weights = self._get_base_weights(index, order)
+        for coalition in powerset(self._grand_coalition_set):
             coalition_size = len(coalition)
             coalition_pos = self.coalition_lookup[coalition]
-            for j, interaction in enumerate(powerset(self.N, max_size=order)):
+            for j, interaction in enumerate(powerset(self._grand_coalition_set, max_size=order)):
                 interaction_size = len(interaction)
                 coalition_cap_interaction = len(set(coalition).intersection(set(interaction)))
                 base_interaction_values[j] += (
@@ -259,11 +369,11 @@ class ExactComputer:
                 )
 
         interaction_lookup = {}
-        for i, interaction in enumerate(powerset(self.N, max_size=order)):
+        for i, interaction in enumerate(powerset(self._grand_coalition_set, max_size=order)):
             interaction_lookup[interaction] = i
 
-        # Transform into InteractionValues object
-        self.computed[index] = InteractionValues(
+        # Transform into InteractionValues object and store in computed dictionary
+        base_interaction = InteractionValues(
             values=base_interaction_values,
             index=index,
             max_order=order,
@@ -273,37 +383,40 @@ class ExactComputer:
             estimated=False,
             baseline_value=self.baseline_value,
         )
+        self._computed[index] = copy.deepcopy(base_interaction)
+        return copy.deepcopy(base_interaction)
 
-        return copy.copy(self.computed[index])
+    def base_generalized_value(self, index: str, order: int) -> InteractionValues:
+        """Computes Base Generalized Values, i.e. probabilistic generalized values that do not
+            depend on the order.
 
-    def base_generalized_value(self, index: str, order: int):
-        """
-        Computes Base Generalized Values, i.e. probabilistic generalized values that do not depend on the order
-        According to the underlying representation using marginal contributions from https://doi.org/10.1016/j.dam.2006.05.002
-        Currently covers:
+        According to the underlying representation using marginal contributions from
+        [this work](https://doi.org/10.1016/j.dam.2006.05.002), the following indices are supported:
             - SGV: Shapley Generalized Value https://doi.org/10.1016/S0166-218X(00)00264-X
             - BGV: Banzhaf Generalized Value https://doi.org/10.1016/S0166-218X(00)00264-X
             - CHGV: Chaining Generalized Value https://doi.org/10.1016/j.dam.2006.05.002
+
         Args:
             order: The highest order of interactions
             index: The generalized value index
 
         Returns:
-            An InteractionValues object containing generalized values
-
+            An InteractionValues object containing generalized values.
         """
 
-        base_generalized_values = np.zeros(self.n_interactions[order])
-        base_weights = self.get_base_weights(index, order)
+        base_generalized_values = np.zeros(self._n_interactions[order])
+        base_weights = self._get_base_weights(index, order)
 
         interaction_lookup = {}
-        for i, interaction in enumerate(powerset(self.N, max_size=order)):
+        for i, interaction in enumerate(powerset(self._grand_coalition_set, max_size=order)):
             interaction_lookup[interaction] = i
 
-        for i, coalition in enumerate(powerset(self.N, min_size=0, max_size=self.n - 1)):
+        for i, coalition in enumerate(
+            powerset(self._grand_coalition_set, min_size=0, max_size=self.n - 1)
+        ):
             coalition_val = self.game_values[i]
             for j, interaction in enumerate(
-                powerset((self.N - set(coalition)), min_size=1, max_size=order)
+                powerset((self._grand_coalition_set - set(coalition)), min_size=1, max_size=order)
             ):
                 coalition_weight = base_weights[len(coalition), len(interaction)]
                 base_generalized_values[
@@ -314,7 +427,7 @@ class ExactComputer:
                 )
 
         # Transform into InteractionValues object
-        self.computed[index] = InteractionValues(
+        base_generalized_values = InteractionValues(
             values=base_generalized_values,
             index=index,
             max_order=order,
@@ -323,10 +436,12 @@ class ExactComputer:
             interaction_lookup=interaction_lookup,
             estimated=False,
         )
+        self._computed[index] = copy.deepcopy(base_generalized_values)
+        return copy.deepcopy(base_generalized_values)
 
-        return copy.copy(self.computed[index])
-
-    def base_aggregation(self, base_interactions: InteractionValues, order: int):
+    def base_aggregation(
+        self, base_interactions: InteractionValues, order: int
+    ) -> InteractionValues:
         """Transform Base Interactions into Interactions satisfying efficiency, e.g. SII to k-SII
 
         Args:
@@ -336,36 +451,34 @@ class ExactComputer:
         Returns:
             InteractionValues object containing transformed base_interactions
         """
-        transformed_values = np.zeros(self.get_n_interactions()[order])
+        transformed_values = np.zeros(self.get_n_interactions(self.n)[order])
         transformed_lookup = {}
-        # Lookup Bernoulli numbers
-        bernoulli_numbers = bernoulli(order)
-
-        for i, interaction in enumerate(powerset(self.N, max_size=order)):
+        bernoulli_numbers = bernoulli(order)  # lookup Bernoulli numbers
+        for i, interaction in enumerate(powerset(self._grand_coalition_set, max_size=order)):
             transformed_lookup[interaction] = i
             if len(interaction) == 0:
                 # Initialize emptyset baseline value
                 transformed_values[i] = base_interactions.baseline_value
             else:
-                S_effect = base_interactions[interaction]
+                interaction_effect = base_interactions[interaction]
                 subset_size = len(interaction)
                 # go over all subsets S_tilde of length |S| + 1, ..., n that contain S
                 for interaction_higher_order in powerset(
-                    self.N, min_size=subset_size + 1, max_size=order
+                    self._grand_coalition_set, min_size=subset_size + 1, max_size=order
                 ):
                     if not set(interaction).issubset(interaction_higher_order):
                         continue
                     # get the effect of T
-                    S_tilde_effect = base_interactions[interaction_higher_order]
+                    interaction_tilde_effect = base_interactions[interaction_higher_order]
                     # normalization with bernoulli numbers
-                    S_effect += (
+                    interaction_effect += (
                         bernoulli_numbers[len(interaction_higher_order) - subset_size]
-                        * S_tilde_effect
+                        * interaction_tilde_effect
                     )
-                transformed_values[i] = S_effect
+                transformed_values[i] = interaction_effect
 
-        transformed_index = "k-" + base_interactions.index
-
+        # setup interaction values
+        transformed_index = "k-" + base_interactions.index  # raname the index (e.g. SII -> k-SII)
         transformed_interactions = InteractionValues(
             values=transformed_values,
             index=transformed_index,
@@ -373,12 +486,12 @@ class ExactComputer:
             max_order=order,
             interaction_lookup=transformed_lookup,
             n_players=self.n,
+            estimated=False,
         )
+        return copy.deepcopy(transformed_interactions)
 
-        return transformed_interactions
-
-    def compute_stii(self, order: int):
-        """Computes the STII index up to order "order"
+    def compute_stii(self, order: int) -> InteractionValues:
+        """Computes the STII index up to order "order".
 
         Args:
             order: The highest order of interactions
@@ -387,29 +500,29 @@ class ExactComputer:
             InteractionValues object containing STII
         """
 
-        stii_values = np.zeros(self.n_interactions[order])
+        stii_values = np.zeros(self._n_interactions[order])
+        stii_values[0] = self.baseline_value  # set baseline value
 
-        # Set baseline value
-        stii_values[0] = self.baseline_value
-
-        # Create interaction lookup
+        # create interaction lookup
         interaction_lookup = {}
-        for interaction_pos, interaction in enumerate(powerset(self.N, max_size=order)):
+        for interaction_pos, interaction in enumerate(
+            powerset(self._grand_coalition_set, max_size=order)
+        ):
             interaction_lookup[interaction] = interaction_pos
 
-        # Lower-order interactions (size < order) are the Möbius transform, i.e. discrete derivative with empty set
-        for interaction in powerset(self.N, max_size=order - 1):
-            stii_values[interaction_lookup[interaction]] = self.get_discrete_derivative(
-                interaction, ()
+        # lower-order interactions (size < order) are the Möbius transform, i.e. discrete derivative with empty set
+        for interaction in powerset(self._grand_coalition_set, max_size=order - 1):
+            stii_values[interaction_lookup[interaction]] = self._get_discrete_derivative(
+                interaction, tuple()
             )
 
-        # Pre-compute STII weights
-        stii_weights = self.get_stii_weights(order)
+        # pre-compute STII weights
+        stii_weights = self._get_stii_weights(order)
 
-        # Top-order STII interactions
-        for interaction in powerset(self.N, min_size=order, max_size=order):
+        # top-order STII interactions
+        for interaction in powerset(self._grand_coalition_set, min_size=order, max_size=order):
             interaction_pos = interaction_lookup[interaction]
-            for coalition_pos, coalition in enumerate(powerset(self.N)):
+            for coalition_pos, coalition in enumerate(powerset(self._grand_coalition_set)):
                 coalition_size = len(coalition)
                 intersection_size = len(set(coalition).intersection(set(interaction)))
                 stii_values[interaction_pos] += (
@@ -418,7 +531,7 @@ class ExactComputer:
                     * self.game_values[coalition_pos]
                 )
 
-        # Transform into InteractionValues object
+        # transform into InteractionValues object
         stii = InteractionValues(
             values=stii_values,
             index="STII",
@@ -428,47 +541,47 @@ class ExactComputer:
             interaction_lookup=interaction_lookup,
             estimated=False,
         )
+        return copy.deepcopy(stii)
 
-        return stii
+    def compute_fsii(self, order: int) -> InteractionValues:
+        """Computes the FSII index up to order "order" after
+            [Tsai et al. 2023](https://jmlr.org/papers/v24/22-0202.html).
 
-    def compute_fsii(self, order: int):
-        """Computes the FSII index up to order "order"
-        According to https://jmlr.org/papers/v24/22-0202.html
         Args:
             order: The highest order of interactions
 
         Returns:
             InteractionValues object containing STII
         """
-        fsii_weights = self.get_fsii_weights()
-        lstsq_weights = np.zeros(2**self.n)
-        coalition_matrix = np.zeros((2**self.n, self.n_interactions[order]))
+        fsii_weights = self._get_fsii_weights()
+        least_squares_weights = np.zeros(2**self.n, dtype=float)
+        coalition_matrix = np.zeros((2**self.n, self._n_interactions[order]), dtype=bool)
 
-        # Create interaction lookup
+        # create interaction lookup
         interaction_lookup = {}
-        for interaction_pos, interaction in enumerate(powerset(self.N, max_size=order)):
+        for interaction_pos, interaction in enumerate(
+            powerset(self._grand_coalition_set, max_size=order)
+        ):
             interaction_lookup[interaction] = interaction_pos
 
         coalition_store = {}
-        # Set LSTSQ matrices
-        for coalition_pos, coalition in enumerate(powerset(self.N)):
-            lstsq_weights[coalition_pos] = fsii_weights[len(coalition)]
+        # Set least squares matrices
+        for coalition_pos, coalition in enumerate(powerset(self._grand_coalition_set)):
+            least_squares_weights[coalition_pos] = fsii_weights[len(coalition)]
             for interaction in powerset(coalition, max_size=order):
                 pos = interaction_lookup[interaction]
                 coalition_matrix[coalition_pos, pos] = 1
             coalition_store[coalition] = coalition_pos
-        weight_matrix_sqrt = np.sqrt(np.diag(lstsq_weights))
+        weight_matrix_sqrt = np.sqrt(np.diag(least_squares_weights))
         coalition_matrix_weighted_sqrt = np.dot(weight_matrix_sqrt, coalition_matrix)
         game_value_weighted_sqrt = np.dot(self.game_values, weight_matrix_sqrt)
-        # Solve WLSQ problem
+        # solve the weighted least squares (WLSQ) problem
         fsii_values, residuals, rank, singular_values = np.linalg.lstsq(
             coalition_matrix_weighted_sqrt, game_value_weighted_sqrt, rcond=None
         )
 
-        # Set baseline value
-        fsii_values[0] = self.baseline_value
-
-        # Transform into InteractionValues object
+        # transform into InteractionValues object
+        fsii_values[0] = self.baseline_value  # set baseline value
         fsii = InteractionValues(
             values=fsii_values,
             index="FSII",
@@ -478,11 +591,10 @@ class ExactComputer:
             interaction_lookup=interaction_lookup,
             estimated=False,
         )
+        return copy.deepcopy(fsii)
 
-        return fsii
-
-    def get_jointsv_weights(self, order):
-        """Pre-compute JointSV weights for coalition_size=0,...,n-order
+    def get_jointsv_weights(self, order: int) -> np.ndarray:
+        """Pre-compute JointSV weights for all coalition sizes (0, ... , n - order).
 
         Args:
             order: The highest order of interactions
@@ -500,35 +612,17 @@ class ExactComputer:
             qden = sum([binom(self.n - r, s) for s in range(1, limd + 1)])
             qnum = sum([binom(r, s) * weights[s] for s in range(limn, r)])
             weights[r] = qnum / qden
-        # Check that the checksum is satisfied
+        # check that the checksum is satisfied
         checksum = sum([binom(self.n, i) * weights[i] for i in range((self.n - order), self.n)])
         assert np.isclose(checksum, 1.0)
         return weights
 
-    def get_bernoulli_weights(self, order):
-        """Returns the bernoulli weights in the k-additive approximation via SII, e.g. used in kADD-SHAP
+    def compute_kadd_shap(self, order: int) -> InteractionValues:
+        """Computes the kADD-SHAP index up to order "order". This is similar to FSII except that the
+            coalition matrix contains the Bernoulli weights.
 
-        Args:
-            order: The highest order of interactions
-
-        Returns:
-            An array containing the bernoulli weights
-        """
-
-        bernoulli_numbers = bernoulli(order)
-        weights = np.zeros((order + 1, order + 1))
-        for interaction_size in range(1, order + 1):
-            for intersection_size in range(interaction_size + 1):
-                for sum_index in range(1, intersection_size + 1):
-                    weights[interaction_size, intersection_size] += (
-                        binom(intersection_size, sum_index)
-                        * bernoulli_numbers[interaction_size - sum_index]
-                    )
-        return weights
-
-    def compute_kadd_shap(self, order: int):
-        """Computes the kADD-SHAP index up to order "order". This is similar to FSII except that the coalition matrix contains the Bernoulli weights
-        According to https://doi.org/10.1016/j.artint.2023.104014
+        The implementation is according to
+        [Pelegrina et al. 2023](https://doi.org/10.1016/j.artint.2023.104014).
 
         Args:
             order: The highest order of interactions
@@ -537,26 +631,26 @@ class ExactComputer:
             An InteractionValues object containing kADD-SHAP values
         """
 
-        weights = self.get_fsii_weights()
-        lstsq_weights = np.zeros(2**self.n)
-        coalition_matrix = np.zeros((2**self.n, self.n_interactions[order]))
-        bernoulli_weights = self.get_bernoulli_weights(order)
+        weights = self._get_fsii_weights()
+        least_squares_weights = np.zeros(2**self.n)
+        coalition_matrix = np.zeros((2**self.n, self._n_interactions[order]))
+        bernoulli_weights = get_bernoulli_weights(order)
 
         interaction_lookup = {}
-        for i, interaction in enumerate(powerset(self.N, max_size=order)):
+        for i, interaction in enumerate(powerset(self._grand_coalition_set, max_size=order)):
             interaction_lookup[interaction] = i
 
-        for coalition_pos, coalition in enumerate(powerset(self.N)):
-            lstsq_weights[coalition_pos] = weights[len(coalition)]
-            for interaction in powerset(self.N, min_size=1, max_size=order):
+        for coalition_pos, coalition in enumerate(powerset(self._grand_coalition_set)):
+            least_squares_weights[coalition_pos] = weights[len(coalition)]
+            for interaction in powerset(self._grand_coalition_set, min_size=1, max_size=order):
                 intersection_size = len(set(coalition).intersection(interaction))
                 interaction_size = len(interaction)
                 # This is different from FSII
-                coalition_matrix[
-                    coalition_pos, interaction_lookup[interaction]
-                ] = bernoulli_weights[interaction_size, intersection_size]
+                coalition_matrix[coalition_pos, interaction_lookup[interaction]] = (
+                    bernoulli_weights[interaction_size, intersection_size]
+                )
 
-        weight_matrix_sqrt = np.sqrt(np.diag(lstsq_weights))
+        weight_matrix_sqrt = np.sqrt(np.diag(least_squares_weights))
         coalition_matrix_weighted_sqrt = np.dot(weight_matrix_sqrt, coalition_matrix)
         game_value_weighted_sqrt = np.dot(self.game_values, weight_matrix_sqrt)
         kADD_shap_values, residuals, rank, singular_values = np.linalg.lstsq(
@@ -579,10 +673,10 @@ class ExactComputer:
 
         return kADD_shap
 
-    def compute_jointSV(self, order):
+    def compute_joint_sv(self, order: int):
         """
-        Computes the JointSV index up to order "order"
-        According to https://openreview.net/forum?id=vcUmUvQCloe
+        Computes the JointSV index up to order "order" according to
+        https://openreview.net/forum?id=vcUmUvQCloe.
 
         Args:
             order: The highest order of interactions
@@ -591,21 +685,23 @@ class ExactComputer:
             An InteractionValues object containing kADD-SHAP values
 
         """
-        jointSV_values = np.zeros(self.n_interactions[order])
+        jointSV_values = np.zeros(self._n_interactions[order])
         # Set baseline value
         jointSV_values[0] = self.baseline_value
         coalition_weights = self.get_jointsv_weights(order)
 
         interaction_lookup = {}
-        for i, interaction in enumerate(powerset(self.N, max_size=order)):
+        for i, interaction in enumerate(powerset(self._grand_coalition_set, max_size=order)):
             interaction_lookup[interaction] = i
 
         for coalition_pos, coalition in enumerate(
-            powerset(self.N, min_size=0, max_size=self.n - 1)
+            powerset(self._grand_coalition_set, min_size=0, max_size=self.n - 1)
         ):
             coalition_val = self.game_values[coalition_pos]
             coalition_weight = coalition_weights[len(coalition)]
-            for interaction in powerset(self.N - set(coalition), min_size=1, max_size=order):
+            for interaction in powerset(
+                self._grand_coalition_set - set(coalition), min_size=1, max_size=order
+            ):
                 jointSV_values[interaction_lookup[interaction]] += coalition_weight * (
                     self.game_values[self.coalition_lookup[tuple(sorted(coalition + interaction))]]
                     - coalition_val
@@ -625,10 +721,12 @@ class ExactComputer:
 
     def shapley_generalized_value(self, order: int, index: str) -> InteractionValues:
         """
-        Computes Shapley Generalized Values, i.e. Generalized Values that satisfy efficiency
-        According to the underlying representation in https://doi.org/10.1016/j.dam.2006.05.002
-        Currently covers:
+        Computes Shapley Generalized Values (i.e. Generalized Values that satisfy efficiency) after
+            the underlying representation in https://doi.org/10.1016/j.dam.2006.05.002.
+
+        Currently, the following indices are supported:
             - JointSV: https://openreview.net/forum?id=vcUmUvQCloe
+
         Args:
             order: The highest order of interactions
             index: The generalized value index
@@ -636,18 +734,22 @@ class ExactComputer:
         Returns:
             An InteractionValues object containing generalized values
 
+        Raises:
+            ValueError: If the index is not supported.
         """
         if index == "JointSV":
-            shapley_generalized_value = self.compute_jointSV(order)
+            shapley_generalized_value = self.compute_joint_sv(order)
+            self._computed[index] = shapley_generalized_value
+            return copy.copy(shapley_generalized_value)
+        else:
+            raise ValueError(f"Index {index} not supported")
 
-        self.computed[index] = shapley_generalized_value
-        return copy.copy(shapley_generalized_value)
+    def shapley_interaction(self, index: str, order: int) -> InteractionValues:
+        """Computes k-additive Shapley Interactions, i.e. probabilistic interaction indices that
+            depend on the order k.
 
-    def shapley_interaction(self, order: int, index: str = "k-SII") -> InteractionValues:
-        """
-        Computes k-additive Shapley Interactions, i.e. probabilistic interaction indices that depend on the order k
-        According to the underlying representation using discrete derivatives from https://doi.org/10.1016/j.geb.2005.03.002
-        Currently covers:
+        According to the underlying representation using discrete derivatives from
+        https://doi.org/10.1016/j.geb.2005.03.002, the following indices are supported:
             - k-SII: k-Shapley Values https://proceedings.mlr.press/v206/bordt23a.html
             - STII:  Shapley-Taylor Interaction Index https://proceedings.mlr.press/v119/sundararajan20a.html
             - FSII: Faithful Shapley Interaction Index https://jmlr.org/papers/v24/22-0202.html
@@ -660,30 +762,34 @@ class ExactComputer:
         Returns:
             An InteractionValues object containing interaction values
 
+        Raises:
+            ValueError: If the index is not supported
         """
         if index == "k-SII":
             sii = self.base_interaction("SII", order)
-            self.computed["SII"] = sii
+            self._computed["SII"] = sii  # nice
             shapley_interaction = self.base_aggregation(sii, order)
-        if index == "STII":
+        elif index == "STII":
             shapley_interaction = self.compute_stii(order)
-        if index == "FSII":
+        elif index == "FSII":
             shapley_interaction = self.compute_fsii(order)
-        if index == "kADD-SHAP":
+        elif index == "kADD-SHAP":
             shapley_interaction = self.compute_kadd_shap(order)
+        else:
+            raise ValueError(f"Index {index} not supported")
 
-        self.computed[index] = shapley_interaction
-
+        self._computed[index] = shapley_interaction
         return copy.copy(shapley_interaction)
 
-    def shapley_base_interaction(self, order: int, index: str) -> InteractionValues:
-        """
-        Computes Shapley Base Interactions, i.e. probabilistic interaction indices that do not depend on the order
-        According to the underlying representation using discrete derivatives from https://doi.org/10.1016/j.geb.2005.03.002
-        Currently covers:
+    def shapley_base_interaction(self, index: str, order: int) -> InteractionValues:
+        """Computes Shapley Base Interactions, i.e. probabilistic interaction indices that do not
+            depend on the order.
+
+        According to the underlying representation using discrete derivatives from
+        https://doi.org/10.1016/j.geb.2005.03.002, the following indices are supported:
             - SII: Shapley Interaction Index https://link.springer.com/article/10.1007/s001820050125
-            - CHII: Chaining Interaction Index https://link.springer.com/chapter/10.1007/978-94-017-0647-6_5
             - BII: Banzhaf Interaction Index https://link.springer.com/article/10.1007/s001820050125
+            - CHII: Chaining Interaction Index https://link.springer.com/chapter/10.1007/978-94-017-0647-6_5
 
         Args:
             order: The highest order of interactions
@@ -694,33 +800,64 @@ class ExactComputer:
 
         """
         base_interaction = self.base_interaction(index, order)
-        self.computed[index] = base_interaction
+        self._computed[index] = base_interaction
         return copy.copy(base_interaction)
 
-    def probabilistic_value(self, index: str) -> InteractionValues:
-        """Computes common semi-values or probabilistic values, i.e. shapley values without efficiency axiom. These are special of interaction indices and generalized values for order = 1.
-        According to the underlying representation using marginal contributions, cf.
-            - semi-values https://doi.org/10.1287/moor.6.1.122
-            - probabilistic values https://doi.org/10.1017/CBO9780511528446.008
+    def probabilistic_value(self, index: str, *args, **kwargs) -> InteractionValues:
+        """Computes common semi-values or probabilistic values, i.e. shapley values without
+        efficiency axiom.
 
-        Currently covers:
-            - SV: Shapley Value https://doi.org/10.1515/9781400881970-018
-            - BV: Banzhaf https://doi.org/10.1515/9781400881970-018
+        These semi-values are special forms of interaction indices and generalized values for
+        order = 1. According to the underlying representation using marginal contributions (cf.
+        [semi-values](https://doi.org/10.1287/moor.6.1.122) or
+        [probabilistic values](https://doi.org/10.1017/CBO9780511528446.008) the following indices
+        are currently supported:
+            - SV: Shapley value: https://doi.org/10.1515/9781400881970-018
+            - BV: Banzhaf value: https://doi.org/10.1515/9781400881970-018
 
         Args:
             index: The interaction index
+            args and kwargs: Additional arguments and keyword arguments (not used)
 
         Returns:
             An InteractionValues object containing probabilistic values
+
+        Raises:
+            ValueError: If the index is not supported
         """
         if index == "BV":
             probabilistic_value = self.base_interaction(index="BII", order=1)
-        if index == "SV":
+        elif index == "SV":
             probabilistic_value = self.base_interaction(index="SII", order=1)
             # Change emptyset value of SII to baseline value
             probabilistic_value.baseline_value = self.baseline_value
-            probabilistic_value.values[
-                probabilistic_value.interaction_lookup[tuple()]
-            ] = self.baseline_value
-        self.computed[index] = probabilistic_value
+            probabilistic_value.values[probabilistic_value.interaction_lookup[tuple()]] = (
+                self.baseline_value
+            )
+        else:
+            raise ValueError(f"Index {index} not supported")
+        self._computed[index] = probabilistic_value
         return copy.copy(probabilistic_value)
+
+
+def get_bernoulli_weights(order: int) -> np.ndarray:
+    """Returns the bernoulli weights in the k-additive approximation via SII, e.g. used in
+        kADD-SHAP.
+
+    Args:
+        order: The highest order of interactions
+
+    Returns:
+        An array containing the bernoulli weights
+    """
+    # TODO: We should import this in the kADD-SHAP approximator from here
+    bernoulli_numbers = bernoulli(order)
+    weights = np.zeros((order + 1, order + 1))
+    for interaction_size in range(1, order + 1):
+        for intersection_size in range(interaction_size + 1):
+            for sum_index in range(1, intersection_size + 1):
+                weights[interaction_size, intersection_size] += (
+                    binom(intersection_size, sum_index)
+                    * bernoulli_numbers[interaction_size - sum_index]
+                )
+    return weights

--- a/shapiq/interaction_values.py
+++ b/shapiq/interaction_values.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from shapiq.utils import generate_interaction_lookup, powerset
 
-AVAILABLE_INDICES = {"k-SII", "SII", "STI", "FSI", "STII", "FSII", "SV", "BV", "BZV", "Moebius"}
+AVAILABLE_INDICES = {"k-SII", "SII", "STI", "FSI", "STII", "FSII", "SV", "BV", "BZF", "Moebius"}
 
 
 @dataclass

--- a/shapiq/interaction_values.py
+++ b/shapiq/interaction_values.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from shapiq.utils import generate_interaction_lookup, powerset
 
-AVAILABLE_INDICES = {"k-SII", "SII", "STI", "FSI", "STII", "FSII", "SV", "BV", "Moebius"}
+AVAILABLE_INDICES = {"k-SII", "SII", "STI", "FSI", "STII", "FSII", "SV", "BV", "BZV", "Moebius"}
 
 
 @dataclass

--- a/shapiq/interaction_values.py
+++ b/shapiq/interaction_values.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from shapiq.utils import generate_interaction_lookup, powerset
 
-AVAILABLE_INDICES = {"k-SII", "SII", "STI", "FSI", "STII", "FSII", "SV", "BZF", "Moebius"}
+AVAILABLE_INDICES = {"k-SII", "SII", "STI", "FSI", "STII", "FSII", "SV", "BV", "Moebius"}
 
 
 @dataclass

--- a/shapiq/interaction_values.py
+++ b/shapiq/interaction_values.py
@@ -69,6 +69,22 @@ class InteractionValues:
             raise ValueError(
                 f"Index {self.index} is not valid. " f"Available indices are {AVAILABLE_INDICES}."
             )
+
+        # set BV if order is 1
+        if self.index == "BII" and self.max_order == 1:
+            self.index = "BV"
+
+        # set SV if order is 1
+        # TODO: check if this is correct and all indices are covered: at the moment all indices
+        # in the following set are covered + "k-" and "II" variants of them
+        indices_to_change_to_SV = {"SII", "SIII", "FSI", "FSII", "STI", "STII", "kADD-SHAP"}
+        if self.max_order == 1:
+            index_test = self.index
+            if index_test.startswith("k-"):  # remove aggregation k
+                index_test = index_test[2:]
+            if index_test in indices_to_change_to_SV:
+                self.index = "SV"
+
         if self.interaction_lookup is None:
             self.interaction_lookup = generate_interaction_lookup(
                 self.n_players, self.min_order, self.max_order

--- a/shapiq/interaction_values.py
+++ b/shapiq/interaction_values.py
@@ -10,7 +10,25 @@ import numpy as np
 
 from shapiq.utils import generate_interaction_lookup, powerset
 
-AVAILABLE_INDICES = {"k-SII", "SII", "STI", "FSI", "STII", "FSII", "SV", "BV", "BZF", "Moebius"}
+AVAILABLE_INDICES = {
+    "JointSV",
+    "SGV",
+    "BGV",
+    "CHGV",
+    "CHII",
+    "BII",
+    "kADD-SHAP",
+    "k-SII",
+    "SII",
+    "STI",
+    "FSI",
+    "STII",
+    "FSII",
+    "SV",
+    "BV",
+    "BZF",
+    "Moebius",
+}
 
 
 @dataclass

--- a/tests/test_exact_computer.py
+++ b/tests/test_exact_computer.py
@@ -1,0 +1,37 @@
+from shapiq.games.soum import SOUM
+from shapiq.approximator.moebius_converter import MoebiusConverter
+from shapiq.exact_computer import ExactComputer
+import numpy as np
+
+
+def test_exact_computer_on_soum():
+    n = np.random.randint(low=2, high=12)
+    order = np.random.randint(low=1, high=min(n, 5))
+    n_basis_games = np.random.randint(low=1, high=100)
+
+    n = 5
+    order = 2
+    n_basis_games = 1
+    soum = SOUM(n, n_basis_games=1, min_interaction_size=1)
+
+    predicted_value = soum(np.ones(n))[0]
+    emptyset_prediction = soum(np.zeros(n))[0]
+
+    # Compute via exactComputer
+    exact_computer = ExactComputer(soum.N, soum)
+
+    # Compute via sparse Möbius representation
+    moebius_converter = MoebiusConverter(soum.N, soum.moebius_coefficients)
+
+    # Compare ground truth via MoebiusConvert with exact computation of ExactComputer
+    shapley_interactions_gt = {}
+    shapley_interactions_exact = {}
+    for index in ["STII", "k-SII", "FSII"]:
+        shapley_interactions_gt[index] = moebius_converter.moebius_to_shapley_interaction(
+            order, index
+        )
+        shapley_interactions_exact[index] = exact_computer.shapley_interaction(order, index)
+        print(
+            np.sum((shapley_interactions_exact[index] - shapley_interactions_gt[index]).values ** 2)
+        )
+    print("test")

--- a/tests/test_exact_computer.py
+++ b/tests/test_exact_computer.py
@@ -6,7 +6,7 @@ import numpy as np
 
 def test_exact_computer_on_soum():
     for i in range(100):
-        n = np.random.randint(low=2, high=12)
+        n = np.random.randint(low=2, high=10)
         N = set(range(n))
         order = np.random.randint(low=1, high=min(n, 5))
         n_basis_games = np.random.randint(low=1, high=100)
@@ -21,6 +21,10 @@ def test_exact_computer_on_soum():
         # Compute via sparse Möbius representation
         moebius_converter = MoebiusConverter(N, soum.moebius_coefficients)
 
+        moebius_transform = exact_computer.moebius_transform()
+        # Assert equality with ground truth Möbius coefficients from SOUM
+        assert np.sum((moebius_transform - soum.moebius_coefficients).values ** 2) < 10e-7
+
         # Compare ground truth via MoebiusConvert with exact computation of ExactComputer
         shapley_interactions_gt = {}
         shapley_interactions_exact = {}
@@ -29,9 +33,42 @@ def test_exact_computer_on_soum():
                 order, index
             )
             shapley_interactions_exact[index] = exact_computer.shapley_interaction(order, index)
+            # Check equality with ground truth calculations from SOUM
             assert (
                 np.sum(
                     (shapley_interactions_exact[index] - shapley_interactions_gt[index]).values ** 2
                 )
                 < 10e-7
             )
+
+        index = "JointSV"
+        shapley_generalized_values = exact_computer.shapley_generalized_value(
+            order=order, index=index
+        )
+        # Assert efficiency
+        assert (np.sum(shapley_generalized_values.values) - predicted_value) ** 2 < 10e-7
+
+        index = "kADD-SHAP"
+        shapley_interactions_exact[index] = exact_computer.shapley_interaction(order, index)
+
+        base_interaction_indices = ["SII", "BII", "CHII"]
+        base_interactions = {}
+        for base_index in base_interaction_indices:
+            base_interactions[base_index] = exact_computer.shapley_base_interaction(
+                order=order, index=base_index
+            )
+
+        base_gv_indices = ["SGV", "BGV", "CHGV"]
+        base_gv = {}
+        for base_gv_index in base_gv_indices:
+            base_gv[base_gv_index] = exact_computer.base_generalized_value(
+                order=order, index=base_gv_index
+            )
+
+        probabilistic_values_indices = ["SV", "BV"]
+        probabilistic_values = {}
+        for pv_index in probabilistic_values_indices:
+            probabilistic_values[pv_index] = exact_computer.probabilistic_value(index=pv_index)
+
+        # Assert efficiency for SV
+        assert (np.sum(probabilistic_values["SV"].values) - predicted_value) ** 2 < 10e-7

--- a/tests/test_exact_computer.py
+++ b/tests/test_exact_computer.py
@@ -5,33 +5,33 @@ import numpy as np
 
 
 def test_exact_computer_on_soum():
-    n = np.random.randint(low=2, high=12)
-    order = np.random.randint(low=1, high=min(n, 5))
-    n_basis_games = np.random.randint(low=1, high=100)
+    for i in range(100):
+        n = np.random.randint(low=2, high=12)
+        N = set(range(n))
+        order = np.random.randint(low=1, high=min(n, 5))
+        n_basis_games = np.random.randint(low=1, high=100)
+        soum = SOUM(n, n_basis_games=1, min_interaction_size=1)
 
-    n = 5
-    order = 2
-    n_basis_games = 1
-    soum = SOUM(n, n_basis_games=1, min_interaction_size=1)
+        predicted_value = soum(np.ones(n))[0]
+        emptyset_prediction = soum(np.zeros(n))[0]
 
-    predicted_value = soum(np.ones(n))[0]
-    emptyset_prediction = soum(np.zeros(n))[0]
+        # Compute via exactComputer
+        exact_computer = ExactComputer(N, soum)
 
-    # Compute via exactComputer
-    exact_computer = ExactComputer(soum.N, soum)
+        # Compute via sparse Möbius representation
+        moebius_converter = MoebiusConverter(N, soum.moebius_coefficients)
 
-    # Compute via sparse Möbius representation
-    moebius_converter = MoebiusConverter(soum.N, soum.moebius_coefficients)
-
-    # Compare ground truth via MoebiusConvert with exact computation of ExactComputer
-    shapley_interactions_gt = {}
-    shapley_interactions_exact = {}
-    for index in ["STII", "k-SII", "FSII"]:
-        shapley_interactions_gt[index] = moebius_converter.moebius_to_shapley_interaction(
-            order, index
-        )
-        shapley_interactions_exact[index] = exact_computer.shapley_interaction(order, index)
-        print(
-            np.sum((shapley_interactions_exact[index] - shapley_interactions_gt[index]).values ** 2)
-        )
-    print("test")
+        # Compare ground truth via MoebiusConvert with exact computation of ExactComputer
+        shapley_interactions_gt = {}
+        shapley_interactions_exact = {}
+        for index in ["STII", "k-SII", "FSII"]:
+            shapley_interactions_gt[index] = moebius_converter.moebius_to_shapley_interaction(
+                order, index
+            )
+            shapley_interactions_exact[index] = exact_computer.shapley_interaction(order, index)
+            assert (
+                np.sum(
+                    (shapley_interactions_exact[index] - shapley_interactions_gt[index]).values ** 2
+                )
+                < 10e-7
+            )

--- a/tests/test_exact_computer.py
+++ b/tests/test_exact_computer.py
@@ -1,11 +1,15 @@
+"""This test module tests the ExactComputer class."""
+
+import numpy as np
+import pytest
+
 from shapiq.games.soum import SOUM
 from shapiq.approximator.moebius_converter import MoebiusConverter
 from shapiq.exact_computer import ExactComputer
-import numpy as np
 
 
 def test_exact_computer_on_soum():
-    for i in range(100):
+    for i in range(20):
         n = np.random.randint(low=2, high=10)
         N = set(range(n))
         order = np.random.randint(low=1, high=min(n, 5))
@@ -15,7 +19,7 @@ def test_exact_computer_on_soum():
         predicted_value = soum(np.ones(n))[0]
 
         # Compute via exactComputer
-        exact_computer = ExactComputer(N, soum)
+        exact_computer = ExactComputer(n_players=n, game_fun=soum)
 
         # Compute via sparse Möbius representation
         moebius_converter = MoebiusConverter(N, soum.moebius_coefficients)
@@ -31,7 +35,9 @@ def test_exact_computer_on_soum():
             shapley_interactions_gt[index] = moebius_converter.moebius_to_shapley_interaction(
                 order, index
             )
-            shapley_interactions_exact[index] = exact_computer.shapley_interaction(order, index)
+            shapley_interactions_exact[index] = exact_computer.shapley_interaction(
+                index=index, order=order
+            )
             # Check equality with ground truth calculations from SOUM
             assert (
                 np.sum(
@@ -48,7 +54,9 @@ def test_exact_computer_on_soum():
         assert (np.sum(shapley_generalized_values.values) - predicted_value) ** 2 < 10e-7
 
         index = "kADD-SHAP"
-        shapley_interactions_exact[index] = exact_computer.shapley_interaction(order, index)
+        shapley_interactions_exact[index] = exact_computer.shapley_interaction(
+            index=index, order=order
+        )
 
         base_interaction_indices = ["SII", "BII", "CHII"]
         base_interactions = {}
@@ -71,3 +79,46 @@ def test_exact_computer_on_soum():
 
         # Assert efficiency for SV
         assert (np.sum(probabilistic_values["SV"].values) - predicted_value) ** 2 < 10e-7
+
+
+@pytest.mark.parametrize(
+    "index, order",
+    [
+        ("SV", 1),
+        ("BV", 1),
+        ("SII", 2),
+        ("BII", 2),
+        ("CHII", 2),
+        ("SGV", 2),
+        ("BGV", 2),
+        ("CHGV", 2),
+        ("STII", 2),
+        ("k-SII", 2),
+        ("FSII", 2),
+        ("JointSV", 2),
+        ("kADD-SHAP", 2),
+        ("SII", None),
+    ],
+)
+def test_exact_computer_call(index, order):
+    """Tests the call function for the ExactComputer."""
+    n = 5
+    soum = SOUM(n, n_basis_games=10)
+    exact_computer = ExactComputer(n_players=n, game_fun=soum)
+    interaction_values = exact_computer(index=index, order=order)
+    if order is None:
+        order = n
+    assert interaction_values is not None  # should return something
+    assert interaction_values.max_order == order  # order should be the same
+    assert interaction_values.index == index  # index should be the same
+    assert interaction_values.estimated is False  # nothing should be estimated
+    assert interaction_values.values is not None  # values should be computed
+
+
+def test_basic_functions():
+    """Tests the basic functions of the ExactComputer."""
+    n = 5
+    soum = SOUM(n, n_basis_games=10)
+    exact_computer = ExactComputer(n_players=n, game_fun=soum)
+    isinstance(repr(exact_computer), str)
+    isinstance(str(exact_computer), str)

--- a/tests/test_exact_computer.py
+++ b/tests/test_exact_computer.py
@@ -10,10 +10,9 @@ def test_exact_computer_on_soum():
         N = set(range(n))
         order = np.random.randint(low=1, high=min(n, 5))
         n_basis_games = np.random.randint(low=1, high=100)
-        soum = SOUM(n, n_basis_games=1, min_interaction_size=1)
+        soum = SOUM(n, n_basis_games=n_basis_games)
 
         predicted_value = soum(np.ones(n))[0]
-        emptyset_prediction = soum(np.zeros(n))[0]
 
         # Compute via exactComputer
         exact_computer = ExactComputer(N, soum)

--- a/tests/test_exact_computer.py
+++ b/tests/test_exact_computer.py
@@ -33,7 +33,7 @@ def test_exact_computer_on_soum():
         shapley_interactions_exact = {}
         for index in ["STII", "k-SII", "FSII"]:
             shapley_interactions_gt[index] = moebius_converter.moebius_to_shapley_interaction(
-                order, index
+                index=index, order=order
             )
             shapley_interactions_exact[index] = exact_computer.shapley_interaction(
                 index=index, order=order

--- a/tests/tests_approximators/test_approximator_moebius_converter.py
+++ b/tests/tests_approximators/test_approximator_moebius_converter.py
@@ -20,7 +20,7 @@ def test_soum_moebius_conversion():
         shapley_interactions = {}
         for index in ["STII", "k-SII", "FSII"]:
             shapley_interactions[index] = moebius_converter.moebius_to_shapley_interaction(
-                order, index
+                index=index, order=order
             )
             # Assert efficiency
             assert (np.sum(shapley_interactions[index].values) - predicted_value) ** 2 < 10e-7


### PR DESCRIPTION
This pull requests builds on https://github.com/mmschlk/shapiq/pull/109

The ExactComputer class can be used to compute interaction indices and other indices exhaustively.
Currently includes:
- base-interactions: Shapley Interaction Index (SII), Banzhaf Interaction Index (BII), Chaining Interaction Index (CHII)
- base-generalized-values: Shapley Generalized Value (SGV), Banzhaf Generalized Values (BGV), Chaining Generalized Value (CHGV)
- shapley-interactions: k-Shapley Values (k-SII), Shapley Taylor Interaction Index (STII), Faithful Shapley Interaction Index (FSII), k-Additive SHAP (kADD-SHAP)
- probabilistic-values: Shapley Values (SV), Banzhaf Values (BV)
- shapley-generalized-values: Joint Shapley Values (JointSV)

References are documented in the code.

Tests include ground truth comparison on SOUM with MoebiusConverter (k-SII, STII, FSII) and efficiency (JointSV, SV).