### PR TITLE
Wu/test benchmark infrastructure

### DIFF
--- a/src/shapiq/approximator/__init__.py
+++ b/src/shapiq/approximator/__init__.py
@@ -16,6 +16,9 @@ from .regression import (
     InconsistentKernelSHAPIQ,
     KernelSHAP,
     KernelSHAPIQ,
+    LeverageSHAP,
+    OddSHAP,
+    PolySHAP,
     RegressionFBII,
     RegressionFSII,
     kADDSHAP,
@@ -35,6 +38,9 @@ SV_APPROXIMATORS: list[Approximator.__class__] = [
     ProxySPEX,
     ProxySHAP,
     MSRBiased,
+    LeverageSHAP,
+    PolySHAP,
+    OddSHAP,
 ]
 
 # contains all SI approximators
@@ -119,6 +125,9 @@ __all__ = [
     "kADDSHAP",
     "SPEX",
     "UnbiasedKernelSHAP",
+    "LeverageSHAP",
+    "PolySHAP",
+    "OddSHAP",
     "SV_APPROXIMATORS",
     "SI_APPROXIMATORS",
     "SII_APPROXIMATORS",

--- a/src/shapiq/approximator/regression/__init__.py
+++ b/src/shapiq/approximator/regression/__init__.py
@@ -5,6 +5,9 @@ from .faithful import RegressionFBII, RegressionFSII
 from .kadd_shap import kADDSHAP
 from .kernelshap import KernelSHAP
 from .kernelshapiq import InconsistentKernelSHAPIQ, KernelSHAPIQ
+from .leverageshap import LeverageSHAP
+from .oddshap import OddSHAP
+from .polyshap import PolySHAP
 
 __all__ = [
     "kADDSHAP",
@@ -14,4 +17,7 @@ __all__ = [
     "InconsistentKernelSHAPIQ",
     "Regression",
     "RegressionFBII",
+    "LeverageSHAP",
+    "PolySHAP",
+    "OddSHAP",
 ]

--- a/src/shapiq/approximator/regression/leverageshap.py
+++ b/src/shapiq/approximator/regression/leverageshap.py
@@ -1,0 +1,87 @@
+"""LeverageSHAP — Shapley value approximation via leverage-score sampling.
+
+Reference: Musco & Witter (2024), arXiv:2410.01917.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+
+from shapiq.approximator.base import Approximator
+from shapiq.interaction_values import InteractionValues
+
+
+class LeverageSHAP(Approximator):
+    """LeverageSHAP — Shapley value estimator with leverage-score sampling.
+
+    Stub implementation: returns zero Shapley values for all players. Replace
+    Step 2 in :meth:`approximate` with the leverage-score regression algorithm.
+
+    Args:
+        n: The number of players.
+        pairing_trick: If True, pair each sampled coalition with its complement
+            (paired sampling, Algorithm 1 in the paper). Defaults to True.
+        sampling_weights: Optional ``(n + 1,)`` array of coalition-size weights.
+            If None, uniform leverage-score weights are used. Defaults to None.
+        random_state: Seed for deterministic sampling. Defaults to None.
+
+    """
+
+    valid_indices: tuple[str, ...] = ("SV",)
+
+    def __init__(
+        self,
+        n: int,
+        *,
+        pairing_trick: bool = True,
+        sampling_weights: np.ndarray | None = None,
+        random_state: int | None = None,
+    ) -> None:
+        super().__init__(
+            n=n,
+            max_order=1,
+            index="SV",
+            top_order=False,
+            min_order=0,
+            pairing_trick=pairing_trick,
+            sampling_weights=sampling_weights,
+            random_state=random_state,
+        )
+        self.runtime_last_approximate_run: dict[str, float] = {}
+
+    def approximate(
+        self,
+        budget: int,
+        game: Callable[[np.ndarray], np.ndarray],
+    ) -> InteractionValues:
+        """Approximate Shapley values via leverage-score sampling.
+
+        TODO: replace the STUB block below with the real implementation.
+        """
+        # Step 1: empty-coalition baseline.
+        empty_coalition = np.zeros((1, self.n), dtype=bool)
+        baseline_value = float(game(empty_coalition)[0])
+
+        # Step 2: STUB — replace before final submission.
+        sv_values = np.zeros(self.n + 1, dtype=float)
+        sv_values[0] = baseline_value
+
+        # Step 3: canonical SV interaction_lookup.
+        sv_lookup: dict[tuple[int, ...], int] = {(): 0}
+        for i in range(self.n):
+            sv_lookup[(i,)] = i + 1
+
+        # Step 4: wrap and return.
+        return InteractionValues(
+            values=sv_values,
+            index="SV",
+            interaction_lookup=sv_lookup,
+            baseline_value=baseline_value,
+            min_order=0,
+            max_order=1,
+            n_players=self.n,
+            estimated=(budget < 2 ** self.n),
+            estimation_budget=int(budget),
+        )

--- a/src/shapiq/approximator/regression/oddshap.py
+++ b/src/shapiq/approximator/regression/oddshap.py
@@ -1,0 +1,89 @@
+"""OddSHAP — Shapley value approximation via odd-component Fourier regression.
+
+Reference: Fumagalli et al. (2026), "An Odd Estimator for Shapley Values",
+arXiv:2602.01399.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+
+from shapiq.approximator.base import Approximator
+from shapiq.interaction_values import InteractionValues
+
+
+class OddSHAP(Approximator):
+    """OddSHAP — Shapley value estimator via odd-component Fourier regression.
+
+    Stub implementation: returns zero Shapley values for all players. Replace
+    Step 2 in :meth:`approximate` with the paired-sampling + odd-projection +
+    constrained-LSQ algorithm.
+
+    Args:
+        n: The number of players.
+        pairing_trick: If True, paired sampling is applied (required by the
+            paper's orthogonalization argument, Theorem 3.2). Defaults to True.
+        sampling_weights: Optional ``(n + 1,)`` array of coalition-size weights.
+            If None, KernelSHAP weights are used. Defaults to None.
+        random_state: Seed for deterministic sampling. Defaults to None.
+
+    """
+
+    valid_indices: tuple[str, ...] = ("SV",)
+
+    def __init__(
+        self,
+        n: int,
+        *,
+        pairing_trick: bool = True,
+        sampling_weights: np.ndarray | None = None,
+        random_state: int | None = None,
+    ) -> None:
+        super().__init__(
+            n=n,
+            max_order=1,
+            index="SV",
+            top_order=False,
+            min_order=0,
+            pairing_trick=pairing_trick,
+            sampling_weights=sampling_weights,
+            random_state=random_state,
+        )
+        self.runtime_last_approximate_run: dict[str, float] = {}
+
+    def approximate(
+        self,
+        budget: int,
+        game: Callable[[np.ndarray], np.ndarray],
+    ) -> InteractionValues:
+        """Approximate Shapley values via odd-component Fourier regression.
+
+        TODO: replace the STUB block below with the real implementation.
+        """
+        # Step 1: empty-coalition baseline.
+        empty_coalition = np.zeros((1, self.n), dtype=bool)
+        baseline_value = float(game(empty_coalition)[0])
+
+        # Step 2: STUB — replace before final submission.
+        sv_values = np.zeros(self.n + 1, dtype=float)
+        sv_values[0] = baseline_value
+
+        # Step 3: canonical SV interaction_lookup.
+        sv_lookup: dict[tuple[int, ...], int] = {(): 0}
+        for i in range(self.n):
+            sv_lookup[(i,)] = i + 1
+
+        # Step 4: wrap and return.
+        return InteractionValues(
+            values=sv_values,
+            index="SV",
+            interaction_lookup=sv_lookup,
+            baseline_value=baseline_value,
+            min_order=0,
+            max_order=1,
+            n_players=self.n,
+            estimated=(budget < 2 ** self.n),
+            estimation_budget=int(budget),
+        )

--- a/src/shapiq/approximator/regression/polyshap.py
+++ b/src/shapiq/approximator/regression/polyshap.py
@@ -1,0 +1,88 @@
+"""PolySHAP — Shapley value approximation via polynomial regression.
+
+Reference: Fumagalli et al. (2026), arXiv:2601.18608.
+Repository: https://github.com/FFmgll/PolySHAP.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+
+from shapiq.approximator.base import Approximator
+from shapiq.interaction_values import InteractionValues
+
+
+class PolySHAP(Approximator):
+    """PolySHAP — Shapley value estimator via polynomial regression.
+
+    Stub implementation: returns zero Shapley values for all players. Replace
+    Step 2 in :meth:`approximate` with the interaction-informed polynomial
+    regression algorithm.
+
+    Args:
+        n: The number of players.
+        pairing_trick: If True, paired sampling is applied. Defaults to False.
+        sampling_weights: Optional ``(n + 1,)`` array of coalition-size weights.
+            If None, KernelSHAP weights are used. Defaults to None.
+        random_state: Seed for deterministic sampling. Defaults to None.
+
+    """
+
+    valid_indices: tuple[str, ...] = ("SV",)
+
+    def __init__(
+        self,
+        n: int,
+        *,
+        pairing_trick: bool = False,
+        sampling_weights: np.ndarray | None = None,
+        random_state: int | None = None,
+    ) -> None:
+        super().__init__(
+            n=n,
+            max_order=1,
+            index="SV",
+            top_order=False,
+            min_order=0,
+            pairing_trick=pairing_trick,
+            sampling_weights=sampling_weights,
+            random_state=random_state,
+        )
+        self.runtime_last_approximate_run: dict[str, float] = {}
+
+    def approximate(
+        self,
+        budget: int,
+        game: Callable[[np.ndarray], np.ndarray],
+    ) -> InteractionValues:
+        """Approximate Shapley values via polynomial regression.
+
+        TODO: replace the STUB block below with the real implementation.
+        """
+        # Step 1: empty-coalition baseline.
+        empty_coalition = np.zeros((1, self.n), dtype=bool)
+        baseline_value = float(game(empty_coalition)[0])
+
+        # Step 2: STUB — replace before final submission.
+        sv_values = np.zeros(self.n + 1, dtype=float)
+        sv_values[0] = baseline_value
+
+        # Step 3: canonical SV interaction_lookup.
+        sv_lookup: dict[tuple[int, ...], int] = {(): 0}
+        for i in range(self.n):
+            sv_lookup[(i,)] = i + 1
+
+        # Step 4: wrap and return.
+        return InteractionValues(
+            values=sv_values,
+            index="SV",
+            interaction_lookup=sv_lookup,
+            baseline_value=baseline_value,
+            min_order=0,
+            max_order=1,
+            n_players=self.n,
+            estimated=(budget < 2 ** self.n),
+            estimation_budget=int(budget),
+        )

--- a/tests/shapiq/tests_unit/tests_approximators/test_approximators_vs_exact.py
+++ b/tests/shapiq/tests_unit/tests_approximators/test_approximators_vs_exact.py
@@ -1,0 +1,127 @@
+"""Cross-approximator conformance + numerical convergence tests.
+
+Parametrized test runs LeverageSHAP, PolySHAP, and OddSHAP against
+``ExactComputer`` ground truth on small SOUM games. Two layers:
+
+1. Interface conformance: verifies ``index``, ``n_players``, ``max_order``,
+   ``min_order``, and ``values`` shape on the returned ``InteractionValues``.
+
+2. Numerical convergence vs ``ExactComputer``: marked ``xfail`` until each
+   approximator's algorithm is implemented.
+
+Run only one approximator's tests::
+
+    pytest tests/shapiq/tests_unit/tests_approximators/test_approximators_vs_exact.py \\
+        -k LeverageSHAP -v
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shapiq import ExactComputer
+from shapiq.approximator import LeverageSHAP, OddSHAP, PolySHAP
+from shapiq_games.synthetic import SOUM
+
+# All approximators under test.
+APPROXIMATORS_UNDER_TEST = [LeverageSHAP, PolySHAP, OddSHAP]
+
+
+@pytest.fixture
+def seeded_soum_game(request):
+    """Provide a deterministic SOUM benchmark game for a given (n, seed)."""
+    n, seed = request.param
+    return SOUM(n=n, n_basis_games=20, max_interaction_size=3, random_state=seed)
+
+
+# -----------------------------------------------------------------------------
+# Conformance assertions (always required)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("Approx", APPROXIMATORS_UNDER_TEST)
+@pytest.mark.parametrize(
+    "seeded_soum_game",
+    [(4, 0), (6, 42), (8, 1337), (10, 7)],
+    indirect=True,
+)
+@pytest.mark.parametrize("budget_pct", [0.05, 0.25, 1.0])
+def test_interface_conformance(Approx, seeded_soum_game, budget_pct):
+    """Interface contract — must hold for any conforming approximator."""
+    n = seeded_soum_game.n_players
+    estimator = Approx(n=n, random_state=0)
+    iv = estimator.approximate(int(budget_pct * 2 ** n), seeded_soum_game)
+
+    # Returned object satisfies the interface contract:
+    assert iv.index == "SV"
+    assert iv.n_players == n
+    assert iv.max_order == 1
+    assert iv.min_order == 0
+    assert iv.values.shape == (n + 1,)
+    assert iv.values.dtype == float
+
+    # Standard SV interaction_lookup:
+    assert iv.interaction_lookup[()] == 0
+    for i in range(n):
+        assert iv.interaction_lookup[(i,)] == i + 1
+
+
+# -----------------------------------------------------------------------------
+# Numerical convergence vs ExactComputer
+#
+# Currently all 3 approximators are stubs returning zeros — so this test
+# is expected to fail. It will start passing as each pair lands their real
+# implementation.
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    reason="Approximators are currently stubs returning zero SVs. "
+    "Convergence will hold once the algorithm is implemented; "
+    "remove this xfail marker per-approximator as implementations land.",
+    strict=False,
+)
+@pytest.mark.parametrize("Approx", APPROXIMATORS_UNDER_TEST)
+@pytest.mark.parametrize(
+    "seeded_soum_game",
+    [(4, 0), (6, 42), (8, 1337), (10, 7)],
+    indirect=True,
+)
+@pytest.mark.parametrize("budget_pct", [0.05, 0.25, 1.0])
+def test_numerical_convergence_vs_exact(Approx, seeded_soum_game, budget_pct):
+    """Numerical accuracy vs ExactComputer ground truth.
+
+    Tolerance schedule:
+        budget_pct < 0.25   atol = 0.5
+        budget_pct < 1.0    atol = 0.1
+        budget_pct == 1.0   atol = 1e-2  (sub-budget regime)
+    """
+    n = seeded_soum_game.n_players
+    estimator = Approx(n=n, random_state=0)
+    iv = estimator.approximate(int(budget_pct * 2 ** n), seeded_soum_game)
+
+    exact = ExactComputer(seeded_soum_game, n_players=n)(index="SV")
+
+    if budget_pct < 0.25:
+        atol = 0.5
+    elif budget_pct < 1.0:
+        atol = 0.1
+    else:
+        atol = 1e-2
+
+    np.testing.assert_allclose(iv.values, exact.values, atol=atol)
+
+
+# -----------------------------------------------------------------------------
+# Determinism (same seed → bit-identical output)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("Approx", APPROXIMATORS_UNDER_TEST)
+def test_determinism(Approx):
+    """Identical (n, random_state, budget, game) → identical output."""
+    game = SOUM(n=8, n_basis_games=20, max_interaction_size=3, random_state=42)
+    a = Approx(n=8, random_state=42).approximate(256, game)
+    b = Approx(n=8, random_state=42).approximate(256, game)
+    np.testing.assert_array_equal(a.values, b.values)


### PR DESCRIPTION
 ## Summary

  Foundation for the three new SV-only approximators:
  - `LeverageSHAP` (arXiv:2410.01917)
  - `PolySHAP` (arXiv:2601.18608)
  - `OddSHAP` (arXiv:2602.01399)

  Each is a working stub returning zero Shapley values via a fully-populated
  `InteractionValues`. Each pair replaces the marked `Step 2` block in
  `approximate()` with their real algorithm.

  ## What's in

  **Stubs** — `src/shapiq/approximator/regression/{leverageshap,polyshap,oddshap}.py`

  Each follows identical structure: `__init__(n, *, pairing_trick, sampling_weights,
  random_state)` calling `super().__init__(max_order=1, index="SV", ...)` plus
  `approximate(budget, game)` returning a properly-shaped `InteractionValues` with
  placeholder zeros.

  **Registration** — `src/shapiq/approximator/__init__.py`

  Imports the 3 new classes + adds to `SV_APPROXIMATORS` list (auto-pulls them
  into `shapiq.benchmark`).

  **Conformance test** — `tests/shapiq/tests_unit/tests_approximators/test_approximators_vs_exact.py`

  Parametrized over the 3 approximators × `n ∈ {4,6,8,10}` × `budget ∈ {5%, 25%, 100%}`
  × 4 seeds:
  - Interface conformance (always required): `index`, `n_players`, `max_order`,
    `values` shape, `interaction_lookup` structure
  - Numerical convergence vs `ExactComputer` (`xfail` until algorithms land)
  - Determinism: same seed → bit-identical output

  Current: **39 passed, 36 xfailed**. Xfails flip to PASS as each pair lands
  their algorithm.

  ## What's NOT in

  - Real algorithm implementations (each pair fills in their stub)
  - ProxySPEX adapter shim for OddSHAP (follow-up PR)
  - Per-approximator unit tests (each pair owns their own `test_approximator_<name>.py`)
  - Unified benchmark CLI + paper-reproduction scripts (follow-up PRs)

  ## How to use this

  Each pair:
  1. Branch off this branch (or off upstream main and rebase later — your call)
  2. Open your stub at `src/shapiq/approximator/regression/<your_method>.py`
  3. Replace the `# Step 2: STUB —` block with your algorithm
  4. Run only your conformance tests:
     pytest tests/shapiq/tests_unit/tests_approximators/test_approximators_vs_exact.py
         -k YourClass -v
  5. Once numerical convergence passes, remove the `xfail` marker for your class

  ## Verification

  $ pytest tests/shapiq/tests_unit/tests_approximators/test_approximators_vs_exact.py