### PR TITLE
355 disallow budgetnone in explainer andor other occurrences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### Development
+- changes `budget` to be an mandatory parameter given to the `TabularExplainer.explain()` method [#355](https://github.com/mmschlk/shapiq/pull/356).
 
 ### v1.2.3 (2025-03-24)
 - substantially improves the runtime of all `Regression` approximators by a) a faster pre-computation of the regression matrices and b) a faster computation of the weighted least squares regression [#340](https://github.com/mmschlk/shapiq/issues/340)

--- a/shapiq/explainer/tabular.py
+++ b/shapiq/explainer/tabular.py
@@ -188,14 +188,11 @@ class TabularExplainer(Explainer):
         Args:
             x: The data point to explain as a 2-dimensional array with shape
                 (1, n_features).
-            budget: The budget to use for the approximation.
+            budget: The budget to use for the approximation. It indicates how many coalitions are sampled, thus high values indicate more accurate approximations, but induce higher computational costs.
+                In particular one should be aware of the exponential growth of the number of coalitions with the number of features i.e. 2**(n_players).
+                We abstain from giving a general recommendation for the budget, as it depends on the specific use case and the desired accuracy.
             random_state: The random state to re-initialize Imputer and Approximator with. Defaults to ``None``.
         """
-        if budget > 2048:
-            warnings.warn(
-                f"Using the budget of 2**n_features={budget}, which might take long\
-                          to compute. Set the `budget` parameter to suppress this warning."
-            )
         if random_state is not None:
             self._imputer._rng = np.random.default_rng(random_state)
             self._approximator._rng = np.random.default_rng(random_state)

--- a/shapiq/explainer/tabular.py
+++ b/shapiq/explainer/tabular.py
@@ -181,24 +181,21 @@ class TabularExplainer(Explainer):
         self._approximator = self._init_approximator(approximator, self.index, self._max_order)
 
     def explain_function(
-        self, x: np.ndarray, budget: int | None = None, random_state: int | None = None
+        self, x: np.ndarray, budget: int, random_state: int | None = None
     ) -> InteractionValues:
         """Explains the model's predictions.
 
         Args:
             x: The data point to explain as a 2-dimensional array with shape
                 (1, n_features).
-            budget: The budget to use for the approximation. Defaults to `None`, which will
-                set the budget to 2**n_features based on the number of features.
+            budget: The budget to use for the approximation.
             random_state: The random state to re-initialize Imputer and Approximator with. Defaults to ``None``.
         """
-        if budget is None:
-            budget = 2**self._n_features
-            if budget > 2048:
-                warnings.warn(
-                    f"Using the budget of 2**n_features={budget}, which might take long\
-                              to compute. Set the `budget` parameter to suppress this warning."
-                )
+        if budget > 2048:
+            warnings.warn(
+                f"Using the budget of 2**n_features={budget}, which might take long\
+                          to compute. Set the `budget` parameter to suppress this warning."
+            )
         if random_state is not None:
             self._imputer._rng = np.random.default_rng(random_state)
             self._approximator._rng = np.random.default_rng(random_state)

--- a/tests/fixtures/data.py
+++ b/tests/fixtures/data.py
@@ -18,10 +18,12 @@ from sklearn.datasets import make_classification, make_regression
 # normal datasets
 NR_FEATURES = 7
 NR_FEATURES_INFORMATIVE = 7
+BUDGET_NR_FEATURES = 2 ** NR_FEATURES
 
 # small datasets
 NR_FEATURES_SMALL = 3
 NR_FEATURES_SMALL_INFORMATIVE = 2
+BUDGET_NR_FEATURES_SMALL = 2 ** NR_FEATURES_SMALL
 
 
 @pytest.fixture

--- a/tests/tests_explainer/test_explainer_models.py
+++ b/tests/tests_explainer/test_explainer_models.py
@@ -4,6 +4,7 @@ import pytest
 
 from shapiq import InteractionValues
 from shapiq.explainer import Explainer, TabularExplainer, TreeExplainer
+from tests.fixtures.data import BUDGET_NR_FEATURES
 
 
 def test_torch_reg(torch_reg_model, background_reg_data):
@@ -15,7 +16,7 @@ def test_torch_reg(torch_reg_model, background_reg_data):
     prediction = torch_reg_model(x_explain_tensor).detach().numpy()[0]
 
     explainer = Explainer(model=torch_reg_model, data=background_reg_data)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction == pytest.approx(sum_of_values, rel=0.01)
@@ -25,18 +26,19 @@ def test_torch_clf(torch_clf_model, background_clf_data):
     """Test the explainer with basic torch classification model."""
     import torch
 
+
     x_explain = background_clf_data[0]
     x_explain_tensor = torch.tensor(x_explain, dtype=torch.float32).reshape(1, -1)
     prediction = torch_clf_model(x_explain_tensor).detach().numpy()[0]
 
     explainer = Explainer(model=torch_clf_model, data=background_clf_data, class_index=2)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain,budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction[2] == pytest.approx(sum_of_values, rel=0.001)
 
     explainer = Explainer(model=torch_clf_model, data=background_clf_data, class_index=0)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain,budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction[0] == pytest.approx(sum_of_values, rel=0.001)
@@ -49,13 +51,13 @@ def test_sklearn_clf_tree(dt_clf_model, background_clf_data):
     prediction = dt_clf_model.predict_proba(x_explain.reshape(1, -1))[0]
 
     explainer = TabularExplainer(model=dt_clf_model, data=background_clf_data, class_index=2)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction[2] == pytest.approx(sum_of_values, abs=0.001)
 
     explainer = TabularExplainer(model=dt_clf_model, data=background_clf_data, class_index=0)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction[0] == pytest.approx(sum_of_values, abs=0.001)
@@ -63,7 +65,7 @@ def test_sklearn_clf_tree(dt_clf_model, background_clf_data):
     # do the same with the bare explainer (only for class_label=2)
     explainer = Explainer(model=dt_clf_model, data=background_clf_data, class_index=2)
     assert isinstance(explainer, TreeExplainer)  # check explainer to be a TreeExplainer
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction[2] == pytest.approx(sum_of_values, abs=0.001)
@@ -76,7 +78,7 @@ def test_sklearn_reg_tree(dt_reg_model, background_reg_data):
     prediction = dt_reg_model.predict(x_explain.reshape(1, -1))[0]
 
     explainer = TabularExplainer(model=dt_reg_model, data=background_reg_data)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction == pytest.approx(sum_of_values, abs=0.001)
@@ -84,7 +86,7 @@ def test_sklearn_reg_tree(dt_reg_model, background_reg_data):
     # do the same with the bare explainer
     explainer = Explainer(model=dt_reg_model, data=background_reg_data)
     assert isinstance(explainer, TreeExplainer)  # check explainer to be a TreeExplainer
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction == pytest.approx(sum_of_values, abs=0.001)
@@ -97,20 +99,20 @@ def test_sklearn_clf_forest(rf_clf_model, background_clf_data):
     prediction = rf_clf_model.predict_proba(x_explain.reshape(1, -1))[0]
 
     explainer = TabularExplainer(model=rf_clf_model, data=background_clf_data, class_index=2)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction[2] == pytest.approx(sum_of_values, rel=0.001)
 
     explainer = TabularExplainer(model=rf_clf_model, data=background_clf_data, class_index=0)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction[0] == pytest.approx(sum_of_values, rel=0.001)
 
     # do the same with the bare explainer (only for class_label=2)
     explainer = Explainer(model=rf_clf_model, data=background_clf_data, class_index=2)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction[2] == pytest.approx(sum_of_values, rel=0.001)
@@ -123,14 +125,14 @@ def test_sklearn_reg_forest(rf_reg_model, background_reg_data):
     prediction = rf_reg_model.predict(x_explain.reshape(1, -1))[0]
 
     explainer = TabularExplainer(model=rf_reg_model, data=background_reg_data)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction == pytest.approx(sum_of_values)
 
     # do the same with the bare explainer
     explainer = Explainer(model=rf_reg_model, data=background_reg_data)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction == pytest.approx(sum_of_values, rel=0.01)
@@ -143,20 +145,20 @@ def test_sklearn_clf_logistic_regression(lr_clf_model, background_clf_data):
     prediction = lr_clf_model.predict_proba(x_explain.reshape(1, -1))[0]
 
     explainer = TabularExplainer(model=lr_clf_model, data=background_clf_data, class_index=2)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction[2] == pytest.approx(sum_of_values)
 
     explainer = TabularExplainer(model=lr_clf_model, data=background_clf_data, class_index=0)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction[0] == pytest.approx(sum_of_values)
 
     # do the same with the bare explainer (only for class_label=2)
     explainer = Explainer(model=lr_clf_model, data=background_clf_data, class_index=2)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction[2] == pytest.approx(sum_of_values)
@@ -169,14 +171,14 @@ def test_sklearn_reg_linear_regression(lr_reg_model, background_reg_data):
     prediction = lr_reg_model.predict(x_explain.reshape(1, -1))[0]
 
     explainer = TabularExplainer(model=lr_reg_model, data=background_reg_data)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction == pytest.approx(sum_of_values)
 
     # do the same with the bare explainer
     explainer = Explainer(model=lr_reg_model, data=background_reg_data)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction == pytest.approx(sum_of_values)
@@ -189,7 +191,8 @@ def test_lightgbm_reg(lightgbm_reg_model, background_reg_data):
     prediction = lightgbm_reg_model.predict(x_explain.reshape(1, -1))[0]
 
     explainer = TabularExplainer(model=lightgbm_reg_model, data=background_reg_data)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
+
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction == pytest.approx(sum_of_values)
@@ -197,7 +200,8 @@ def test_lightgbm_reg(lightgbm_reg_model, background_reg_data):
     # do the same with the bare explainer
     explainer = Explainer(model=lightgbm_reg_model, data=background_reg_data)
     assert isinstance(explainer, TreeExplainer)  # check explainer to be a TreeExplainer
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
+
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction == pytest.approx(sum_of_values)
@@ -210,13 +214,15 @@ def test_lightgbm_clf(lightgbm_clf_model, background_clf_data):
     prediction = lightgbm_clf_model.predict_proba(x_explain.reshape(1, -1))[0]
 
     explainer = TabularExplainer(model=lightgbm_clf_model, data=background_clf_data, class_index=2)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
+
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction[2] == pytest.approx(sum_of_values, rel=0.001)
 
     explainer = TabularExplainer(model=lightgbm_clf_model, data=background_clf_data, class_index=0)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
+
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert prediction[0] == pytest.approx(sum_of_values, rel=0.001)
@@ -224,7 +230,8 @@ def test_lightgbm_clf(lightgbm_clf_model, background_clf_data):
     # do the same with the bare explainer (only for class_label=2)
     explainer = Explainer(model=lightgbm_clf_model, data=background_clf_data, class_index=2)
     assert isinstance(explainer, TreeExplainer)  # check explainer to be a TreeExplainer
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
+
     assert isinstance(values, InteractionValues)
     # note we do not check for efficiency here as the explanations are in log-odds space and
     # it is not straightforward to compare them with the probabilities from the model
@@ -239,7 +246,8 @@ def test_isoforest_clf(if_clf_model, if_clf_dataset):
     prediction = if_clf_model.predict(x_explain.reshape(1, -1))[0]
 
     explainer = TabularExplainer(model=if_clf_model, data=x_data, class_index=2)
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
+
     assert isinstance(values, InteractionValues)
     sum_of_values = sum(values.values)
     assert pytest.approx(sum_of_values, abs=0.001) == prediction
@@ -247,6 +255,7 @@ def test_isoforest_clf(if_clf_model, if_clf_dataset):
     # do the same with the bare explainer
     explainer = Explainer(model=if_clf_model, data=x_data, class_index=2)
     assert isinstance(explainer, TreeExplainer)  # check explainer to be a TreeExplainer
-    values = explainer.explain(x_explain)
+    values = explainer.explain(x_explain, budget=BUDGET_NR_FEATURES)
+
     assert isinstance(values, InteractionValues)
     # tree explainer explains a bit differently than the tabular explainer so we do not compare the values

--- a/tests/tests_explainer/test_explainer_tabpfn.py
+++ b/tests/tests_explainer/test_explainer_tabpfn.py
@@ -3,6 +3,7 @@
 import pytest
 
 from shapiq import Explainer, InteractionValues, TabPFNExplainer, TabularExplainer
+from tests.fixtures.data import BUDGET_NR_FEATURES_SMALL
 from tests.markers import skip_if_no_tabpfn
 
 
@@ -21,7 +22,7 @@ def test_tabpfn_explainer_clf(tabpfn_classification_problem):
     assert model.n_features_in_ == data.shape[1]
 
     explainer = TabPFNExplainer(model=model, data=data, labels=labels, x_test=x_test)
-    explanation = explainer.explain(x=x_explain)
+    explanation = explainer.explain(x=x_explain, budget=BUDGET_NR_FEATURES_SMALL)
     assert isinstance(explanation, InteractionValues)
 
     # test that bare explainer gets turned into TabPFNExplainer
@@ -49,7 +50,7 @@ def test_tabpfn_explainer_reg(tabpfn_regression_problem):
     assert model.n_features_in_ == data.shape[1]
 
     explainer = TabPFNExplainer(model=model, data=data, labels=labels, x_test=x_test)
-    explanation = explainer.explain(x=x_explain)
+    explanation = explainer.explain(x=x_explain, budget=BUDGET_NR_FEATURES_SMALL)
     assert isinstance(explanation, InteractionValues)
 
     # test that bare explainer gets turned into TabPFNExplainer

--- a/tests/tests_explainer/test_explainer_tabular.py
+++ b/tests/tests_explainer/test_explainer_tabular.py
@@ -116,7 +116,7 @@ def test_init_params_approx_params(dt_reg_model, background_reg_data, approximat
     assert iv.__class__.__name__ == "InteractionValues"
 
 
-BUDGETS = [2**3, 2**5, BUDGET_NR_FEATURES]
+BUDGETS = [2**5, 2**8, BUDGET_NR_FEATURES]
 
 
 @pytest.mark.parametrize("budget", BUDGETS)
@@ -140,8 +140,6 @@ def test_explain(dt_reg_model, background_reg_data, index, budget, max_order, im
     interaction_values = explainer.explain(x, budget=budget)
     assert interaction_values.index == index
     assert interaction_values.max_order == max_order
-    if budget is None:
-        budget = 100_000_000_000
     assert interaction_values.estimation_budget <= budget + 2
     interaction_values0 = explainer.explain(x, budget=budget, random_state=0)
     interaction_values2 = explainer.explain(x, budget=budget, random_state=0)

--- a/tests/tests_explainer/test_explainer_tabular.py
+++ b/tests/tests_explainer/test_explainer_tabular.py
@@ -5,6 +5,7 @@ import pytest
 
 from shapiq.approximator import RegressionFSII
 from shapiq.explainer import TabularExplainer
+from tests.fixtures.data import BUDGET_NR_FEATURES
 
 INDICES = ["SII", "k-SII", "STII", "FSII", "FBII"]
 MAX_ORDERS = [2, 3]
@@ -111,11 +112,11 @@ def test_init_params_approx_params(dt_reg_model, background_reg_data, approximat
     explainer = TabularExplainer(
         approximator=approximator, model=dt_reg_model, data=background_reg_data, max_order=max_order
     )
-    iv = explainer.explain(background_reg_data[0])
+    iv = explainer.explain(background_reg_data[0],budget=BUDGET_NR_FEATURES)
     assert iv.__class__.__name__ == "InteractionValues"
 
 
-BUDGETS = [2**5, 2**8, None]
+BUDGETS = [2**3, 2**5, BUDGET_NR_FEATURES]
 
 
 @pytest.mark.parametrize("budget", BUDGETS)
@@ -200,7 +201,7 @@ def test_against_shap_linear():
         approximator="auto",
         imputer="marginal",
     )
-    shapiq_values = explainer_shapiq.explain_X(X)
+    shapiq_values = explainer_shapiq.explain_X(X, budget=2 ** dim)
     shapiq_values = np.array([values.get_n_order_values(1) for values in shapiq_values])
 
     assert np.allclose(shap_values, shapiq_values, atol=1e-5)


### PR DESCRIPTION
This PR deals with issue #355, namely that the `budget` parameter was not highlighted relevant, through the decision of `budget = None`. Yet it is a crucial part of Explanations, with coalition samples.

Thus this PR changes the parameter to be necessary.

In this context tests needed to be updated to account for the API change.

While these changes do make the usage somewhat more "complicated,” they highlight the importance of coalition samples and their implications for memory and time consumption.