### PR TITLE
Make SV default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- **`Explainer` default changed to Shapley values.** `Explainer`,
+  `TabularExplainer`, `TabPFNExplainer`, `AgnosticExplainer`, and `TreeExplainer`
+  now default to `index="SV"`, `max_order=1`. Previously they defaulted to
+  `index="k-SII"`, `max_order=2`. Users relying on the previous default must
+  pass these arguments explicitly. NN explainers and `ProductKernelExplainer`
+  are unaffected — they already defaulted to `"SV"`. Approximators and
+  computers also retain their existing defaults.
+
 ## v1.5.0 (2026-05-22)
 
 ### Highlights of new Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,6 @@
 # Changelog
 
-## Unreleased
-
-### Breaking changes
-
-- **`Explainer` default changed to Shapley values.** `Explainer`,
-  `TabularExplainer`, `TabPFNExplainer`, `AgnosticExplainer`, and `TreeExplainer`
-  now default to `index="SV"`, `max_order=1`. Previously they defaulted to
-  `index="k-SII"`, `max_order=2`. Users relying on the previous default must
-  pass these arguments explicitly. NN explainers and `ProductKernelExplainer`
-  are unaffected — they already defaulted to `"SV"`. Approximators and
-  computers also retain their existing defaults.
-
-## v1.5.0 (2026-05-22)
+## v1.5.0 (2026-05-26)
 
 ### Highlights of new Features
 
@@ -22,6 +10,7 @@
 - adds `LinearTreeSHAP` in `shapiq.tree.linear` for fast first-order Shapley value computation
 - adds `InterventionalTreeExplainer` in `shapiq.tree.interventional`
 - adds `KNNExplainer`, `WeightedKNNExplainer` and `ThresholdNNExplainer` for nearest neighbor models
+- changes the default for all user-facing `Explainer` classes to `index="SV"`, `max_order=1` (Shapley values) — see Breaking Changes below
 
 
 ### Introducing ProxySHAP [#501](https://github.com/mmschlk/shapiq/pull/501), [Preprint](https://arxiv.org/abs/2605.22738)
