### PR TITLE
Remove zeros from interaction lookup, check in test

### DIFF
--- a/src/shapiq/game_theory/aggregation.py
+++ b/src/shapiq/game_theory/aggregation.py
@@ -72,10 +72,14 @@ def aggregate_base_attributions(
         for interaction in powerset(base_interaction, min_size=1, max_size=order):
             scaling = float(bernoulli_numbers[len(base_interaction) - len(interaction)])
             update_interaction = scaling * base_interaction_value
-            try:
-                transformed_interactions[interaction] += update_interaction
-            except KeyError:
-                transformed_interactions[interaction] = update_interaction
+            if update_interaction == 0:
+                continue
+            transformed_interactions[interaction] = (
+                transformed_interactions.get(interaction, 0) + update_interaction
+            )
+            # if the interactions sum to 0, we pop them from the dict
+            if transformed_interactions[interaction] == 0:
+                transformed_interactions.pop(interaction)
 
     # update the index name after the aggregation (e.g., SII -> k-SII)
     new_index = _change_index(index)

--- a/src/shapiq/game_theory/moebius_converter.py
+++ b/src/shapiq/game_theory/moebius_converter.py
@@ -144,11 +144,9 @@ class MoebiusConverter:
             index = "SII"
         base_interaction_dict = {}
         # Pre-compute weights
-        # distribution_weights = np.zeros((self.n + 1, order + 1))
         distribution_weights = np.zeros((self.n + 1, order + 1))
         for moebius_size in range(1, self.n + 1):
             for interaction_size in range(1, min(order, moebius_size) + 1):
-                # import ipdb; ipdb.set_trace(context=20)  # noqa: T201
                 distribution_weights[moebius_size, interaction_size] = (
                     _get_moebius_distribution_weight(moebius_size, interaction_size, order, index)
                 )

--- a/src/shapiq/game_theory/moebius_converter.py
+++ b/src/shapiq/game_theory/moebius_converter.py
@@ -157,7 +157,6 @@ class MoebiusConverter:
             strict=False,
         ):
             moebius_size = len(moebius_set)
-            # for higher-order Möbius sets (size > order) distribute the value on all interactions
             for interaction in powerset(moebius_set, min_size=0, max_size=order):
                 val_distributed = distribution_weights[moebius_size, len(interaction)]
                 # Check if Möbius value is distributed onto this interaction
@@ -167,6 +166,8 @@ class MoebiusConverter:
                 base_interaction_dict[interaction] = (
                     base_interaction_dict.get(interaction, 0) + moebius_val_calc
                 )
+                if base_interaction_dict[interaction] == 0:
+                    base_interaction_dict.pop(interaction)
 
         base_interaction_values = np.zeros(len(base_interaction_dict))
         base_interaction_lookup = {}
@@ -233,6 +234,9 @@ class MoebiusConverter:
                 if moebius_val_calc == 0:
                     continue
                 stii_dict[moebius_set] = stii_dict.get(moebius_set, 0) + moebius_val_calc
+                # if Möbius values sum up to zero, we pop it from the dict
+                if stii_dict[moebius_set] == 0:
+                    stii_dict.pop(moebius_set)
             else:
                 # higher-order Möbius sets (size > order) distribute to all top-order interactions
                 for interaction in powerset(moebius_set, min_size=order, max_size=order):
@@ -242,6 +246,8 @@ class MoebiusConverter:
                     if moebius_val_calc == 0:
                         continue
                     stii_dict[interaction] = stii_dict.get(interaction, 0) + moebius_val_calc
+                    if stii_dict[interaction] == 0:
+                        stii_dict.pop(interaction)
 
         stii_values = np.zeros(len(stii_dict))
         stii_lookup = {}
@@ -317,6 +323,9 @@ class MoebiusConverter:
                 if moebius_val_calc == 0:
                     continue
                 fii_dict[interaction] = fii_dict.get(interaction, 0) + moebius_val_calc
+                # if Möbius values sum up to zero, we pop it from the dict
+                if fii_dict[interaction] == 0:
+                    fii_dict.pop(interaction)
 
         fii_values = np.zeros(len(fii_dict))
         fii_lookup = {}

--- a/src/shapiq/game_theory/moebius_converter.py
+++ b/src/shapiq/game_theory/moebius_converter.py
@@ -144,9 +144,11 @@ class MoebiusConverter:
             index = "SII"
         base_interaction_dict = {}
         # Pre-compute weights
+        # distribution_weights = np.zeros((self.n + 1, order + 1))
         distribution_weights = np.zeros((self.n + 1, order + 1))
         for moebius_size in range(1, self.n + 1):
             for interaction_size in range(1, min(order, moebius_size) + 1):
