### PR TITLE
Fix Package Import without Write Access

### DIFF
--- a/shapiq/datasets/_all.py
+++ b/shapiq/datasets/_all.py
@@ -10,7 +10,11 @@ GITHUB_DATA_URL = "https://raw.githubusercontent.com/mmschlk/shapiq/main/data/"
 
 # csv files are located next to this file in a folder called "data"
 SHAPIQ_DATASETS_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
-os.makedirs(SHAPIQ_DATASETS_FOLDER, exist_ok=True)
+
+
+def _create_folder() -> None:
+    """Create the datasets folder if it does not exist."""
+    os.makedirs(SHAPIQ_DATASETS_FOLDER, exist_ok=True)
 
 
 def _try_load(csv_file_name: str) -> pd.DataFrame:
@@ -23,6 +27,7 @@ def _try_load(csv_file_name: str) -> pd.DataFrame:
     Returns:
         The dataset as a pandas DataFrame.
     """
+    _create_folder()
     try:
         return pd.read_csv(os.path.join(SHAPIQ_DATASETS_FOLDER, csv_file_name))
     except FileNotFoundError:


### PR DESCRIPTION
This PR simply wraps the creation of the data folder in a function which will be called upon loading the datasets and not at init time of the package. This means that if the package is installed in environments without write access also possible to import.