### PR TITLE
Adds the UpSet plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Development
 - adds the `sentence_plot` function to the `plot` module to visualize the contributions of words to a language model prediction in a sentence-like format
 - makes abbreviations in the `plot` module optional [#281](https://github.com/mmschlk/shapiq/issues/281)
+- adds the `upset_plot` function to the `plot` module to visualize the interactions of higher-order [#290](https://github.com/mmschlk/shapiq/issues/290)
 
 ### v1.1.1 (2024-11-13)
 

--- a/shapiq/__init__.py
+++ b/shapiq/__init__.py
@@ -56,8 +56,10 @@ from .plot import (
     bar_plot,
     force_plot,
     network_plot,
+    sentence_plot,
     si_graph_plot,
     stacked_bar_plot,
+    upset_plot,
     waterfall_plot,
 )
 
@@ -106,6 +108,8 @@ __all__ = [
     "bar_plot",
     "si_graph_plot",
     "waterfall_plot",
+    "sentence_plot",
+    "upset_plot",
     # public utils
     "powerset",
     "get_explicit_subsets",

--- a/shapiq/interaction_values.py
+++ b/shapiq/interaction_values.py
@@ -716,3 +716,15 @@ class InteractionValues:
         from shapiq.plot.sentence import sentence_plot
 
         return sentence_plot(self, words, show=show, **kwargs)
+
+    def plot_upset(self, show: bool = True, **kwargs) -> Optional[plt.Figure]:
+        """Plots the upset plot.
+
+        For arguments, see shapiq.plot.upset_plot().
+
+        Returns:
+            The upset plot as a matplotlib figure (if show is ``False``).
+        """
+        from shapiq.plot.upset import upset_plot
+
+        return upset_plot(self, show=show, **kwargs)

--- a/shapiq/plot/__init__.py
+++ b/shapiq/plot/__init__.py
@@ -6,6 +6,7 @@ from .network import network_plot
 from .sentence import sentence_plot
 from .si_graph import si_graph_plot
 from .stacked_bar import stacked_bar_plot
+from .upset import upset_plot
 from .utils import abbreviate_feature_names, get_interaction_values_and_feature_names
 from .watefall import waterfall_plot
 
@@ -17,6 +18,7 @@ __all__ = [
     "bar_plot",
     "waterfall_plot",
     "sentence_plot",
+    "upset_plot",
     # utils
     "abbreviate_feature_names",
     "get_interaction_values_and_feature_names",

--- a/shapiq/plot/upset.py
+++ b/shapiq/plot/upset.py
@@ -11,10 +11,10 @@ from ._config import BLUE, RED
 
 def upset_plot(
     interaction_values: InteractionValues,
+    n_interactions: int = 20,
     feature_names: Optional[Sequence[str]] = None,
-    top_n: int = 20,
     color_matrix: bool = False,
-    present_features_only: bool = True,
+    all_features: bool = True,
     show: bool = False,
 ) -> Optional[plt.Figure]:
     """Plots the upset plot.
@@ -29,12 +29,12 @@ def upset_plot(
         interaction_values: The interaction values as an interaction object.
         feature_names: The names of the features. Defaults to ``None``. If ``None``, the features
             will be named with their index.
-        top_n: The number of top interactions to plot. Defaults to ``20``. Note this number is
+        n_interactions: The number of top interactions to plot. Defaults to ``20``. Note this number is
             completely arbitrary and can be adjusted to the user's needs.
         color_matrix: Whether to color the matrix (red for positive values, blue for negative) or
             not (black). Defaults to ``False``.
-        present_features_only: Whether to only plot the features that are present in the top
-            interactions. Defaults to ``True``.
+        all_features: Whether to plot all ``n_players`` features or only the features that are
+            present in the top interactions. Defaults to ``True``.
         show: Whether to show the plot. Defaults to ``False``.
 
     Returns:
@@ -52,22 +52,21 @@ def upset_plot(
     }
     values_abs = abs(values)
     idx = values_abs.argsort()[::-1]
-    idx = idx[:top_n] if top_n > 0 else idx
+    idx = idx[:n_interactions] if n_interactions > 0 else idx
     values = values[idx]
     interactions: list[tuple[int, ...]] = [values_ids[i] for i in idx]
 
     # prepare feature names ------------------------------------------------------------------------
-    features = set([feature for interaction in interactions for feature in interaction])
+    if all_features:
+        features = set(range(interaction_values.n_players))
+    else:
+        features = set([feature for interaction in interactions for feature in interaction])
     n_features = len(features)
     feature_pos = {feature: n_features - 1 - i for i, feature in enumerate(features)}
     if feature_names is None:
         feature_names = [f"Feature {feature}" for feature in features]
     else:
         feature_names = [feature_names[feature] for feature in features]
-
-    print(features)
-    print(feature_pos)
-    print(feature_names)
 
     # create figure --------------------------------------------------------------------------------
     height_upper, height_lower = 5, n_features * 0.75

--- a/shapiq/plot/upset.py
+++ b/shapiq/plot/upset.py
@@ -1,0 +1,127 @@
+"""This module contains the upset plot."""
+
+from collections.abc import Sequence
+from typing import Optional
+
+import matplotlib.pyplot as plt
+
+from ..interaction_values import InteractionValues
+from ._config import BLUE, RED
+
+
+def upset_plot(
+    interaction_values: InteractionValues,
+    feature_names: Optional[Sequence[str]] = None,
+    color_matrix: bool = False,
+    show: bool = False,
+) -> Optional[plt.Figure]:
+    """Plots the upset plot.
+
+    Args:
+        interaction_values: The interaction values as an interaction object.
+        feature_names: The names of the features. Defaults to ``None``. If ``None``, the features
+            will be named with their index.
+        color_matrix: Whether to color the matrix (red for positive values, blue for negative) or
+            not (black). Defaults to ``False``.
+        show: Whether to show the plot. Defaults to ``False``.
+
+    Returns:
+        If ``show`` is ``True``, the function returns ``None``. Otherwise, it returns a tuple with
+        the figure and the axis of the plot.
+    """
+
+    # prepare data
+    values = interaction_values.values
+    values_ids: dict[int, tuple[int, ...]] = {
+        v: k for k, v in interaction_values.interaction_lookup.items()
+    }
+    values_abs = abs(values)
+    idx = values_abs.argsort()[::-1]
+    values = values[idx]
+    interactions: list[tuple[int, ...]] = [values_ids[i] for i in idx]
+    features = set([feature for interaction in interactions for feature in interaction])
+    n_features = len(features)
+    feature_pos: dict[int, int] = {}
+    for pos in range(n_features):
+        feature_pos[list(features)[pos]] = n_features - pos - 1
+
+    # create figure
+    height_upper, height_lower = 5, n_features * 0.75
+    height = height_upper + height_lower
+    ratio = [height_upper, height_lower]
+    fig, ax = plt.subplots(
+        2, 1, figsize=(10, height), gridspec_kw={"height_ratios": ratio}, sharex=True
+    )
+
+    # plot lower part of the upset plot
+    for x_pos, interaction in enumerate(interactions):
+        color = RED.hex if values[x_pos] >= 0 else BLUE.hex
+
+        # plot upper part
+        bar = ax[0].bar(x_pos, values[x_pos], color=color)
+        label = [f"{values[x_pos]:.2f}"]
+        ax[0].bar_label(bar, label, label_type="edge", color="black", fontsize=12, padding=3)
+
+        # plot lower part
+        # plot the matrix in the background
+        ax[1].plot(
+            [x_pos for _ in range(n_features)],
+            list(range(n_features)),
+            color="lightgray",
+            marker="o",
+            markersize=15,
+            linewidth=0,
+        )
+        # add the interaction to the matrix
+        x_pos = [x_pos for _ in range(len(interaction))]
+        y_pos = [feature_pos[feature] for feature in interaction]
+        ax[1].plot(
+            x_pos,
+            y_pos,
+            color="black" if not color_matrix else color,
+            marker="o",
+            markersize=15,
+            linewidth=1.5,
+        )
+
+    # beautify upper plot --------------------------------------------------------------------------
+    min_max = (min(values), max(values))
+    delta = (min_max[1] - min_max[0]) * 0.1
+    ax[0].set_ylim(min_max[0] - delta, min_max[1] + delta)
+    ax[0].set_ylabel("Interaction Value")
+    ax[0].spines["top"].set_visible(False)
+    ax[0].spines["right"].set_visible(False)
+    ax[0].spines["bottom"].set_visible(False)
+    # add line at 0
+    ax[0].axhline(0, color="black", linewidth=0.5)
+
+    # beautify lower plot
+    ax[1].set_ylim(-1, n_features)
+    # add feature names
+    if feature_names is None:
+        feature_names = [f"Feature {feature}" for feature in features]
+    else:
+        feature_names = [feature_names[feature] for feature in features]
+    ax[1].yaxis.set_ticks(range(n_features))
+    ax[1].set_yticklabels(feature_names)
+    # remove y-tick markings but keep labels
+    ax[1].tick_params(axis="y", length=0)
+    # remove x-axis
+    ax[1].set_xticks([])
+    # remove spines
+    ax[1].spines["top"].set_visible(False)
+    ax[1].spines["right"].set_visible(False)
+    ax[1].spines["bottom"].set_visible(False)
+    ax[1].spines["left"].set_visible(False)
+
+    # add an alternating lightgray bacground behind the feature names
+    for i in range(n_features):
+        if i % 2 == 0:
+            ax[1].axhspan(i - 0.5, i + 0.5, color="lightgray", alpha=0.25, zorder=0, lw=0)
+
+    # adjust whitespace
+    plt.subplots_adjust(hspace=0.0)
+
+    if not show:
+        return fig
+    plt.show()

--- a/shapiq/plot/upset.py
+++ b/shapiq/plot/upset.py
@@ -19,7 +19,9 @@ def upset_plot(
 
     UpSet plots are used to visualize the interactions between features. The plot consists of two
     parts: the upper part shows the interaction values as bars, and the lower part shows the
-    interactions as a matrix. Originally, the UpSet plot was introduced by Lex et al. [1].
+    interactions as a matrix. Originally, the UpSet plot was introduced by Lex et al. [1]. For a
+    more detailed explanation, see the references or the original
+    [documentation](https://upset.app/).
 
     Args:
         interaction_values: The interaction values as an interaction object.

--- a/shapiq/plot/upset.py
+++ b/shapiq/plot/upset.py
@@ -17,6 +17,10 @@ def upset_plot(
 ) -> Optional[plt.Figure]:
     """Plots the upset plot.
 
+    UpSet plots are used to visualize the interactions between features. The plot consists of two
+    parts: the upper part shows the interaction values as bars, and the lower part shows the
+    interactions as a matrix. Originally, the UpSet plot was introduced by Lex et al. [1].
+
     Args:
         interaction_values: The interaction values as an interaction object.
         feature_names: The names of the features. Defaults to ``None``. If ``None``, the features
@@ -28,6 +32,9 @@ def upset_plot(
     Returns:
         If ``show`` is ``True``, the function returns ``None``. Otherwise, it returns a tuple with
         the figure and the axis of the plot.
+
+    References:
+        - [1] Alexander Lex, Nils Gehlenborg, Hendrik Strobelt, Romain Vuillemot, Hanspeter Pfister. UpSet: Visualization of Intersecting Sets IEEE Transactions on Visualization and Computer Graphics (InfoVis), 20(12): 1983--1992, doi:10.1109/TVCG.2014.2346248, 2014.
     """
 
     # prepare data

--- a/tests/tests_plots/test_upset.py
+++ b/tests/tests_plots/test_upset.py
@@ -41,16 +41,21 @@ def test_upset_plot():
     assert isinstance(fig, plt.Figure)
     plt.close("all")
 
-    fp = upset_plot(iv, feature_names=feature_names, color_matrix=True, show=True)
-    assert fp is None
+    fig = upset_plot(iv, feature_names=feature_names, color_matrix=True, show=True)
+    assert fig is None
     plt.close("all")
 
     # in the following feature 3 is not shown
-    fp = upset_plot(iv, n_interactions=5, all_features=False, show=False)
+    fig = upset_plot(iv, n_interactions=5, all_features=False, show=False)
     assert isinstance(fig, plt.Figure)
     plt.close("all")
 
     # in the following feature 3 is shown
-    fp = upset_plot(iv, n_interactions=5, all_features=True, show=False)
+    fig = upset_plot(iv, n_interactions=5, all_features=True, show=False)
+    assert isinstance(fig, plt.Figure)
+    plt.close("all")
+
+    # test once directly from the interaction values
+    fig = iv.plot_upset(feature_names=feature_names, show=False)
     assert isinstance(fig, plt.Figure)
     plt.close("all")

--- a/tests/tests_plots/test_upset.py
+++ b/tests/tests_plots/test_upset.py
@@ -1,0 +1,46 @@
+"""This module contains all tests for the upset plot."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from shapiq.interaction_values import InteractionValues
+from shapiq.plot import upset_plot
+
+
+def test_upset_plot():
+    """Test the force plot function."""
+    lookup = {
+        (0,): 0,
+        (1,): 1,
+        (2,): 2,
+        (0, 1): 3,
+        (0, 2): 4,
+        (0, 1, 2): 5,
+        (1, 4): 6,
+        (2, 3): 7,
+        (0, 1, 3): 8,
+        (0, 2, 3): 9,
+        (0, 1, 2, 3): 10,
+        (0, 1, 2, 4): 11,
+        (0, 1, 2, 3, 4): 12,
+    }
+    iv = InteractionValues(
+        values=np.array([1, 2, 1.5, -0.9, 0.1, 0.3, -0.2, 0.1, 0.11, -0.1, 0.2, 0.8, 0.05]),
+        interaction_lookup=lookup,
+        index="k-SII",
+        min_order=1,
+        max_order=5,
+        baseline_value=0.0,
+        n_players=5,
+    )
+    n_players = iv.n_players
+    feature_names = [f"feature-{i}" for i in range(n_players)]
+    feature_names = np.array(feature_names)
+
+    fig = upset_plot(iv, show=False, feature_names=feature_names)
+    assert isinstance(fig, plt.Figure)
+    plt.close("all")
+
+    fp = upset_plot(iv, show=True, feature_names=feature_names, color_matrix=True)
+    assert fp is None
+    plt.close("all")

--- a/tests/tests_plots/test_upset.py
+++ b/tests/tests_plots/test_upset.py
@@ -37,10 +37,20 @@ def test_upset_plot():
     feature_names = [f"feature-{i}" for i in range(n_players)]
     feature_names = np.array(feature_names)
 
-    fig = upset_plot(iv, show=False, feature_names=feature_names)
+    fig = upset_plot(iv, feature_names=feature_names, show=False)
     assert isinstance(fig, plt.Figure)
     plt.close("all")
 
-    fp = upset_plot(iv, show=True, feature_names=feature_names, color_matrix=True)
+    fp = upset_plot(iv, feature_names=feature_names, color_matrix=True, show=True)
     assert fp is None
+    plt.close("all")
+
+    # in the following feature 3 is not shown
+    fp = upset_plot(iv, n_interactions=5, all_features=False, show=False)
+    assert isinstance(fig, plt.Figure)
+    plt.close("all")
+
+    # in the following feature 3 is shown
+    fp = upset_plot(iv, n_interactions=5, all_features=True, show=False)
+    assert isinstance(fig, plt.Figure)
     plt.close("all")


### PR DESCRIPTION
This PR closes #290. 

This pull request introduces a new `upset_plot` function to the `plot` module, which visualizes the interactions of higher-order features. It also includes necessary updates to integrate this new function throughout the codebase.

New feature addition:

* [`shapiq/plot/upset.py`](diffhunk://#diff-ed3a006f03c6a1b50c2bf4bce74bf2934deb8a170f51aeef8edabd4ed34e9106R1-R140): Added the `upset_plot` function to visualize the interactions of higher-order features.
* [`tests/tests_plots/test_upset.py`](diffhunk://#diff-6e6310b8bd3a0cdf5968653a140f653e3257a0f9b49e64f898677c9d360d62f5R1-R61): Added tests for the `upset_plot` function to ensure it works correctly under various conditions.

Integration of the new feature:

* [`shapiq/__init__.py`](diffhunk://#diff-ce98d5f086101a11ae79e05bb76299b45ab4d0f94b8faae50b37f107d1259074R59-R62): Added `upset_plot` to the list of imports and the `__all__` attribute to make it publicly accessible. [[1]](diffhunk://#diff-ce98d5f086101a11ae79e05bb76299b45ab4d0f94b8faae50b37f107d1259074R59-R62) [[2]](diffhunk://#diff-ce98d5f086101a11ae79e05bb76299b45ab4d0f94b8faae50b37f107d1259074R111-R112)
* [`shapiq/interaction_values.py`](diffhunk://#diff-afe7e96f1c2507b94a51204c7e43314a51137dd16aa4b95bd5f8c987c238df1cR719-R730): Added the `plot_upset` method to the `InteractionValues` class, allowing users to plot upset plots directly from interaction values.
* [`shapiq/plot/__init__.py`](diffhunk://#diff-e8e775c6aeb7e14d0c2bf6ffe31948c3723522f7b72504fa2f4117a0e85afc40R9): Included `upset_plot` in the module imports and the `__all__` attribute. [[1]](diffhunk://#diff-e8e775c6aeb7e14d0c2bf6ffe31948c3723522f7b72504fa2f4117a0e85afc40R9) [[2]](diffhunk://#diff-e8e775c6aeb7e14d0c2bf6ffe31948c3723522f7b72504fa2f4117a0e85afc40R21)

Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6): Updated to include the addition of the `upset_plot` function to the `plot` module.