### PR TITLE
bug fix for stacked_bar plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - removes `sample_replacements` parameter from `MarginalImputer` and removes the DeprecationWarning for it
 - adds a trivial computation to `TreeSHAP-IQ` for trees that use only one feature in the tree (this works for decision stumps or trees splitting on only one feature multiple times). In such trees, the computation is trivial as the whole effect of $\nu(N) - \nu(\emptyset)$ is all on the main effect of the single feature and there is no interaction effect. This expands on the fix in v1.2.1 [#286](https://github.com/mmschlk/shapiq/issues/286).
 - fixes a bug with xgboost where feature names where trees that did not contain all features would lead `TreeExplainer` to fail
+- fixes a bug with `stacked_bar_plot` where the higher order interactions were inflated by the lower order interactions, thus wrongly showing the higher order interactions as higher than they are
 
 ### v1.2.2 (2025-03-11)
 - changes python support to 3.10-3.13 [#318](https://github.com/mmschlk/shapiq/pull/318)

--- a/shapiq/interaction_values.py
+++ b/shapiq/interaction_values.py
@@ -469,7 +469,7 @@ class InteractionValues:
             raise ValueError("Order must be greater or equal to 1.")
         values_shape = tuple([self.n_players] * order)
         values = np.zeros(values_shape, dtype=float)
-        for interaction in powerset(range(self.n_players), min_size=1, max_size=order):
+        for interaction in powerset(range(self.n_players), min_size=order, max_size=order):
             # get all orderings of the interaction (e.g. (0, 1) and (1, 0) for interaction (0, 1))
             for perm in permutations(interaction):
                 values[perm] = self[interaction]


### PR DESCRIPTION
**TLDR**: The fix comprises updating the `get_n_order_values` in `Interactionvalues` as it necessary for the stacked bar plot to work properly.


Currently the stacked_bar plot inflates the bars incorrectly and thus makes the interpretation difficult.
If given the following simple game setup
```
import matplotlib.pyplot as plt
import numpy as np

from shapiq import ExactComputer, powerset, Game
from shapiq.games.benchmark import SOUM

class SimpleGame(Game):
    def __init__(self) -> None:
        super().__init__(n_players=3, normalize=True, normalization_value=0)

    def value_function(self, coalitions: np.ndarray) -> np.ndarray:
        coalition_values = {
            (): 0,
            (0,): 0,
            (1,): 0,
            (2,): 0,
            (0, 1): 100,
            (0, 2): 100,
            (1, 2): 100,
            (0, 1, 2): 300,
        }

        values = np.array([coalition_values[tuple(np.where(x)[0])] for x in coalitions])

        return values

game = SimpleGame()


exact_computer = ExactComputer(n_players=game.n_players, game=game)

moebius = exact_computer("Moebius")
moebius.plot_stacked_bar(show=True)
```
For this game the interaction values of (0,1), (0,2) and (1,2) equal 100 and the rest is zero.
While this is correctly computed the problem lies in the visualisation:
![image](https://github.com/user-attachments/assets/9ad1a7c5-3af4-49b9-9f8d-6173bbbe3596)

With the fix it correctly becomes:
![image](https://github.com/user-attachments/assets/87c62b65-c554-48e6-915d-e3d580f9d865)