+                # import ipdb; ipdb.set_trace(context=20)  # noqa: T201
                 distribution_weights[moebius_size, interaction_size] = (
                     _get_moebius_distribution_weight(moebius_size, interaction_size, order, index)
                 )
@@ -161,10 +163,10 @@ class MoebiusConverter:
             for interaction in powerset(moebius_set, min_size=0, max_size=order):
                 val_distributed = distribution_weights[moebius_size, len(interaction)]
                 # Check if Möbius value is distributed onto this interaction
-                if interaction in base_interaction_dict:
-                    base_interaction_dict[interaction] += moebius_val * val_distributed
-                else:
-                    base_interaction_dict[interaction] = moebius_val * val_distributed
+                moebius_val_calc = moebius_val * val_distributed
+                if moebius_val_calc == 0:
+                    continue
+                base_interaction_dict[interaction] = base_interaction_dict.get(interaction, 0) + moebius_val_calc
 
         base_interaction_values = np.zeros(len(base_interaction_dict))
         base_interaction_lookup = {}
@@ -227,19 +229,19 @@ class MoebiusConverter:
             if moebius_size < order:
                 # For STII, interaction below size order are the Möbius coefficients
                 val_distributed = distribution_weights[moebius_size, moebius_size]
-                if moebius_set in stii_dict:
-                    stii_dict[moebius_set] += moebius_val * val_distributed
-                else:
-                    stii_dict[moebius_set] = moebius_val * val_distributed
+                moebius_val_calc = moebius_val * val_distributed
+                if moebius_val_calc == 0:
+                    continue
+                stii_dict[moebius_set] = stii_dict.get(moebius_set, 0) + moebius_val_calc
             else:
                 # higher-order Möbius sets (size > order) distribute to all top-order interactions
                 for interaction in powerset(moebius_set, min_size=order, max_size=order):
                     val_distributed = distribution_weights[moebius_size, len(interaction)]
                     # Check if Möbius value is distributed onto this interaction
-                    if interaction in stii_dict:
-                        stii_dict[interaction] += moebius_val * val_distributed
-                    else:
-                        stii_dict[interaction] = moebius_val * val_distributed
+                    moebius_val_calc = moebius_val * val_distributed
+                    if moebius_val_calc == 0:
+                        continue
+                    stii_dict[interaction] = stii_dict.get(interaction, 0) + moebius_val_calc
 
         stii_values = np.zeros(len(stii_dict))
         stii_lookup = {}
@@ -311,10 +313,10 @@ class MoebiusConverter:
             for interaction in powerset(moebius_set, min_size=1, max_size=order):
                 val_distributed = distribution_weights[moebius_size, len(interaction)]
                 # Check if Möbius value is distributed onto this interaction
-                if interaction in fii_dict:
-                    fii_dict[interaction] += moebius_val * val_distributed
-                else:
-                    fii_dict[interaction] = moebius_val * val_distributed
+                moebius_val_calc = moebius_val * val_distributed
+                if moebius_val_calc == 0:
+                    continue
+                fii_dict[interaction] = fii_dict.get(interaction, 0) + moebius_val_calc
 
         fii_values = np.zeros(len(fii_dict))
         fii_lookup = {}

--- a/src/shapiq/game_theory/moebius_converter.py
+++ b/src/shapiq/game_theory/moebius_converter.py
@@ -164,7 +164,9 @@ class MoebiusConverter:
                 moebius_val_calc = moebius_val * val_distributed
                 if moebius_val_calc == 0:
                     continue
-                base_interaction_dict[interaction] = base_interaction_dict.get(interaction, 0) + moebius_val_calc
+                base_interaction_dict[interaction] = (
+                    base_interaction_dict.get(interaction, 0) + moebius_val_calc
+                )
 
         base_interaction_values = np.zeros(len(base_interaction_dict))
         base_interaction_lookup = {}

--- a/tests/shapiq/tests_unit/tests_game_theory/test_moebius_converter.py
+++ b/tests/shapiq/tests_unit/tests_game_theory/test_moebius_converter.py
@@ -27,7 +27,7 @@ def test_soum_moebius_conversion():
             # Assert efficiency
             assert (np.sum(shapley_interactions.values) - predicted_value) ** 2 < 10e-7
             assert (shapley_interactions[()] - emptyset_prediction) ** 2 < 10e-7
