### PR TITLE
Fix TreeExplainer instanciation when a tree in LightGBM Classifier model has n_features_in_tree = 1

### DIFF
--- a/shapiq/explainer/tree/treeshapiq.py
+++ b/shapiq/explainer/tree/treeshapiq.py
@@ -409,7 +409,7 @@ class TreeSHAPIQ:
             self.subset_ancestors_store[order] = subset_ancestors
 
             # If the tree has only one feature, we assign a default value of 0
-            if self._n_features_in_tree == 1:
+            if self.n_interpolation_size == 1:
                 self.D_store[order] = np.array([0])
             else:
                 self.D_store[order] = np.polynomial.chebyshev.chebpts2(self.n_interpolation_size)

--- a/shapiq/explainer/tree/treeshapiq.py
+++ b/shapiq/explainer/tree/treeshapiq.py
@@ -407,7 +407,13 @@ class TreeSHAPIQ:
                 interaction_order=order, n_features=self._n_features_in_tree
             )
             self.subset_ancestors_store[order] = subset_ancestors
-            self.D_store[order] = np.polynomial.chebyshev.chebpts2(self.n_interpolation_size)
+
+            # If the tree has only one feature
+            if self._n_features_in_tree == 1:
+                self.D_store[order] = np.array([0])  # Assign a default value
+            else:
+                self.D_store[order] = np.polynomial.chebyshev.chebpts2(self.n_interpolation_size)
+
             self.D_powers_store[order] = self._cache(self.D_store[order])
             if self._index in ("SV", "SII", "k-SII"):
                 self.Ns_store[order] = self._get_N(self.D_store[order])

--- a/shapiq/explainer/tree/treeshapiq.py
+++ b/shapiq/explainer/tree/treeshapiq.py
@@ -408,9 +408,9 @@ class TreeSHAPIQ:
             )
             self.subset_ancestors_store[order] = subset_ancestors
 
-            # If the tree has only one feature
+            # If the tree has only one feature, we assign a default value of 0
             if self._n_features_in_tree == 1:
-                self.D_store[order] = np.array([0])  # Assign a default value
+                self.D_store[order] = np.array([0])
             else:
                 self.D_store[order] = np.polynomial.chebyshev.chebpts2(self.n_interpolation_size)
 

--- a/tests/tests_explainer/tests_tree_explainer/test_tree_treeshapiq.py
+++ b/tests/tests_explainer/tests_tree_explainer/test_tree_treeshapiq.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from shapiq.explainer.tree import TreeModel, TreeSHAPIQ, TreeExplainer
+from shapiq.explainer.tree import TreeExplainer, TreeModel, TreeSHAPIQ
 
 
 def test_init(dt_clf_model, background_clf_data):

--- a/tests/tests_explainer/tests_tree_explainer/test_tree_treeshapiq.py
+++ b/tests/tests_explainer/tests_tree_explainer/test_tree_treeshapiq.py
@@ -133,6 +133,7 @@ def test_edge_case_params():
     with pytest.raises(ValueError):
         _ = TreeSHAPIQ(model=tree_model, max_order=0)
 
+
 def test_no_bug_with_one_feature_tree():
     # create the dataset
     X = np.array(

--- a/tests/tests_explainer/tests_tree_explainer/test_tree_treeshapiq.py
+++ b/tests/tests_explainer/tests_tree_explainer/test_tree_treeshapiq.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from shapiq.explainer.tree import TreeModel, TreeSHAPIQ
+from shapiq.explainer.tree import TreeModel, TreeSHAPIQ, TreeExplainer
 
 
 def test_init(dt_clf_model, background_clf_data):
@@ -132,3 +132,28 @@ def test_edge_case_params():
     # test with max_order = 0
     with pytest.raises(ValueError):
         _ = TreeSHAPIQ(model=tree_model, max_order=0)
+
+def test_no_bug_with_one_feature_tree():
+    # create the dataset
+    X = np.array(
+        [
+            [1, 1, 1, 1],
+            [1, 1, 1, 2],
+            [2, 1, 1, 1],
+            [3, 2, 1, 1],
+        ]
+    )
+
+    # Define simple one feature tree
+    tree = {
+        "children_left": np.array([1, -1, -1]),
+        "children_right": np.array([2, -1, -1]),
+        "features": np.array([0, -2, -2]),
+        "thresholds": np.array([2.5, -2, -2]),
+        "values": np.array([0.5, 0.0, 1]),
+        "node_sample_weight": np.array([14, 5, 9]),
+    }
+    tree = TreeModel(**tree)
+    explainer = TreeExplainer(model=tree, index="SV", max_order=1)
+    shapley_values = explainer.explain(X[2])
+    print(shapley_values)


### PR DESCRIPTION
Hello,

I am opening this PR to fix the bug mentioned [here](https://github.com/mmschlk/shapiq/issues/286) for the TreeExplainer.

Let me know id it does fix the problem correctly!