### PR TITLE
fix(InteractionValues): skip dense lookup build for sparse-dict input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ The conversion of the tree methods has been moved to C++ giving at least 2x up t
 - fixes `min_order` in `TreeExplainer` so that it now actually restricts the returned `InteractionValues` to interactions of order ``min_order..max_order`` (``min_order=0`` continues to include the empty interaction at the baseline value); invalid values now raise a clear `ValueError`. [#325](https://github.com/mmschlk/shapiq/issues/325)
 - fixes tree conversion breaking when the `LC_NUMERIC` locale is not set to the standard `"C"` value. [#515](https://github.com/mmschlk/shapiq/pull/515)
 - fixes a segfault in the `ProxySHAP` C++ extension code. [#506](https://github.com/mmschlk/shapiq/pull/506)
-
+- fixes a Out Of Memory (OOM) when values is an dictionary and n_players is large.  [#531](https://github.com/mmschlk/shapiq/issues/531)
 
 ## v1.4.1 (2025-11-10)
 

--- a/src/shapiq/interaction_values.py
+++ b/src/shapiq/interaction_values.py
@@ -1189,22 +1189,20 @@ def _validate_and_return_interactions(
     Raises:
         TypeError: If the values or interaction_lookup are not of the expected types.
     """
-    interactions: dict[tuple[int, ...], float] = {}
-    # Dict-input does not consume the lookup (see deepcopy branch below) and
-    # building it is O(2**n_players) worst case — skip to avoid OOM at large n.
-    if interaction_lookup is None and not isinstance(values, dict):
-        interaction_lookup = generate_interaction_lookup(
-            players=n_players,
-            min_order=min_order,
-            max_order=max_order,
-        )
-    if interaction_lookup is not None and not isinstance(interaction_lookup, dict):
-        msg = f"Interaction lookup must be a dictionary. Got {type(interaction_lookup)}."
-        raise TypeError(msg)
-
+    interactions: dict[tuple[int, ...], float]
     if isinstance(values, dict):
-        interactions = copy.deepcopy(values)  # type: ignore[assignment]
+        # Shallow copy is sufficient, as keys and values are immutable (tuples[float,...] and float).
+        interactions = dict(values)
     else:
+        if interaction_lookup is None:
+            interaction_lookup = generate_interaction_lookup(
+                players=n_players,
+                min_order=min_order,
+                max_order=max_order,
+            )
+        if not isinstance(interaction_lookup, dict):
+            msg = f"Interaction lookup must be a dictionary. Got {type(interaction_lookup)}."
+            raise TypeError(msg)
         interactions = {
             interaction: values[index].item() for interaction, index in interaction_lookup.items()
         }

--- a/src/shapiq/interaction_values.py
+++ b/src/shapiq/interaction_values.py
@@ -1190,7 +1190,9 @@ def _validate_and_return_interactions(
         TypeError: If the values or interaction_lookup are not of the expected types.
     """
     interactions: dict[tuple[int, ...], float] = {}
-    if interaction_lookup is None:
+    # Dict-input does not consume the lookup (see deepcopy branch below) and
+    # building it is O(2**n_players) worst case — skip to avoid OOM at large n.
+    if interaction_lookup is None and not isinstance(values, dict):
         interaction_lookup = generate_interaction_lookup(
             players=n_players,
             min_order=min_order,

--- a/tests/shapiq/tests_unit/test_interaction_values.py
+++ b/tests/shapiq/tests_unit/test_interaction_values.py
@@ -929,3 +929,36 @@ def test_from_empty_array():
     assert len(iv.interaction_lookup) == 1
     assert iv[()] == baseline_value
     assert iv.baseline_value == baseline_value
+
+
+def test_init_with_sparse_dict():
+    """Regression: a sparse-dict ``values`` input must not allocate the dense
+    interaction lookup of size Σ C(n_players, k).
+
+    Before the fix, ``_validate_and_return_interactions`` unconditionally called
+    ``generate_interaction_lookup(n_players, min_order, max_order)`` even when
+    ``values`` was a dict (where the built lookup is then unused — the dict
+    branch only does ``copy.deepcopy(values)``).  For n_players=30 and
+    max_order=30 that lookup would have 2**30 ~ 1e9 entries and OOM.
+
+    The fix skips the build when ``values`` is a dict.  Pre-fix, this test
+    crashes with MemoryError; post-fix it completes instantly.
+    """
+    sparse_values = {(0,): 1.0, (1,): 2.0, (0, 1): 3.0}
+
+    iv = InteractionValues(
+        values=sparse_values,
+        index="SV",
+        max_order=30,
+        n_players=30,
+        min_order=1,
+        baseline_value=0.0,
+    )
+
+    assert iv.interactions == sparse_values
+    assert iv.n_players == 30
+    assert iv.max_order == 30
+    # ``interaction_lookup`` is a property derived from ``self.interactions``;
+    # it should only contain keys actually present in ``values``, not the
+    # full enumeration of Σ C(n_players, k) interactions.
+    assert set(iv.interaction_lookup.keys()) == set(sparse_values.keys())


### PR DESCRIPTION
# fix(InteractionValues): skip dense lookup build for sparse-dict input

Closes #531

## Problem

`_validate_and_return_interactions` (in `src/shapiq/interaction_values.py`)
unconditionally calls `generate_interaction_lookup(n_players, min_order,
max_order)` when `interaction_lookup` is `None` — including when `values` is
a sparse `dict[tuple[int, ...], float]`. In the dict branch, the built lookup
is then discarded:

- The `isinstance(values, dict)` branch only does `copy.deepcopy(values)` and
  does not reference `interaction_lookup`.
- The function returns only the `interactions` dict; the lookup is not
  passed back to the caller.
- `InteractionValues.interaction_lookup` is a `@property` derived from
  `self.interactions.items()`, not a stored field — the built lookup is not
  retained on the instance either.

For `n_players >= ~25` with `max_order` not capped, the lookup has up to
`2**n_players` entries and `MemoryError`s.

This is observable on the post-PR-#519 sparse path of
`InterventionalTreeExplainer.explain_function`, which wraps a sparse result
via `InteractionValues(values=dict, interaction_lookup=None, ...)` and
triggers the OOM on any tree-based value function with `d >= ~25`.

See linked issue for the minimal reproduction and the analysis of why this is
a bug rather than an "implicit must-pair-lookup" API contract.

## Fix

One-line guard: only build the dense lookup when it will actually be consumed
(i.e., when `values` is an `ndarray`).

```diff
-    if interaction_lookup is None:
+    if interaction_lookup is None and not isinstance(values, dict):
         interaction_lookup = generate_interaction_lookup(
             players=n_players, min_order=min_order, max_order=max_order,
         )
```

Behavior in all four input combinations is preserved:

| `values` | `interaction_lookup` | Pre-fix | Post-fix |
|---|---|---|---|
| `dict`    | `None`        | Build (then discard) → OOM at large `n` | Skip build, `deepcopy(values)` |
| `dict`    | caller-supplied | Type-check, then `deepcopy(values)` | Unchanged |
| `ndarray` | `None`        | Build, then index by `lookup.items()` | Build (gated), then index — same |
| `ndarray` | caller-supplied | Type-check, then index | Unchanged |

The type check `if interaction_lookup is not None and not isinstance(...)` on
the following line still validates caller-supplied lookups in all four cases.

## Tests

Adds `tests/shapiq/tests_unit/test_interaction_values.py::
test_init_with_sparse_dict_does_not_build_dense_lookup` — a regression test
constructing `InteractionValues(values={(0,): 1.0, (1,): 2.0, (0, 1): 3.0},
n_players=30, max_order=30, ...)`. This `MemoryError`s pre-fix and completes
in ~0.13 s post-fix.

Full test file passes (`47 passed`) on the changed branch.

## Test plan

- [x] Regression test added and passing
- [x] Full `tests/shapiq/tests_unit/test_interaction_values.py` passes
- [ ] CI green (will verify after push)