@@ -45,6 +34,16 @@ One application of these explainers is Data Valuation, i.e. the task of evaluati
 
 - removes `path_to_values` parameter from `shapiq.Game`, which was previously deprecated. Use `shapiq.Game.load()` instead. [#496](https://github.com/mmschlk/shapiq/pull/496)
 - removes pickle support from `shapiq.InteractionValues`. JSON is now the only supported file format. Use `InteractionValues.save()` and `InteractionValues.load()` with JSON files. [#496](https://github.com/mmschlk/shapiq/pull/496)
+
+### Breaking Changes
+
+- **`Explainer` default changed to Shapley values.** `Explainer`,
+  `TabularExplainer`, `TabPFNExplainer`, `AgnosticExplainer`, and `TreeExplainer`
+  now default to `index="SV"`, `max_order=1`. Previously they defaulted to
+  `index="k-SII"`, `max_order=2`. Users relying on the previous default must
+  pass these arguments explicitly. NN explainers and `ProductKernelExplainer`
+  are unaffected — they already defaulted to `"SV"`. Approximators and
+  computers also retain their existing defaults.
 
 ### Extending shapiq-games [#476](https://github.com/mmschlk/shapiq/issues/476)
 - adds standard SHAP datasets for benchmarking in `shapiq_games.benchmark.local_xai`.

--- a/examples/basics/plot_parallel_computation.py
+++ b/examples/basics/plot_parallel_computation.py
@@ -36,7 +36,13 @@ X_test = rng.standard_normal((6, n_features))
 # Explain a Single Instance
 # --------------------------
 
-explainer = shapiq.Explainer(model=synthetic_model, data=X_background, random_state=0)
+explainer = shapiq.Explainer(
+    model=synthetic_model,
+    data=X_background,
+    index="k-SII",
+    max_order=2,
+    random_state=0,
+)
 print(f"Explainer type: {type(explainer).__name__}")
 
 iv = explainer.explain(X_test[0], budget=256)

--- a/src/shapiq/explainer/agnostic.py
+++ b/src/shapiq/explainer/agnostic.py
@@ -40,8 +40,8 @@ class AgnosticExplainer(Explainer):
         game: Game | Callable[[np.ndarray], np.ndarray],
         *,
         n_players: int | None = None,
-        index: AgnosticExplainerIndices = "k-SII",
-        max_order: int = 2,
+        index: AgnosticExplainerIndices = "SV",
+        max_order: int = 1,
         approximator: (
             Approximator[AgnosticExplainerIndices] | Literal["auto"] | TabularExplainerApproximators
         ) = "auto",
@@ -58,9 +58,10 @@ class AgnosticExplainer(Explainer):
                 the :class:`shapiq.games.base.Game`.
 
             index: The type of game-theoretic index to be used for the explanation.
-                Defaults to "k-SII".
+                Defaults to ``"SV"``.
 
-            max_order: The maximum order of interactions to be computed. Defaults to 2.
+            max_order: The maximum order of interactions to be computed. Set to ``1`` for no
+                interactions (i.e, for Shapley values ``"SV"`` or Banzhaf values ``"BV"``).
 
             approximator: The approximator to use for the game-based approach. Defaults to "auto",
                 which will automatically select the appropriate approximator based on the index and

--- a/src/shapiq/explainer/base.py
+++ b/src/shapiq/explainer/base.py
@@ -36,8 +36,8 @@ def generic_to_specific_explainer(
     model: Model | Game | Callable[[np.ndarray], np.ndarray],
     data: np.ndarray | None = None,
     class_index: int | None = None,
-    index: ExplainerIndices = "k-SII",
-    max_order: int = 2,
+    index: ExplainerIndices = "SV",
+    max_order: int = 1,
     **kwargs: Any,
 ) -> None:
     """Transform the base Explainer instance into a specific explainer subclass.
@@ -51,8 +51,8 @@ def generic_to_specific_explainer(
         model: The model object to be explained.
         data: A background dataset to be used for imputation.
         class_index: The class index of the model to explain.
-        index: The type of Shapley interaction index to use.
-        max_order: The maximum interaction order to be computed.
+        index: The type of Shapley interaction index to use. Defaults to ``"SV"``.
+        max_order: The maximum interaction order to be computed. Defaults to ``1``.
         **kwargs: Additional keyword-only arguments passed to the specific explainer class.
     """
     generic_explainer.__class__ = explainer_cls
@@ -88,8 +88,8 @@ class Explainer:
         model: Model | Game | Callable[[np.ndarray], np.ndarray],
         data: np.ndarray | None = None,
         class_index: int | None = None,
-        index: ExplainerIndices = "k-SII",
-        max_order: int = 2,
+        index: ExplainerIndices = "SV",
+        max_order: int = 1,
         **kwargs: Any,
     ) -> None:
         """Initialize the Explainer class.
@@ -109,9 +109,9 @@ class Explainer:
                 for regression models. Note, it is important to specify the class index for your
                 classification model.
 
-            index: The type of Shapley interaction index to use. Defaults to ``"k-SII"``, which
-                computes the k-Shapley Interaction Index. If ``max_order`` is set to 1, this
-                corresponds to the Shapley value (``index="SV"``). Options are:
+            index: The type of Shapley interaction index to use. Defaults to ``"SV"``, which
+                computes the Shapley value. To compute interactions, pass an interaction index
+                explicitly and set ``max_order`` accordingly. Options are:
                 - ``"SV"``: Shapley value
                 - ``"k-SII"``: k-Shapley Interaction Index
                 - ``"FSII"``: Faithful Shapley Interaction Index
@@ -119,8 +119,8 @@ class Explainer:
                 - ``"STII"``: Shapley Taylor Interaction Index
                 - ``"SII"``: Shapley Interaction Index
 
-            max_order: The maximum interaction order to be computed. Defaults to ``2``. Set to
-                ``1`` for no interactions (single feature attribution).
+            max_order: The maximum order of interactions to be computed. Set to ``1`` for no
+                interactions (i.e, for Shapley values ``"SV"`` or Banzhaf values ``"BV"``).
 
             **kwargs: Additional keyword-only arguments passed to the specific explainer classes.
 

--- a/src/shapiq/explainer/tabpfn.py
+++ b/src/shapiq/explainer/tabpfn.py
@@ -41,8 +41,8 @@ class TabPFNExplainer(TabularExplainer):
         data: np.ndarray,
         labels: np.ndarray,
         *,
-        index: ExplainerIndices = "k-SII",
-        max_order: int = 2,
+        index: ExplainerIndices = "SV",
+        max_order: int = 1,
         x_test: np.ndarray | None = None,
         empty_prediction: float | None = None,
         class_index: int | None = None,
@@ -70,16 +70,15 @@ class TabPFNExplainer(TabularExplainer):
                 :class:`~shapiq.approximator.RegressionFBII` for ``"FBII"``, and
                 :class:`~shapiq.approximator.SVARMIQ` for ``"STII"``.
 
-            index: The index to explain the model with. Defaults to ``"k-SII"`` which computes the
-                k-Shapley Interaction Index. If ``max_order`` is set to 1, this corresponds to the
-                Shapley value (``index="SV"``). Options: ``"SV"`` (Shapley value), ``"k-SII"``
+            index: The index to explain the model with. Defaults to ``"SV"`` which computes the
+                Shapley value. Options: ``"SV"`` (Shapley value), ``"k-SII"``
                 (k-Shapley Interaction Index), ``"FSII"`` (Faithful Shapley Interaction Index),
                 ``"FBII"`` (Faithful Banzhaf Interaction Index, becomes ``BV`` for order 1),
                 ``"STII"`` (Shapley Taylor Interaction Index), ``"SII"`` (Shapley Interaction
                 Index).
 
-            max_order: The maximum interaction order to be computed. Defaults to ``2``. Set to
-                ``1`` for no interactions (single feature importance).
+            max_order: The maximum order of interactions to be computed. Set to ``1`` for no
+                interactions (i.e, for Shapley values ``"SV"`` or Banzhaf values ``"BV"``).
 
             x_test: An optional test data set to compute the model's empty prediction (average
                 prediction) on. If no test data and ``empty_prediction`` is set to ``None`` the last

--- a/src/shapiq/explainer/tabular.py
+++ b/src/shapiq/explainer/tabular.py
@@ -51,8 +51,8 @@ class TabularExplainer(Explainer):
         approximator: (
             Literal["auto"] | TabularExplainerApproximators | Approximator[TabularExplainerIndices]
         ) = "auto",
-        index: TabularExplainerIndices = "k-SII",
-        max_order: int = 2,
+        index: TabularExplainerIndices = "SV",
+        max_order: int = 1,
         random_state: int | None = None,
         verbose: bool = False,
         **kwargs: Any,
@@ -85,16 +85,15 @@ class TabularExplainer(Explainer):
                 :class:`~shapiq.approximator.RegressionFBII` for ``"FBII"``, and
                 :class:`~shapiq.approximator.SVARMIQ` for ``"STII"``.
 
-            index: The index to explain the model with. Defaults to ``"k-SII"`` which computes the
-                k-Shapley Interaction Index. If ``max_order`` is set to 1, this corresponds to the
-                Shapley value (``index="SV"``). Options: ``"SV"`` (Shapley value), ``"k-SII"``
+            index: The index to explain the model with. Defaults to ``"SV"`` which computes the
+                Shapley value. Options: ``"SV"`` (Shapley value), ``"k-SII"``
                 (k-Shapley Interaction Index), ``"FSII"`` (Faithful Shapley Interaction Index),
                 ``"FBII"`` (Faithful Banzhaf Interaction Index, becomes ``BV`` for order 1),
                 ``"STII"`` (Shapley Taylor Interaction Index), ``"SII"`` (Shapley Interaction
                 Index).
 
-            max_order: The maximum interaction order to be computed. Defaults to ``2``. Set to
-                ``1`` for no interactions (single feature importance).
+            max_order: The maximum order of interactions to be computed. Set to ``1`` for no
+                interactions (i.e, for Shapley values ``"SV"`` or Banzhaf values ``"BV"``).
 
             random_state: The random state to initialize Imputer and Approximator with. Defaults to
                 ``None``.

--- a/src/shapiq/tree/explainer.py
+++ b/src/shapiq/tree/explainer.py
@@ -56,9 +56,9 @@ class TreeExplainer(Explainer):
         *,
         mode: TREE_MODES = "pathdependent",
         reference_dataset: np.ndarray | None = None,
-        max_order: int = 2,
+        max_order: int = 1,
         min_order: int = 0,
-        index: TreeSHAPIQIndices = "k-SII",
+        index: TreeSHAPIQIndices = "SV",
         class_index: int | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
@@ -72,9 +72,10 @@ class TreeExplainer(Explainer):
             In ``"interventional"`` mode, the explainer computes interventional interaction values using the Interventional TreeExplainer algorithm.
             Defaults to ``"pathdependent"``.
 
-            max_order: The maximum interaction order to be computed. An interaction order of ``1``
-                corresponds to the Shapley value. Any value higher than ``1`` computes the Shapley
-                interaction values up to that order. Defaults to ``2``.
+            max_order: The maximum order of interactions to be computed. Set to ``1`` for no
+                interactions (i.e, for Shapley values ``"SV"`` or Banzhaf values ``"BV"``). Any
+                value higher than ``1`` computes interaction values up to that order. Defaults to
+                ``1``.
 
             min_order: The minimum interaction order to keep in the returned
                 :class:`~shapiq.interaction_values.InteractionValues`. Must satisfy
@@ -86,7 +87,7 @@ class TreeExplainer(Explainer):
 
             index: The type of interaction to be computed. It can be one of
                 ``["k-SII", "SII", "STII", "FSII", "BII", "SV"]``. All indices apart from ``"BII"``
-                will reduce to the ``"SV"`` (Shapley value) for order 1. Defaults to ``"k-SII"``.
+                will reduce to the ``"SV"`` (Shapley value) for order 1. Defaults to ``"SV"``.
 
             class_index: The class index of the model to explain. Defaults to ``None``, which will
                 set the class index to ``1`` per default for classification models and is ignored

--- a/tests/shapiq/tests_unit/tests_explainer/test_explainer_tabular.py
+++ b/tests/shapiq/tests_unit/tests_explainer/test_explainer_tabular.py
@@ -27,10 +27,10 @@ def test_auto_params(dt_reg_model, background_reg_data):
         model=model_function,
         data=background_reg_data,
     )
-    assert explainer.index == "k-SII"
-    assert explainer.approximator.index == "k-SII"
-    assert explainer.max_order == 2
-    assert explainer.approximator.__class__.__name__ == "KernelSHAPIQ"
+    assert explainer.index == "SV"
+    assert explainer.approximator.index == "SV"
+    assert explainer.max_order == 1
+    assert explainer.approximator.__class__.__name__ == "KernelSHAP"
 
 
 def test_init_params_error_and_warning(dt_reg_model, background_reg_data):
@@ -86,6 +86,7 @@ def test_init_params_approx(dt_reg_model, background_reg_data):
     explainer = TabularExplainer(
         approximator="regression",
         index="FSII",
+        max_order=2,
         model=model_function,
         data=data,
     )

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -13,7 +13,7 @@ from tests.shapiq.markers import skip_if_no_lightgbm
 
 def test_decision_tree_classifier(rf_clf_model, background_clf_data):
     """Test TreeExplainer with a simple decision tree classifier."""
-    explainer = TreeExplainer(model=rf_clf_model, max_order=2, min_order=1)
+    explainer = TreeExplainer(model=rf_clf_model, max_order=2, min_order=1, index="k-SII")
 
     x_explain = background_clf_data[0]
     explanation = explainer.explain(x_explain)
@@ -22,7 +22,7 @@ def test_decision_tree_classifier(rf_clf_model, background_clf_data):
     assert type(explanation).__name__ == "InteractionValues"  # check correct return type
 
     # check init with class label
-    _ = TreeExplainer(model=rf_clf_model, max_order=2, min_order=0, class_index=0)
+    _ = TreeExplainer(model=rf_clf_model, max_order=2, min_order=0, index="k-SII", class_index=0)
 
     assert True
 
@@ -42,7 +42,7 @@ def test_decision_tree_classifier(rf_clf_model, background_clf_data):
 
 def test_decision_tree_regression(dt_reg_model, background_reg_data):
     """Test TreeExplainer with a simple decision tree regressor."""
-    explainer = TreeExplainer(model=dt_reg_model, max_order=2, min_order=1)
+    explainer = TreeExplainer(model=dt_reg_model, max_order=2, min_order=1, index="k-SII")
 
     x_explain = background_reg_data[0]
     explanation = explainer.explain(x_explain)
@@ -64,7 +64,7 @@ def test_decision_tree_regression(dt_reg_model, background_reg_data):
 
 def test_random_forest_regression(rf_reg_model, background_reg_data):
     """Test TreeExplainer with a simple decision tree regressor."""
-    explainer = TreeExplainer(model=rf_reg_model, max_order=2, min_order=1)
+    explainer = TreeExplainer(model=rf_reg_model, max_order=2, min_order=1, index="k-SII")
 
     x_explain = background_reg_data[0]
     explanation = explainer.explain(x_explain)
@@ -190,9 +190,9 @@ def test_min_order_filters_interactions(rf_reg_model, background_reg_data):
 def test_min_order_validation(rf_reg_model):
     """Invalid ``min_order`` configurations must be rejected eagerly."""
     with pytest.raises(ValueError, match="min_order"):
-        TreeExplainer(model=rf_reg_model, max_order=2, min_order=3)
+        TreeExplainer(model=rf_reg_model, max_order=2, min_order=3, index="k-SII")
     with pytest.raises(ValueError, match="min_order"):
-        TreeExplainer(model=rf_reg_model, max_order=2, min_order=-1)
+        TreeExplainer(model=rf_reg_model, max_order=2, min_order=-1, index="k-SII")
 
 
 def test_xgboost_reg(xgb_reg_model, background_reg_data):


### PR DESCRIPTION
Makes Shapley Values "SV" the default for `shapiq` explainers.