### PR TITLE
fixes #336

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - adds a trivial computation to `TreeSHAP-IQ` for trees that use only one feature in the tree (this works for decision stumps or trees splitting on only one feature multiple times). In such trees, the computation is trivial as the whole effect of $\nu(N) - \nu(\emptyset)$ is all on the main effect of the single feature and there is no interaction effect. This expands on the fix in v1.2.1 [#286](https://github.com/mmschlk/shapiq/issues/286).
 - fixes a bug with xgboost where feature names where trees that did not contain all features would lead `TreeExplainer` to fail
 - fixes a bug with `stacked_bar_plot` where the higher order interactions were inflated by the lower order interactions, thus wrongly showing the higher order interactions as higher than they are
+- fixes a bug where `InteractionValues.get_subset()` returns a faulty `coalition_lookup` dictionary pointing to indices outside the subset of players [#336](https://github.com/mmschlk/shapiq/issues/336)
 
 ### v1.2.2 (2025-03-11)
 - changes python support to 3.10-3.13 [#318](https://github.com/mmschlk/shapiq/pull/318)

--- a/shapiq/interaction_values.py
+++ b/shapiq/interaction_values.py
@@ -545,11 +545,16 @@ class InteractionValues:
             {(1,): 0.2}
         """
         keys = self.interaction_lookup.keys()
-        idx = [i for i, key in enumerate(keys) if all(p in players for p in key)]
+        idx, keys_in_subset = [], []
+        for i, key in enumerate(keys):
+            if all(p in players for p in key):
+                idx.append(i)
+                keys_in_subset.append(key)
         new_values = self.values[idx]
-        new_interaction_lookup = {
-            key: self.interaction_lookup[key] for i, key in enumerate(keys) if i in idx
-        }
+        new_interaction_lookup = {}
+        for index, key in enumerate(keys_in_subset):
+            new_interaction_lookup[key] = index
+
         n_players = self.n_players - len(players)
 
         return InteractionValues(

--- a/tests/test_base_interaction_values.py
+++ b/tests/test_base_interaction_values.py
@@ -624,8 +624,10 @@ def test_plot():
     _ = interaction_values.plot_stacked_bar(feature_names=["a" for _ in range(n)])
 
 
-def test_subset():
-    n = 5
+@pytest.mark.parametrize("subset_players", [[0, 1], [0, 1, 3, 4]])
+def test_subset(subset_players):
+    """Test Subset function"""
+    n = 7
     min_order = 1
     max_order = 3
     values = np.random.rand(2**n - 1)
@@ -634,7 +636,7 @@ def test_subset():
     }
     interaction_values = InteractionValues(
         values=values,
-        index=None,
+        index="SII",
         max_order=max_order,
         n_players=n,
         min_order=min_order,
@@ -644,10 +646,10 @@ def test_subset():
         baseline_value=0.0,
     )
 
-    subset_players = [0, 1, 2]
+    n_players_in_subset = len(subset_players)
     subset_interaction_values = interaction_values.get_subset(subset_players)
 
-    assert subset_interaction_values.n_players == n - len(subset_players)
+    assert subset_interaction_values.n_players == n - n_players_in_subset
     assert all(
         all(p in subset_players for p in key)
         for key in subset_interaction_values.interaction_lookup.keys()
@@ -661,6 +663,12 @@ def test_subset():
     assert subset_interaction_values.estimated == interaction_values.estimated
     assert subset_interaction_values.estimation_budget == interaction_values.estimation_budget
     assert subset_interaction_values.index == interaction_values.index
+
+    # check that all values are correct
+    for interaction in powerset(subset_players, max_size=max_order, min_size=min_order):
+        old_value = interaction_values[interaction]
+        new_value = subset_interaction_values[interaction]
+        assert old_value == new_value
 
 
 @pytest.mark.parametrize("aggregation", ["sum", "mean", "median", "max", "min"])


### PR DESCRIPTION
This pull request includes a bug fixe to the `InteractionValues` class and its associated tests. The most important changes include fixing a bug in the `get_subset` method, updating test cases to use parameterized inputs, and adding checks for value correctness.

Bug fixes:

* Fixed a bug where `InteractionValues.get_subset()` returned a faulty `coalition_lookup` dictionary pointing to indices outside the subset of players (`shapiq/interaction_values.py`).

Test improvements:

* Updated `test_subset` to use `pytest.mark.parametrize` for testing multiple subsets of players (`tests/test_base_interaction_values.py`).
* Added checks in `test_subset` to ensure all values are correct after getting the subset (`tests/test_base_interaction_values.py`).

Documentation updates:

* Added a bug fix entry in `CHANGELOG.md` for the `InteractionValues.get_subset()` method (`CHANGELOG.md`).