-            for _k, v in moebius_converter._computed.items():
+            for v in moebius_converter._computed.values():
                 # check that no 0's are in the interaction lookup (except for the empty set, which is the first entry)
                 interaction_lookup = v.interaction_lookup
                 assert all(v != 0 for idx, v in enumerate(interaction_lookup.values()) if idx > 0)

--- a/tests/shapiq/tests_unit/tests_game_theory/test_moebius_converter.py
+++ b/tests/shapiq/tests_unit/tests_game_theory/test_moebius_converter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from shapiq.game_theory.moebius_converter import MoebiusConverter
 from shapiq_games.synthetic.soum import SOUM
@@ -29,9 +30,36 @@ def test_soum_moebius_conversion():
             assert (shapley_interactions[()] - emptyset_prediction) ** 2 < 10e-7
             for v in moebius_converter._computed.values():
                 # check that no 0's are in the interaction lookup (except for the empty set, which is the first entry)
-                interaction_lookup = v.interaction_lookup
-                assert all(v != 0 for idx, v in enumerate(interaction_lookup.values()) if idx > 0)
+                interactions = v.interactions
+                assert all(v != 0 for idx, v in enumerate(interactions.values()) if idx > 0)
 
         # test direct call of Möbius converter
         for index in ["STII", "k-SII", "SII", "FSII"]:
             moebius_converter(index=index, order=order)
+
+
+@pytest.mark.parametrize("random_state", [10, 19, 20, 21, 23])
+def test_soum_moebius_conversion_failing_states(random_state):
+    """Test SOUM moebius conversion with specific failing random states."""
+    order = 3
+    n_basis_games = 1
+    n = 7
+
+    soum = SOUM(n, n_basis_games=n_basis_games, random_state=random_state)
+    predicted_value = soum(np.ones(n))[0]
+    emptyset_prediction = soum(np.zeros(n))[0]
+
+    moebius_converter = MoebiusConverter(soum.moebius_coefficients)
+
+    for index in ["STII", "k-SII", "FSII"]:
+        shapley_interactions = moebius_converter(index=index, order=order)
+        # Assert efficiency
+        assert (np.sum(shapley_interactions.values) - predicted_value) ** 2 < 10e-7
+        assert (shapley_interactions[()] - emptyset_prediction) ** 2 < 10e-7
+        for v in moebius_converter._computed.values():
+            interactions = v.interactions
+            # Check that no 0's are in the interaction values (except for empty set)
+            non_empty_values = [val for idx, val in enumerate(interactions.values()) if idx > 0]
+            assert all(val != 0 for val in non_empty_values), (
+                f"Found zero values in non-empty interactions with random state {random_state}"
+            )

--- a/tests/shapiq/tests_unit/tests_game_theory/test_moebius_converter.py
+++ b/tests/shapiq/tests_unit/tests_game_theory/test_moebius_converter.py
@@ -22,12 +22,15 @@ def test_soum_moebius_conversion():
 
         moebius_converter = MoebiusConverter(soum.moebius_coefficients)
 
-        shapley_interactions = {}
         for index in ["STII", "k-SII", "FSII"]:
-            shapley_interactions[index] = moebius_converter(index=index, order=order)
+            shapley_interactions = moebius_converter(index=index, order=order)
             # Assert efficiency
-            assert (np.sum(shapley_interactions[index].values) - predicted_value) ** 2 < 10e-7
-            assert (shapley_interactions[index][()] - emptyset_prediction) ** 2 < 10e-7
+            assert (np.sum(shapley_interactions.values) - predicted_value) ** 2 < 10e-7
+            assert (shapley_interactions[()] - emptyset_prediction) ** 2 < 10e-7
+            for _k, v in moebius_converter._computed.items():
+                # check that no 0's are in the interaction lookup (except for the empty set, which is the first entry)
+                interaction_lookup = v.interaction_lookup
+                assert all(v != 0 for idx, v in enumerate(interaction_lookup.values()) if idx > 0)
 
         # test direct call of Möbius converter
         for index in ["STII", "k-SII", "SII", "FSII"]:


### PR DESCRIPTION
## Motivation and Context
---
closes #369.
Prevented zeros from being written to the `interaction_lookup`.
I added this to the test, but it seems like only the change in [here](https://github.com/mmschlk/shapiq/compare/main...CloseChoice:shapiq:369-remove-0s-from-interaction-lookup?expand=1#diff-fb4550248bea0697dcb027a2fec245f5fdf2b3eb42edc89b34f64b30c0e34841R166-R169) runs through the tests. If more thorough tests are desired, let me know.

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
see the changes in the tests.
---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] An entry has been added to `CHANGELOG.md` (if relevant for users).
-   [x] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.

---
