### PR TITLE
Adds the TreeSHAP-IQ game

### DIFF
--- a/shapiq/explainer/tree/explainer.py
+++ b/shapiq/explainer/tree/explainer.py
@@ -28,7 +28,7 @@ class TreeExplainer(Explainer):
 
         # validate and parse model
         validated_model = validate_tree_model(model, class_label=class_label)
-        self._trees: Union[TreeModel, list[TreeModel]] = copy.deepcopy(validated_model)
+        self._trees: list[TreeModel] = copy.deepcopy(validated_model)
         if not isinstance(self._trees, list):
             self._trees = [self._trees]
         self._n_trees = len(self._trees)

--- a/shapiq/games/benchmark/__init__.py
+++ b/shapiq/games/benchmark/__init__.py
@@ -45,6 +45,10 @@ from .local_xai.benchmark_tabular import CaliforniaHousing as CaliforniaHousingL
 from .synthetic.dummy import DummyGame
 from .synthetic.soum import SOUM, UnanimityGame
 
+# treeshap-iq explanation games
+from .treeshapiq_xai.base import TreeSHAPIQXAI
+from .treeshapiq_xai.benchmark import CaliforniaHousing as CaliforniaHousingTreeSHAPIQXAI
+
 # cluster explanation games
 from .unsupervised_cluster.base import ClusterExplanation
 from .unsupervised_cluster.benchmark import AdultCensus as AdultCensusClusterExplanation
@@ -100,6 +104,9 @@ __all__ = [
     "AdultCensusUnsupervisedData",
     "BikeSharingUnsupervisedData",
     "CaliforniaHousingUnsupervisedData",
+    # treeshapiq_xai games
+    "TreeSHAPIQXAI",
+    "CaliforniaHousingTreeSHAPIQXAI",
     # synthetic games
     "DummyGame",
     "SOUM",

--- a/shapiq/games/benchmark/__init__.py
+++ b/shapiq/games/benchmark/__init__.py
@@ -47,6 +47,8 @@ from .synthetic.soum import SOUM, UnanimityGame
 
 # treeshap-iq explanation games
 from .treeshapiq_xai.base import TreeSHAPIQXAI
+from .treeshapiq_xai.benchmark import AdultCensus as AdultCensusTreeSHAPIQXAI
+from .treeshapiq_xai.benchmark import BikeSharing as BikeSharingTreeSHAPIQXAI
 from .treeshapiq_xai.benchmark import CaliforniaHousing as CaliforniaHousingTreeSHAPIQXAI
 
 # cluster explanation games
@@ -106,6 +108,8 @@ __all__ = [
     "CaliforniaHousingUnsupervisedData",
     # treeshapiq_xai games
     "TreeSHAPIQXAI",
+    "AdultCensusTreeSHAPIQXAI",
+    "BikeSharingTreeSHAPIQXAI",
     "CaliforniaHousingTreeSHAPIQXAI",
     # synthetic games
     "DummyGame",

--- a/shapiq/games/benchmark/local_xai/base.py
+++ b/shapiq/games/benchmark/local_xai/base.py
@@ -7,6 +7,8 @@ import numpy as np
 from shapiq.games.base import Game
 from shapiq.games.imputer import MarginalImputer
 
+from ..setup import get_x_explain
+
 
 class LocalExplanation(Game):
     """The LocalExplanation game class.
@@ -71,7 +73,7 @@ class LocalExplanation(Game):
     ) -> None:
 
         # get x_explain
-        self.x = x if x is not None else _get_x_explain(x, data)
+        self.x = x if x is not None else get_x_explain(x, data)
 
         # init the imputer which serves as the workhorse of this Game
         self._imputer = imputer
@@ -103,22 +105,3 @@ class LocalExplanation(Game):
             The output of the model on feature subsets.
         """
         return self._imputer(coalitions)
-
-
-def _get_x_explain(x: Optional[Union[np.ndarray, int]], x_set: np.ndarray) -> np.ndarray:
-    """Returns the data point to explain given the input.
-
-    Args:
-        x: The data point to explain. Can be an index of the background data or a 1d matrix of shape
-            (n_features).
-        x_set: The data set to select the data point from. Should be a 2d matrix of shape
-            (n_samples, n_features).
-
-    Returns:
-        The data point to explain as a numpy array.
-    """
-    if x is None:
-        x = x_set[np.random.randint(0, x_set.shape[0])]
-    if isinstance(x, int):
-        x = x_set[x]
-    return x

--- a/shapiq/games/benchmark/local_xai/benchmark_tabular.py
+++ b/shapiq/games/benchmark/local_xai/benchmark_tabular.py
@@ -5,7 +5,8 @@ from typing import Optional, Union
 import numpy as np
 
 from .._setup import BenchmarkSetup
-from .base import LocalExplanation, _get_x_explain
+from ..setup import get_x_explain
+from .base import LocalExplanation
 
 
 class AdultCensus(LocalExplanation):
@@ -46,7 +47,7 @@ class AdultCensus(LocalExplanation):
         )
 
         # get x_explain
-        x = _get_x_explain(x, setup.x_test)
+        x = get_x_explain(x, setup.x_test)
 
         def predict_function(x):
             return setup.predict_function(x)[:, class_to_explain]
@@ -92,7 +93,7 @@ class BikeSharing(LocalExplanation):
         )
 
         # get x_explain
