### PR TITLE
Minor Bugfixed for shapiq.waterfall_plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - changes logic of `InteractionValues.get_n_order()` function to be callable with **either** the `order: int` parameter and optional assignment of `min_order: int` and `max_order: int` parameters **or** with the min/max order parameters.
 - made `InteractionValues.get_n_order()` and `InteractionValues.get_n_order_values()` function more efficient by iterating over the stored interactions and not over the powerset of all potential interactions, which made the function not usable for higher player counts (models with many features, and results obtained from `TreeExplainer`). Note, this change does not really help `get_n_order_values()` as it still needs to create a numpy array of shape `n_players` times `order`.
 - improved the testing environment by adding a new fixture module containing mock `InteractionValues` objects to be used in the tests. This allows for more efficient and cleaner tests, as well as easier debugging of the tests.
+- fixed a bug in the `shapiq.waterfall_plot` function that caused the plot to not display correctly resulting in cutoff y_ticks. Additionally, the file was renamed from `watefall.py` to `waterfall.py` to match the function name.
 
 ### v1.2.3 (2025-03-24)
 - substantially improves the runtime of all `Regression` approximators by a) a faster pre-computation of the regression matrices and b) a faster computation of the weighted least squares regression [#340](https://github.com/mmschlk/shapiq/issues/340)

--- a/shapiq/plot/__init__.py
+++ b/shapiq/plot/__init__.py
@@ -8,7 +8,7 @@ from .si_graph import si_graph_plot
 from .stacked_bar import stacked_bar_plot
 from .upset import upset_plot
 from .utils import abbreviate_feature_names
-from .watefall import waterfall_plot
+from .waterfall import waterfall_plot
 
 __all__ = [
     "network_plot",

--- a/shapiq/plot/waterfall.py
+++ b/shapiq/plot/waterfall.py
@@ -67,7 +67,7 @@ def _draw_waterfall_plot(
     yticklabels = ["" for _ in range(num_features + 1)]
 
     # size the plot based on how many features we are plotting
-    plt.gcf().set_size_inches(8, num_features * row_height + 1.5)
+    plt.gcf().set_size_inches(8, num_features * row_height + 3.5)
 
     # see how many individual (vs. grouped at the end) features we are plotting
     if num_features == len(values):
@@ -100,7 +100,7 @@ def _draw_waterfall_plot(
 
     # add a last grouped feature to represent the impact of all the features we didn't show
     if num_features < len(values):
-        yticklabels[0] = "%d other features".format()
+        yticklabels[0] = f"{int(len(values) - num_features + 1)} other features"
         remaining_impact = base_values - loc
         if remaining_impact < 0:
             pos_inds.append(0)
@@ -147,6 +147,7 @@ def _draw_waterfall_plot(
     width = bbox.width
     bbox_to_xscale = xlen / width
     hl_scaled = bbox_to_xscale * head_length
+    dpi = fig.dpi
     renderer = fig.canvas.get_renderer()
 
     # draw the positive arrows
@@ -254,6 +255,16 @@ def _draw_waterfall_plot(
         yticklabels[:-1] + [label.split("=")[-1] for label in yticklabels[:-1]],
         fontsize=13,
     )
+
+    # Check that the y-ticks are not drawn outside the plot
+    max_label_width = (
+        max([label.get_window_extent(renderer=renderer).width for label in ax.get_yticklabels()])
+        / dpi
+    )
+    if max_label_width > 0.1 * fig.get_size_inches()[0]:
+        required_width = max_label_width / 0.1
+        fig_height = fig.get_size_inches()[1]
+        fig.set_size_inches(required_width, fig_height, forward=True)
 
     # put horizontal lines for each feature row
     for i in range(num_features):

--- a/tests/tests_plots/test_waterfall.py
+++ b/tests/tests_plots/test_waterfall.py
@@ -13,7 +13,7 @@ def test_waterfall_cooking_game(cooking_game):
     exact_computer = ExactComputer(n_players=cooking_game.n_players, game=cooking_game)
     interaction_values = exact_computer(index="k-SII", order=2)
     print(interaction_values.dict_values)
-    waterfall_plot(interaction_values, show=False)
+    waterfall_plot(interaction_values, show=True)
     plt.close("all")
 
     # visual inspection:
@@ -21,6 +21,15 @@ def test_waterfall_cooking_game(cooking_game):
     # - f(x) = 15
     # - 0, 1, and 2 should individually have negative contributions (go left)
     # - all interactions should have a positive +7 contribution (go right)
+
+    waterfall_plot(interaction_values, show=True, max_display=2)
+    # visual inspection:
+    # - E[f(X)] = 10
+    # - f(x) = 15
+    # - 0x1 should have +7 contribution (go right)
+    # - remaining 5 interactions should have -2 negative contributions (go left)
+    # - Nowhere should there be any cutoffs
+    plt.close("all")
 
 
 def test_waterfall_plot(interaction_values_list: list[InteractionValues]):


### PR DESCRIPTION
### TL;DR
This pull request addresses a bug in the `waterfall_plot` function, improves functionality, and enhances testing. 
The changes include fixing visual issues in the plot, renaming the file for consistency, and adding safeguards to ensure proper rendering of y-ticks. 

### Bug Fixes and Enhancements to `waterfall_plot`:

* Fixed a bug in the `waterfall_plot` function that caused y-ticks to be cut off. Slightly adjusted y_height and added logic to dynamically resize the figure width based on the maximum y-tick label width. [[1]](diffhunk://#diff-1c2d5c4b6a4eef8775cf1b097e47dc98eeb7e91250335ff7f3557b20d5bf199dL70-R70) [[2]](diffhunk://#diff-1c2d5c4b6a4eef8775cf1b097e47dc98eeb7e91250335ff7f3557b20d5bf199dR259-R268)
* Replaced a formatting bug in y-tick labels with an f-string to correctly display the number of grouped features.

### File Renaming for Consistency:

* Renamed the file `shapiq/plot/watefall.py` to `shapiq/plot/waterfall.py` to match the function name and updated the import in `shapiq/plot/__init__.py`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8) [[2]](diffhunk://#diff-e8e775c6aeb7e14d0c2bf6ffe31948c3723522f7b72504fa2f4117a0e85afc40L11-R11)

### Testing Enhancements:

* Updated `test_waterfall_cooking_game` to include visual inspection tests for scenarios with different `max_display` values, ensuring no cutoffs in the plot. [[1]](diffhunk://#diff-17068fa43faff0f1ccf4748148886c6759e04519a9095a1743e9cb53df3fb7f9L16-R16) [[2]](diffhunk://#diff-17068fa43faff0f1ccf4748148886c6759e04519a9095a1743e9cb53df3fb7f9R25-R33)