### PR TITLE
remove warning for adding two indices (closes 88)

### DIFF
--- a/shapiq/interaction_values.py
+++ b/shapiq/interaction_values.py
@@ -2,7 +2,6 @@
 scores."""
 
 import copy
-import warnings
 from dataclasses import dataclass
 from typing import Optional, Union
 
@@ -249,12 +248,7 @@ class InteractionValues:
                 or self.n_players != other.n_players
                 or self.min_order != other.min_order
                 or self.max_order != other.max_order
-            ):  # different interactions
-                warnings.warn(
-                    "Adding InteractionValues with different interactions. Interactions will be "
-                    "merged and added together. The resulting InteractionValues will have the "
-                    "union of the interactions of the two original InteractionValues."
-                )
+            ):  # different interactions but addable
                 interaction_lookup = {**self.interaction_lookup}
                 position = len(self.interaction_lookup)
                 values_to_add = []

--- a/tests/test_base_interaction_values.py
+++ b/tests/test_base_interaction_values.py
@@ -185,8 +185,9 @@ def test_add():
         interaction_lookup=interaction_lookup_second,
         baseline_value=0.0,
     )
-    with pytest.warns(UserWarning):
-        interaction_values_added = interaction_values_first + interaction_values_second
+
+    # test adding InteractionValues with different interactions
+    interaction_values_added = interaction_values_first + interaction_values_second
     assert interaction_values_added.n_players == n + 1  # is the maximum of the two
     assert interaction_values_added.min_order == min_order
     assert interaction_values_added.max_order == max_order + 1  # is the maximum of the two


### PR DESCRIPTION
Removed the warning instead of suppressing, as this actually is very reasonable and default behavior of adding two `InteractionValues` objects. Especially when the object becomes more sparse. 