-        x = _get_x_explain(x, setup.x_test)
+        x = get_x_explain(x, setup.x_test)
 
         predict_function = setup.predict_function
 
@@ -137,7 +138,7 @@ class CaliforniaHousing(LocalExplanation):
         )
 
         # get x_explain
-        x = _get_x_explain(x, setup.x_test)
+        x = get_x_explain(x, setup.x_test)
 
         # call the super constructor
         super().__init__(

--- a/shapiq/games/benchmark/setup.py
+++ b/shapiq/games/benchmark/setup.py
@@ -1,7 +1,7 @@
 """This module contains a setup for the tabular benchmark games."""
 
 import copy
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 
@@ -292,3 +292,22 @@ def _accuracy(y_true: np.ndarray, y_pred: np.ndarray, threshold: float = 0.5) ->
         y_pred = np.argmax(y_pred, axis=1)
 
     return accuracy_score(y_true, y_pred)
+
+
+def get_x_explain(x: Optional[Union[np.ndarray, int]], x_set: np.ndarray) -> np.ndarray:
+    """Returns the data point to explain given the input.
+
+    Args:
+        x: The data point to explain. Can be an index of the background data or a 1d matrix of shape
+            (n_features).
+        x_set: The data set to select the data point from. Should be a 2d matrix of shape
+            (n_samples, n_features).
+
+    Returns:
+        The data point to explain as a numpy array.
+    """
+    if x is None:
+        x = x_set[np.random.randint(0, x_set.shape[0])]
+    if isinstance(x, int):
+        x = x_set[x]
+    return x

--- a/shapiq/games/benchmark/treeshapiq_xai/__init__.py
+++ b/shapiq/games/benchmark/treeshapiq_xai/__init__.py
@@ -1,3 +1,8 @@
 """This module contains the TreeSHAP-IQ explanation benchmark games."""
 
+from .base import TreeSHAPIQXAI
+from .benchmark import CaliforniaHousing
+
+__all__ = ["TreeSHAPIQXAI", "CaliforniaHousing"]
+
 # Path: shapiq/games/benchmark/treeshapiq_xai/__init__.py

--- a/shapiq/games/benchmark/treeshapiq_xai/__init__.py
+++ b/shapiq/games/benchmark/treeshapiq_xai/__init__.py
@@ -1,0 +1,3 @@
+"""This module contains the TreeSHAP-IQ explanation benchmark games."""
+
+# Path: shapiq/games/benchmark/treeshapiq_xai/__init__.py

--- a/shapiq/games/benchmark/treeshapiq_xai/base.py
+++ b/shapiq/games/benchmark/treeshapiq_xai/base.py
@@ -1,5 +1,6 @@
 """This module contains the base TreeSHAP-IQ xai game."""
 
+import copy
 from typing import Optional
 
 import numpy as np
@@ -24,6 +25,8 @@ class TreeSHAPIQXAI(Game):
         normalize: bool = True,
     ) -> None:
         n_players = x.shape[-1]
