### PR TITLE
Sv bugfix in tree

### DIFF
--- a/shapiq/explainer/tree/explainer.py
+++ b/shapiq/explainer/tree/explainer.py
@@ -2,6 +2,7 @@
 computing any-order Shapley Interactions for tree ensembles."""
 
 import copy
+import warnings
 from typing import Any, Optional, Union
 
 import numpy as np
@@ -47,6 +48,10 @@ class TreeExplainer(Explainer):
     ) -> None:
 
         super().__init__(model)
+
+        if index == "SV" and max_order > 1:
+            warnings.warn("For index='SV' the max_order is set to 1.")
+            max_order = 1
 
         # validate and parse model
         validated_model = validate_tree_model(model, class_label=class_label)

--- a/shapiq/explainer/tree/treeshapiq.py
+++ b/shapiq/explainer/tree/treeshapiq.py
@@ -113,7 +113,7 @@ class TreeSHAPIQ:
         self.Ns_id_store: dict = {}
         self.Ns_store: dict = {}
         self.n_interpolation_size = self._n_features_in_tree
-        if self._index in ("SII", "k-SII"):  # SP is of order at most d_max
+        if self._index in ("SV", "SII", "k-SII"):  # SP is of order at most d_max
             self.n_interpolation_size = min(self._edge_tree.max_depth, self._n_features_in_tree)
         self._init_summary_polynomials()
 
@@ -308,7 +308,7 @@ class TreeSHAPIQ:
                 self._int_height[node_id][interaction_sets] == order
             ]
             if len(interactions_seen) > 0:
-                if self._index not in ("SII", "k-SII"):  # for CII
+                if self._index not in ("SV", "SII", "k-SII"):  # for CII
                     D_power = self.D_powers[self._n_features_in_tree - current_height]
                     index_quotient = self._n_features_in_tree - order
                 else:  # for SII and k-SII
@@ -343,7 +343,7 @@ class TreeSHAPIQ:
                     ancestor_heights = self._edge_tree.edge_heights[
                         interactions_ancestors[cond_interaction_seen]
                     ]
-                    if self._index not in ("SII", "k-SII"):  # for CII
+                    if self._index not in ("SV", "SII", "k-SII"):  # for CII
                         D_power = self.D_powers[self._n_features_in_tree - current_height]
                         index_quotient = self._n_features_in_tree - order
                     else:  # for SII and k-SII
@@ -405,7 +405,7 @@ class TreeSHAPIQ:
             self.subset_ancestors_store[order] = subset_ancestors
             self.D_store[order] = np.polynomial.chebyshev.chebpts2(self.n_interpolation_size)
             self.D_powers_store[order] = self._cache(self.D_store[order])
-            if self._index in ("SII", "k-SII"):
+            if self._index in ("SV", "SII", "k-SII"):
                 self.Ns_store[order] = self._get_N(self.D_store[order])
             else:
                 self.Ns_store[order] = self._get_N_cii(self.D_store[order], order)

--- a/tests/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -103,7 +103,7 @@ def test_against_shap_implementation():
         values=values,
     )
 
-    explainer = TreeExplainer(model=tree_model, max_order=1, min_order=1, index="SII")
+    explainer = TreeExplainer(model=tree_model, max_order=1, min_order=1, index="SV")
     explanation = explainer.explain(x_explain)
 
     assert explanation[(0,)] == pytest.approx(-0.09263158, abs=1e-4)
@@ -114,5 +114,10 @@ def test_against_shap_implementation():
     explainer = TreeExplainer(model=tree_model, max_order=1, min_order=1, index="SII")
     explanation = explainer.explain(x_explain)
 
-    explainer = TreeExplainer(model=tree_model, max_order=1, min_order=1, index="SII")
-    explanation = explainer.explain(x_explain)
+    assert explanation[(0,)] == pytest.approx(-0.09263158, abs=1e-4)
+    assert explanation[(1,)] == pytest.approx(-0.12100478, abs=1e-4)
+    assert explanation[(2,)] == pytest.approx(0.02727273, abs=1e-4)
+    assert explanation[(3,)] == pytest.approx(0.0, abs=1e-4)
+
+    with pytest.warns(UserWarning):
+        _ = TreeExplainer(model=tree_model, max_order=2, min_order=1, index="SV")

--- a/tests/tests_games/test_treeshapiq_xai.py
+++ b/tests/tests_games/test_treeshapiq_xai.py
@@ -87,7 +87,7 @@ def test_adult():
     """Test the AdultCensus TreeSHAP-IQ explanation game."""
     max_order = 2
     min_order = 1
-    index = "SII"
+    index = "k-SII"
 
     # benchmark game
     game = AdultCensusTreeSHAPIQXAI(
@@ -107,11 +107,13 @@ def test_adult():
         assert np.isclose(exact_values[interaction], gt_interaction_values[interaction])
 
 
-def test_california():
+@pytest.mark.parametrize("index_order", [("k-SII", 2), ("SV", 1)])
+def test_california(index_order):
     """Test the CaliforniaHousing TreeSHAP-IQ explanation game."""
-    max_order = 2
+    max_order = int(index_order[1])
+    index = str(index_order[0])
+
     min_order = 1
-    index = "SII"
 
     # benchmark game
     game = CaliforniaHousingTreeSHAPIQXAI(


### PR DESCRIPTION
Adds "SV" index to TreeSHAP-IQ such that one no longer has to do "SII" and `max_order = 1`.