### PR TITLE
faster coalition sampler

### DIFF
--- a/sampling_test.py
+++ b/sampling_test.py
@@ -1,11 +1,24 @@
 from shapiq.approximator.sampling import CoalitionSampler, CoalitionSamplerFast
 import numpy as np
+import time
 
-n = 100
+n = 10
+budget = 1000
 sampling_weights = np.ones(n+1)
-sampler = CoalitionSamplerFast(n, pairing_trick=False, sampling_weights=sampling_weights)
 
-sampler.sample(1000)
-print(sampler.coalitions_matrix)
-print(sampler.sampled_coalitions_dict)
-print(sampler.adjusted_sampling_weights)
+# Speed of CoalitionSampler vs CoalitionSamplerFast
+
+start = time.time()
+sampler = CoalitionSamplerFast(n, pairing_trick=False, sampling_weights=sampling_weights)
+sampler.sample(budget)
+end_new = time.time()
+print(f"CoalitionSamplerFast time: {end_new - start:.4f} seconds")
+#print(sampler.sampling_adjustment_weights)
+
+start = time.time()
+sampler = CoalitionSampler(n, pairing_trick=False, replacement=False, sampling_weights=sampling_weights)
+sampler.sample(budget)
+end_old = time.time()
+print(f"CoalitionSampler time: {end_old - start:.4f} seconds")
+#print(sampler.sampling_adjustment_weights)
+


### PR DESCRIPTION
## Faster Coalition Sampler

Update sampler so draws are without replacement.

Consider an unnormalized distribution w over sample sizes.

We will sample coalitions of each size with probabilities $\min(C * w_\text{size} / \binom{n}{\text{size}}, 1)$.

We first find a value $C$ so that

$$
E[C] = \sum_\text{size} \min(C * w_\text{size}, \binom{n}{\text{size}}) = budget.
$$

We then draw $\min(C * w_\text{size}, \binom{n}{\text{size}})$ samples from each size. If this isn't an integer, we round the number of draws from each size to preserve the total budget up to the closest even integer.

We then take that many samples of each size without replacement. We do this efficiently by sampling the INDEX of each coalition of a given size, and building the associated coalition on the fly via a function that maps INDEX to coalitions in $O(n^2)$ time.

Note: We need special handling for odd n with the pairing trick, see code.

Without explicit cases, the above approach handles:
* always sampling the empty and full coalitions
* the so called "border trick" because if we have enough samples to get every coalition of a given size, the probability for that coalition is 1 and we enumerate them all
* sampling without replacement efficiently because there's no rejection sampling