### PR TITLE
Relax interaction values

### DIFF
--- a/shapiq/__init__.py
+++ b/shapiq/__init__.py
@@ -2,7 +2,7 @@
 the well established Shapley value and its generalization to interaction.
 """
 
-__version__ = "1.2.3"
+__version__ = "1.2.3.9000"
 
 # approximator classes
 from .approximator import (

--- a/shapiq/game_theory/indices.py
+++ b/shapiq/game_theory/indices.py
@@ -159,7 +159,10 @@ def index_generalizes_sv(index: str) -> bool:
         >>> index_generalizes_sv("BV")
         False
     """
-    return ALL_AVAILABLE_CONCEPTS[index]["generalizes"] == "SV"
+    if index in ALL_AVAILABLE_CONCEPTS:
+        return ALL_AVAILABLE_CONCEPTS[index]["generalizes"] == "SV"
+    else:
+        return False
 
 
 def index_generalizes_bv(index: str) -> bool:
@@ -179,7 +182,10 @@ def index_generalizes_bv(index: str) -> bool:
         >>> index_generalizes_bv("BV")
         False
     """
-    return ALL_AVAILABLE_CONCEPTS[index]["generalizes"] == "BV"
+    if index in ALL_AVAILABLE_CONCEPTS:
+        return ALL_AVAILABLE_CONCEPTS[index]["generalizes"] == "BV"
+    else:
+        return False
 
 
 def get_computation_index(index: str) -> str:


### PR DESCRIPTION
It is intended to create InteractionValues objects with unknown indices. However, atm. there is an error in the code, which prohibits this. This PR only fixes the bug but does not introduce test logic for the future, which needs to be added at a later date.