### PR TITLE
makes addition and subtraction work also for ivs of different index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,19 @@ We have begun the process of modularizing the `shapiq` package by splitting it i
 
 This restructuring aims to improve maintainability and development scalability. The core `shapiq` package will continue to receive the majority of updates and enhancements, and keeping it streamlined ensures better focus and usability. Meanwhile, separating games and benchmarking functionality allows these components to evolve more independently while maintaining compatibility through clearly defined dependencies.
 
-### Removed Features
-- removes the ability to load `InteractionValues` from pickle files. This is now deprecated and will be removed in the next release. Use `InteractionValues.save(..., as_json=True)` to save interaction values as JSON files instead. [#413](https://github.com/mmschlk/shapiq/issues/413)
+### Maintenance and Development
+- refactored the `shapiq.Games` and `shapiq.InteractionValues` API by adding an interactions and game_values dictionary as the main data structure to store the interaction scores and game values. This allows for more efficient storage and retrieval of interaction values and game values, as well as easier manipulation of the data. [#419](https://github.com/mmschlk/shapiq/pull/419)
+- addition and subtraction of InteractionValues objects (via `shapiq.InteractionValues.__add__`) now also works for different indices, which will raise a warning and will return a new InteractionValues object with the index set of the first. [#422](https://github.com/mmschlk/shapiq/pull/422)
 
 ### Docs
-- added an example notebook for `InteractionValues`, highlighting *Initialisation*, *Modification*, *Visualization* and *Save and Loading*.
+- added an example notebook for `InteractionValues`, highlighting *Initialization*, *Modification*, *Visualization* and *Save and Loading*.
 
 ### Bugfixes
 - fixes a bug where RegressionFBII approximator was throwing an error when the index was `'BV'` or `'FBII'`.[#420](https://github.com/mmschlk/shapiq/pull/420)
+
+### Removed Features
+- removes the ability to load `InteractionValues` from pickle files. This is now deprecated and will be removed in the next release. Use `InteractionValues.save(..., as_json=True)` to save interaction values as JSON files instead. [#413](https://github.com/mmschlk/shapiq/issues/413)
+
 
 ## v1.3.1 (2025-07-11)
 

--- a/src/shapiq/interaction_values.py
+++ b/src/shapiq/interaction_values.py
@@ -487,10 +487,10 @@ class InteractionValues:
         if isinstance(other, InteractionValues):
             if self.index != other.index:  # different indices
                 msg = (
-                    f"Cannot add InteractionValues with different indices {self.index} and "
-                    f"{other.index}."
+                    f"The indices of the InteractionValues objects are different: "
+                    f"{self.index} != {other.index}. Addition might not be meaningful."
                 )
-                raise ValueError(msg)
+                warn(msg, stacklevel=2)
             if (
                 self.interaction_lookup != other.interaction_lookup
                 or self.n_players != other.n_players

--- a/tests/shapiq/tests_unit/test_interaction_values.py
+++ b/tests/shapiq/tests_unit/test_interaction_values.py
@@ -191,8 +191,10 @@ def test_add():
         interaction_lookup=interaction_lookup,
         baseline_value=0.0,
     )
-    with pytest.raises(ValueError):
-        interaction_values_first + interaction_values_second
+    with pytest.warns(match="The indices of the InteractionValues objects are different:"):
+        result = interaction_values_first + interaction_values_second
+        assert result.index == interaction_values_first.index
+        assert result.index != interaction_values_second.index
 
     # test adding InteractionValues with different interactions
     n_players_second = n + 1

--- a/uv.lock
+++ b/uv.lock
@@ -3631,7 +3631,7 @@ dev = [
     { name = "build", specifier = ">=1.2.2.post1" },
     { name = "commonmark" },
     { name = "furo" },
-    { name = "ipython", specifier = "<8.7.0" },
+    { name = "ipython", specifier = "<8.38.0" },
     { name = "ipywidgets" },
     { name = "myst-parser" },
     { name = "nbconvert" },
@@ -3654,7 +3654,7 @@ dev = [
 docs = [
     { name = "commonmark" },
     { name = "furo" },
-    { name = "ipython", specifier = "<8.7.0" },
+    { name = "ipython", specifier = "<8.38.0" },
     { name = "myst-parser" },
     { name = "nbconvert" },
     { name = "nbsphinx" },


### PR DESCRIPTION
## Motivation and Context

This PR allows adding two InteractionValues objects together wich have a different index. This previously was not possible and returned in an error. Now this will only throw a UserWarning but is technically possible. This could be helpful for experiments.

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

Existing Test has been updated to account for the correct indices in the objects and the UserWarning.

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] An entry has been added to `CHANGELOG.md` (if relevant for users).
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
