### PR TITLE
fixes force plots not showing and baseline value

### DIFF
--- a/shapiq/plot/force.py
+++ b/shapiq/plot/force.py
@@ -36,10 +36,11 @@ def force_plot(
 
     if interaction_values.max_order == 1:
         return shap.plots.force(
-            base_value=interaction_values.baseline_value,
+            base_value=np.array([interaction_values.baseline_value], dtype=float),  # must be array
             shap_values=interaction_values.get_n_order_values(1),
             features=feature_values,
             feature_names=feature_names,
+            matplotlib=matplotlib,
             **kwargs,
         )
     else:
@@ -67,7 +68,7 @@ def force_plot(
                 )
 
         return shap.plots.force(
-            base_value=interaction_values.baseline_value,
+            base_value=np.array([interaction_values.baseline_value], dtype=float),  # must be array
             shap_values=np.array(_shap_values),
             feature_names=np.array(_labels),
             matplotlib=matplotlib,


### PR DESCRIPTION
Atm. plotting force plots for "SV" interaction_values does not return a matplotlib plot. The baseline value is also not set.

