### PR TITLE
adds the n_order array to interaction values

### DIFF
--- a/shapiq/interaction_values.py
+++ b/shapiq/interaction_values.py
@@ -337,3 +337,28 @@ class InteractionValues:
     def __rmul__(self, other: Union[int, float]) -> "InteractionValues":
         """Multiplies an InteractionValues object by a scalar."""
         return self.__mul__(other)
+
+    def get_n_order_values(self, order: int) -> "np.ndarray":
+        """Returns the interaction values of a specific order as a numpy array.
+
+        Note:
+            Depending on the order and number of players the resulting array might be sparse and
+            very large.
+
+        Args:
+            order: The order of the interactions to return.
+
+        Returns:
+            The interaction values of the specified order as a numpy array of shape `(n_players,)`
+            for order 1 and `(n_players, n_players)` for order 2, etc.
+
+        Raises:
+            ValueError: If the order is less than 1.
+        """
+        if order < 1:
+            raise ValueError("Order must be greater or equal to 1.")
+        values_shape = tuple([self.n_players] * order)
+        values = np.zeros(values_shape, dtype=float)
+        for interaction in powerset(range(self.n_players), min_size=1, max_size=order):
+            values[interaction] = self[interaction]
+        return values

--- a/shapiq/interaction_values.py
+++ b/shapiq/interaction_values.py
@@ -349,10 +349,15 @@ class InteractionValues:
         Raises:
             ValueError: If the order is less than 1.
         """
+        from itertools import permutations
+
         if order < 1:
             raise ValueError("Order must be greater or equal to 1.")
         values_shape = tuple([self.n_players] * order)
         values = np.zeros(values_shape, dtype=float)
         for interaction in powerset(range(self.n_players), min_size=1, max_size=order):
-            values[interaction] = self[interaction]
+            # get all orderings of the interaction (e.g. (0, 1) and (1, 0) for interaction (0, 1))
+            for perm in permutations(interaction):
+                values[perm] = self[interaction]
+
         return values

--- a/shapiq/interaction_values.py
+++ b/shapiq/interaction_values.py
@@ -2,7 +2,6 @@
 scores."""
 
 import copy
-import warnings
 from dataclasses import dataclass
 from typing import Optional, Union
 
@@ -249,12 +248,7 @@ class InteractionValues:
                 or self.n_players != other.n_players
                 or self.min_order != other.min_order
                 or self.max_order != other.max_order
-            ):  # different interactions
-                warnings.warn(
-                    "Adding InteractionValues with different interactions. Interactions will be "
-                    "merged and added together. The resulting InteractionValues will have the "
-                    "union of the interactions of the two original InteractionValues."
-                )
+            ):  # different interactions but addable
                 interaction_lookup = {**self.interaction_lookup}
                 position = len(self.interaction_lookup)
                 values_to_add = []

--- a/tests/test_base_interaction_values.py
+++ b/tests/test_base_interaction_values.py
@@ -185,8 +185,9 @@ def test_add():
         interaction_lookup=interaction_lookup_second,
         baseline_value=0.0,
     )
-    with pytest.warns(UserWarning):
-        interaction_values_added = interaction_values_first + interaction_values_second
+
+    # test adding InteractionValues with different interactions
+    interaction_values_added = interaction_values_first + interaction_values_second
     assert interaction_values_added.n_players == n + 1  # is the maximum of the two
     assert interaction_values_added.min_order == min_order
     assert interaction_values_added.max_order == max_order + 1  # is the maximum of the two

--- a/tests/test_base_interaction_values.py
+++ b/tests/test_base_interaction_values.py
@@ -286,3 +286,42 @@ def test_sum():
     )
 
     assert np.isclose(sum(interaction_values), np.sum(interaction_values.values))
+
+
+def test_n_order_transform():
+    """Tests the n_order_transform method of the InteractionValues dataclass."""
+    index = "SII"
+    n = 5
+    min_order = 1
+    max_order = 3
+    interaction_lookup = {
+        interaction: i for i, interaction in enumerate(powerset(range(n), min_order, max_order))
+    }
+    values = np.random.rand(len(interaction_lookup))
+    interaction_values = InteractionValues(
+        values=values,
+        index=index,
+        n_players=n,
+        min_order=min_order,
+        max_order=max_order,
+        interaction_lookup=interaction_lookup,
+        baseline_value=0.0,
+    )
+
+    # test n_order_transform order 1
+    interaction_values_transformed = interaction_values.get_n_order_values(1)
+    assert interaction_values_transformed.shape == (n,)
+    assert interaction_values_transformed[3] == interaction_values[(3,)]
+
+    # test n_order_transform order 2
+    interaction_values_transformed = interaction_values.get_n_order_values(2)
+    assert interaction_values_transformed.shape == (n, n)
+    assert interaction_values_transformed[3, 4] == interaction_values[(3, 4)]
+
+    # test n_order_transform order 3
+    interaction_values_transformed = interaction_values.get_n_order_values(3)
+    assert interaction_values_transformed.shape == (n, n, n)
+    assert interaction_values_transformed[0, 3, 4] == interaction_values[(0, 3, 4)]
+
+    with pytest.raises(ValueError):
+        _ = interaction_values.get_n_order_values(0)

--- a/tests/test_base_interaction_values.py
+++ b/tests/test_base_interaction_values.py
@@ -323,6 +323,9 @@ def test_n_order_transform():
     interaction_values_transformed = interaction_values.get_n_order_values(3)
     assert interaction_values_transformed.shape == (n, n, n)
     assert interaction_values_transformed[0, 3, 4] == interaction_values[(0, 3, 4)]
+    assert interaction_values_transformed[4, 3, 0] == interaction_values[(0, 3, 4)]
+    assert interaction_values_transformed[0, 4, 3] == interaction_values[(0, 3, 4)]
+    assert interaction_values_transformed[4, 0, 3] == interaction_values[(0, 3, 4)]
 
     with pytest.raises(ValueError):
         _ = interaction_values.get_n_order_values(0)


### PR DESCRIPTION
Adds the `get_n_order_values function` function to the `InteractionValues` object. The returned array is of shape (n_players,) for order 1, (n_players, n_players) for order 2 etc. All values of the array are filled to allow for unsorted access.

```python
>>> interaction_values: InteractionValues
>>> values_arr = interaction_values.get_n_order_values(2)
>>> value_arr[0, 2]
some value
>>> value_arr[2, 0]
some value
>>> value_arr[2, 0] == value_arr[0, 2]
True
```