### PR TITLE
Include deletion of auto examples dir in agents file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,16 @@
 
 This role of this file is to describe common mistakes and confusion points that agents might encounter as they work in this project. If you ever encounter something in the project that surprises you, please alert the developer working with you and indicate that this is the case in the Agent.md file to help prevent future agents from having the same issue.
 
-
 ## Commands to interact with the codebase which you should run:
 
 ### Build Docs (only use this command verbatim from the project root)
+
 ```bash
-rm -rf docs/source/generated && uv run sphinx-build -b html docs/source docs/build/html
+rm -rf docs/source/generated docs/source/auto_examples && uv run sphinx-build -b html docs/source docs/build/html
 ```
 
 ### Run Pre-commit (takes only 3s)
+
 ```bash
 uv run pre-commit run --all-files
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,13 @@ This role of this file is to describe common mistakes and confusion points that 
 ## Commands to interact with the codebase which you should run:
 
 ### Build Docs (only use this command verbatim from the project root)
+
 ```bash
-rm -rf docs/source/generated && uv run sphinx-build -b html docs/source docs/build/html
+rm -rf docs/source/generated docs/source/auto_examples && uv run sphinx-build -b html docs/source docs/build/html
 ```
 
 ### Run Pre-commit (takes only 3s)
+
 ```bash
 uv run pre-commit run --all-files
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,1 @@
-# AGENTS.md
-
-This role of this file is to describe common mistakes and confusion points that agents might encounter as they work in this project. If you ever encounter something in the project that surprises you, please alert the developer working with you and indicate that this is the case in the Agent.md file to help prevent future agents from having the same issue.
-
-## Commands to interact with the codebase which you should run:
-
-### Build Docs (only use this command verbatim from the project root)
-
-```bash
-rm -rf docs/source/generated docs/source/auto_examples && uv run sphinx-build -b html docs/source docs/build/html
-```
-
-### Run Pre-commit (takes only 3s)
-
-```bash
-uv run pre-commit run --all-files
-```
+AGENTS.md


### PR DESCRIPTION
## Motivation and Context

The directory `docs/source/auto_examples` is generated by sphinx-gallery and should be deleted before re-running `sphinx-build` to prevent errors caused by stale files.

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)