+
+        self.model = copy.deepcopy(tree_model)
 
         # set up explainer for ground truth explanation
         self._tree_explainer = TreeExplainer(

--- a/shapiq/games/benchmark/treeshapiq_xai/base.py
+++ b/shapiq/games/benchmark/treeshapiq_xai/base.py
@@ -4,8 +4,7 @@ from typing import Optional
 
 import numpy as np
 
-from shapiq.explainer import TreeExplainer
-from shapiq.explainer.tree import TreeModel
+from shapiq.explainer.tree import TreeExplainer, TreeModel
 from shapiq.interaction_values import InteractionValues
 from shapiq.utils.types import Model
 

--- a/shapiq/games/benchmark/treeshapiq_xai/base.py
+++ b/shapiq/games/benchmark/treeshapiq_xai/base.py
@@ -1,0 +1,123 @@
+"""This module contains the base TreeSHAP-IQ xai game."""
+
+from typing import Optional
+
+import numpy as np
+
+from shapiq.explainer import TreeExplainer
+from shapiq.explainer.tree import TreeModel
+from shapiq.interaction_values import InteractionValues
+from shapiq.utils.types import Model
+
+from ...base import Game
+
+
+class TreeSHAPIQXAI(Game):
+
+    def __init__(
+        self,
+        x: np.ndarray,
+        tree_model: Model,
+        index: str,
+        class_label: Optional[int] = None,
+        max_order: int = 2,
+        min_order: int = 1,
+        normalize: bool = True,
+    ) -> None:
+        n_players = x.shape[-1]
+
+        # set up explainer for ground truth explanation
+        self._tree_explainer = TreeExplainer(
+            model=tree_model,
+            min_order=min_order,
+            max_order=max_order,
+            interaction_type=index,
+            class_label=class_label,
+        )
+        # compute ground truth values
+        self.gt_interaction_values: InteractionValues = self._tree_explainer.explain(x=x)
+        self.empty_value = float(self._tree_explainer.baseline_value)
+
+        # get attributes for manual tree traversal and evaluation
+        self._trees: list[TreeModel] = self._tree_explainer._trees
+        self.x_explain = x
+
+        super().__init__(
+            n_players=n_players, normalize=normalize, normalization_value=self.empty_value
+        )
+
+    def value_function(self, coalitions: np.ndarray) -> np.ndarray:
+        """Computes the output of the tree model given coalitions of features.
+
+        Args:
+            coalitions: A binary matrix of feature subsets present (`True`) or absent (`False`).
+                The matrix is expected to be in shape `(n_coalitions, n_features)`.
+
+        Returns:
+            The worth of the coalitions as a vector.
+        """
+        worth = np.zeros(len(coalitions), dtype=float)
+        for i, coalition in enumerate(coalitions):
+            if sum(coalition) == 0:  # empty subset
+                worth[i] = self.empty_value
+                continue
+            worth[i] = self.compute_tree_output_from_coalition(coalitions[i])
+        return worth
+
+    def compute_tree_output_from_coalition(self, coalition: np.ndarray) -> float:
+        """Computes the output of the tree models contained in the game.
+
+        Args:
+            coalition: A binary vector of feature indices present (`True`) and absent (`False`) from
+                the coalition.
+
+        Returns:
+            The prediction given partial feature information as an average of individual tree
+                predictions.
+        """
+        output = 0.0
+        for tree in self._trees:
+            tree_prediction = _get_tree_prediction(
+                node_id=tree.nodes[0], tree=tree, coalition=coalition, x_explain=self.x_explain
+            )
+            output += tree_prediction
+        return output
+
+
+def _get_tree_prediction(
+    node_id: int, tree: TreeModel, coalition: np.ndarray, x_explain: np.ndarray
+) -> float:
+    """Traverses the tree and retrieves the prediction of the tree given subsets of features.
+
+    Args:
+        node_id: The current node in the tree model as an integer.
+        tree: The tree model to traverse and get the predictions for.
+        coalition: The binary coalition vector denoting what features are present (`True`) and
+            absent (`False`).
+        x_explain: The feature vector which is to be explained with numerical feature values.
+
+    Returns:
+         The tree prediction given partial feature information.
+    """
+    if tree.leaf_mask[node_id]:  # end of recursion (base case, return the leaf prediction)
+        tree_prediction = tree.values[node_id]
+        return tree_prediction
+    else:  # not a leaf we have to go deeper
+        feature_id, threshold = tree.features[node_id], tree.thresholds[node_id]
+        is_present = bool(coalition[feature_id])
+        left_child, right_child = tree.children_left[node_id], tree.children_right[node_id]
+        if is_present:
+            next_node = left_child if x_explain[feature_id] <= threshold else right_child
+            tree_prediction = _get_tree_prediction(next_node, tree, coalition, x_explain)
+        else:  # feature is out of coalition we have to go both ways and average the predictions
+            prediction_left = _get_tree_prediction(left_child, tree, coalition, x_explain)
+            prediction_right = _get_tree_prediction(right_child, tree, coalition, x_explain)
+            # get weights (tree probabilities of going left or right)
+            left_weight = tree.node_sample_weight[left_child]
+            right_weight = tree.node_sample_weight[right_child]
+            sum_of_weights = left_weight + right_weight
+            # scale predictions
+            prediction_left *= left_weight / sum_of_weights
+            prediction_right *= right_weight / sum_of_weights
+            tree_prediction = prediction_left + prediction_right
+    return tree_prediction

--- a/shapiq/games/benchmark/treeshapiq_xai/base.py
+++ b/shapiq/games/benchmark/treeshapiq_xai/base.py
@@ -13,6 +13,20 @@ from ...base import Game
 
 
 class TreeSHAPIQXAI(Game):
+    """A TreeSHAP-IQ explanation game for tree models.
+
+    The game is based on the TreeSHAP-IQ algorithm and is used to explain the predictions of tree
+    models. TreeSHAP-IQ is used to compute Shapley interaction values for tree models.
+
+    Args:
+        x: The feature vector to be explained.
+        tree_model: The tree model to be explained.
+        index: The type of interaction index to be computed. The default value is "k-SII".
+        class_label: The class label to be explained. The default value is None.
+        max_order: The maximum order of interactions to be computed. The default value is 2.
+        min_order: The minimum order of interactions to be computed. The default value is 1.
+        normalize: A boolean flag to normalize/center the game values. The default value is True.
+    """
 
     def __init__(
         self,

--- a/shapiq/games/benchmark/treeshapiq_xai/benchmark.py
+++ b/shapiq/games/benchmark/treeshapiq_xai/benchmark.py
@@ -8,7 +8,8 @@ from ..setup import BenchmarkSetup, get_x_explain
 from .base import TreeSHAPIQXAI
 
 
-class CaliforniaHousing(TreeSHAPIQXAI):
+class AdultCensus(TreeSHAPIQXAI):
+    """The Adult Census dataset as a TreeSHAP-IQ explanation game."""
 
     def __init__(
         self,
@@ -16,6 +17,75 @@ class CaliforniaHousing(TreeSHAPIQXAI):
         model_name: str = "decision_tree",
         index: str = "k-SII",
         class_label: Optional[int] = None,
+        max_order: int = 2,
+        min_order: int = 1,
+        normalize: bool = True,
+        verbose: bool = True,
+    ) -> None:
+
+        setup = BenchmarkSetup(
+            dataset_name="adult_census",
+            model_name=model_name,
+            verbose=verbose,
+        )
+
+        # get x_explain
+        x = get_x_explain(x, setup.x_test)
+
+        # call the super constructor
+        super().__init__(
+            x=x,
+            tree_model=setup.model,
+            normalize=normalize,
+            index=index,
+            class_label=class_label,
+            max_order=max_order,
+            min_order=min_order,
+        )
+
+
+class BikeSharing(TreeSHAPIQXAI):
+    """The Bike Sharing dataset as a TreeSHAP-IQ explanation game."""
+
+    def __init__(
+        self,
+        x: Optional[Union[np.ndarray, int]] = None,
+        model_name: str = "decision_tree",
+        index: str = "k-SII",
+        max_order: int = 2,
+        min_order: int = 1,
+        normalize: bool = True,
+        verbose: bool = True,
+    ) -> None:
+
+        setup = BenchmarkSetup(
+            dataset_name="bike_sharing",
+            model_name=model_name,
+            verbose=verbose,
+        )
+
+        # get x_explain
+        x = get_x_explain(x, setup.x_test)
+
+        # call the super constructor
+        super().__init__(
+            x=x,
+            tree_model=setup.model,
+            normalize=normalize,
+            index=index,
+            max_order=max_order,
+            min_order=min_order,
+        )
+
+
+class CaliforniaHousing(TreeSHAPIQXAI):
+    """The California Housing dataset as a TreeSHAP-IQ explanation game."""
+
+    def __init__(
+        self,
+        x: Optional[Union[np.ndarray, int]] = None,
+        model_name: str = "decision_tree",
+        index: str = "k-SII",
         max_order: int = 2,
         min_order: int = 1,
         normalize: bool = True,
@@ -37,7 +107,6 @@ class CaliforniaHousing(TreeSHAPIQXAI):
             tree_model=setup.model,
             normalize=normalize,
             index=index,
-            class_label=class_label,
             max_order=max_order,
             min_order=min_order,
         )

--- a/shapiq/games/benchmark/treeshapiq_xai/benchmark.py
+++ b/shapiq/games/benchmark/treeshapiq_xai/benchmark.py
@@ -1,0 +1,43 @@
+"""This module contains the TreeSHAPIQ explanation benchmark games."""
+
+from typing import Optional, Union
+
+import numpy as np
+
+from ..setup import BenchmarkSetup, get_x_explain
+from .base import TreeSHAPIQXAI
+
+
+class CaliforniaHousing(TreeSHAPIQXAI):
+
+    def __init__(
+        self,
+        x: Optional[Union[np.ndarray, int]] = None,
+        model_name: str = "decision_tree",
+        index: str = "k-SII",
+        class_label: Optional[int] = None,
+        max_order: int = 2,
+        min_order: int = 1,
+        normalize: bool = True,
+        verbose: bool = True,
+    ) -> None:
+
+        setup = BenchmarkSetup(
+            dataset_name="california_housing",
+            model_name=model_name,
+            verbose=verbose,
+        )
+
+        # get x_explain
+        x = get_x_explain(x, setup.x_test)
+
+        # call the super constructor
+        super().__init__(
+            x=x,
+            tree_model=setup.model,
+            normalize=normalize,
+            index=index,
+            class_label=class_label,
+            max_order=max_order,
+            min_order=min_order,
+        )

--- a/tests/tests_games/test_treeshapiq_xai.py
+++ b/tests/tests_games/test_treeshapiq_xai.py
@@ -3,13 +3,15 @@
 import numpy as np
 import pytest
 
-# old tree_shap_iq
 from shapiq.approximator.montecarlo import SHAPIQ
 from shapiq.exact import ExactComputer
-
-# own treeshap_iq
 from shapiq.games import Game
-from shapiq.games.benchmark import CaliforniaHousingTreeSHAPIQXAI, TreeSHAPIQXAI
+from shapiq.games.benchmark import (
+    AdultCensusTreeSHAPIQXAI,
+    BikeSharingTreeSHAPIQXAI,
+    CaliforniaHousingTreeSHAPIQXAI,
+    TreeSHAPIQXAI,
+)
 from shapiq.utils.sets import powerset
 
 
@@ -86,7 +88,27 @@ def test_random_forest_selection(
 
 def test_adult():
     """Test the AdultCensus TreeSHAP-IQ explanation game."""
-    raise NotImplementedError("TODO: Implement this test!")
+    max_order = 2
+    min_order = 1
+    index = "SII"
+
+    # benchmark game
+    game = AdultCensusTreeSHAPIQXAI(
+        x=1,
+        model_name="decision_tree",
+        index=index,
+        max_order=max_order,
+        min_order=min_order,
+        normalize=False,
+    )
+    gt_interaction_values = game.gt_interaction_values
+
+    # test against the exact computation
+    exact = ExactComputer(n_players=game.n_players, game_fun=game)
+    exact_values = exact(index=index, order=max_order)
+
+    for interaction in powerset(range(game.n_players), min_size=min_order, max_size=max_order):
+        assert np.isclose(exact_values[interaction], gt_interaction_values[interaction])
 
 
 def test_california():
@@ -116,4 +138,24 @@ def test_california():
 
 def test_bike():
     """Test the BikeSharing TreeSHAP-IQ explanation game."""
-    raise NotImplementedError("TODO: Implement this test!")
+    max_order = 2
+    min_order = 1
+    index = "SII"
+
+    # benchmark game
+    game = BikeSharingTreeSHAPIQXAI(
+        x=1,
+        model_name="decision_tree",
+        index=index,
+        max_order=max_order,
+        min_order=min_order,
+        normalize=False,
+    )
+    gt_interaction_values = game.gt_interaction_values
+
+    # test against the exact computation
+    exact = ExactComputer(n_players=game.n_players, game_fun=game)
+    exact_values = exact(index=index, order=max_order)
+
+    for interaction in powerset(range(game.n_players), min_size=min_order, max_size=max_order):
+        assert np.isclose(exact_values[interaction], gt_interaction_values[interaction])

--- a/tests/tests_games/test_treeshapiq_xai.py
+++ b/tests/tests_games/test_treeshapiq_xai.py
@@ -1,0 +1,74 @@
+"""This test module tests the TreeSHAP-IQ explanation games."""
+
+import numpy as np
+import pytest
+
+from shapiq.approximator.montecarlo import SHAPIQ
+from shapiq.games import Game
+from shapiq.games.benchmark import TreeSHAPIQXAI
+from shapiq.utils.sets import powerset
+
+
+@pytest.mark.parametrize("max_order", [2, 3])
+@pytest.mark.parametrize("index", ["k-SII", "SII", "STII"])
+def test_random_forest_selection(index, max_order, dt_clf_model, background_clf_dataset):
+    """Tests the base TreeSHAP-IQ explanation game."""
+
+    # start with classification model
+    model = dt_clf_model
+    data, target = background_clf_dataset
+    x_explain = data[0]
+    class_label = int(target[0])
+    min_order = 1 if index not in ["STII", "FSII"] else max_order
+
+    game = TreeSHAPIQXAI(
+        x=x_explain,
+        tree_model=model,
+        index=index,
+        class_label=class_label,
+        max_order=max_order,
+        min_order=min_order,
+        normalize=False,
+    )
+    gt_interaction_values = game.gt_interaction_values
+
+    assert isinstance(game, TreeSHAPIQXAI)
+    assert isinstance(game, Game)
+    assert game.n_players == len(x_explain)
+
+    # get the test coalitions
+    test_coalitions = np.array([game.empty_coalition, game.empty_coalition, game.grand_coalition])
+    test_coalitions[1, 0] = True
+    test_coalitions[1, 1] = True
+
+    # test the value function
+    worth = game.value_function(test_coalitions)
+    assert worth.shape == (len(test_coalitions),)
+    assert worth[0] == game.empty_value
+
+    # test against the ground truth "approximation"
+    n_players = game.n_players
+    budget = 2**n_players
+    top_order = index in ["STII", "FSII"]  # false for k-SII and SII
+    approximator = SHAPIQ(n=n_players, max_order=max_order, index=index, top_order=top_order)
+    estimates = approximator.approximate(budget=budget, game=game)
+    assert estimates.estimation_budget <= budget and not estimates.estimated
+    assert estimates.index == index
+
+    for interaction in powerset(range(n_players), min_size=min_order, max_size=max_order):
+        assert np.isclose(estimates[interaction], gt_interaction_values[interaction])
+
+
+def test_adult():
+    """Test the AdultCensus TreeSHAP-IQ explanation game."""
+    raise NotImplementedError("TODO: Implement this test!")
+
+
+def test_california():
+    """Test the CaliforniaHousing TreeSHAP-IQ explanation game."""
+    raise NotImplementedError("TODO: Implement this test!")
+
+
+def test_bike():
+    """Test the BikeSharing TreeSHAP-IQ explanation game."""
+    raise NotImplementedError("TODO: Implement this test!")


### PR DESCRIPTION
This PR adds the TreeSHAP-IQ local XAI game, which can be used to test against larger player numbers because of the TreeSHAP-IQ algorithm for calculating ground-truth values.