### PR TITLE
Fixing wheel packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build Wheels and SDist
 on:
-  pull_request:
+  # pull_request:
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build Wheels and SDist
 on:
-  # pull_request:
+  pull_request:
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,12 +35,8 @@ jobs:
         with:
           python-version: "3.12"
           enable-cache: true
-      # libomp is installed via conda inside build_wheels.sh — see that
-      # script for the rationale (mirrors scikit-learn's wheel build).
-      - uses: conda-incubator/setup-miniconda@v3
-        if: startsWith(matrix.os, 'macos')
-        with:
-          miniforge-version: latest
+      # libomp is installed via `brew install libomp` inside build_wheels.sh and
+      # static-linked into the extension — see that script for the rationale.
       - name: Build wheels
         shell: bash -el {0}
         run: bash build_tools/wheels/build_wheels.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.5.1 (2026-05-30)
+
+### Bugfix
+
+- Fixes segfaults on macOS when using shapiq alongside XGBoost or LightGBM by static-linking the OpenMP runtime instead of vendoring a dynamic `libomp.dylib`. No API changes. [#536](https://github.com/mmschlk/shapiq/issues/536)
+
 ## v1.5.0 (2026-05-29)
 
 ### Highlights of new Features

--- a/build_tools/wheels/build_wheels.sh
+++ b/build_tools/wheels/build_wheels.sh
@@ -1,21 +1,28 @@
 #!/bin/bash
 # Build shapiq wheels with cibuildwheel.
 #
-# On macOS, brew-installed libomp is built against the runner's current macOS
-# SDK, which forces MACOSX_DEPLOYMENT_TARGET up to that runner version. To
-# produce widely-installable wheels we instead pull a pinned conda-forge
-# llvm-openmp package (compiled against an old SDK), wire up the compiler
-# flags so the build links against it, and let delocate vendor libomp.dylib
-# into the wheel via the rpath baked in by LDFLAGS.
+# macOS OpenMP strategy: the interventional extension links libomp *statically
+# and hidden* (-Wl,-load_hidden,<prefix>/lib/libomp.a; see setup.py). libomp's
+# objects are baked into the extension, giving shapiq a private OpenMP runtime
+# that does NOT participate in dyld's process-wide weak-symbol coalescing —
+# which otherwise crashes when another libomp image is present (e.g. xgboost's
+# Homebrew libomp). No separate libomp.dylib is vendored into the wheel.
 #
-# The pin must be llvm-openmp >= 12: our C extensions use
-# `#pragma omp for schedule(dynamic, ...)`, and modern clang lowers those into
-# a call to __kmpc_dispatch_deinit which was first added to the libomp runtime
-# in LLVM 12. Older pins (e.g. 11.1.0) build cleanly but fail at wheel-import
-# time with "symbol not found in flat namespace ___kmpc_dispatch_deinit".
+# Because we static-link, we can use Homebrew's libomp directly and the old
+# conda-forge old-SDK pin is no longer needed:
+#   * Deployment target: the wheel's per-file minimum macOS is governed by our
+#     own -mmacosx-version-min (MACOSX_DEPLOYMENT_TARGET below), not by libomp's.
+#     The libomp objects are merged into the extension, so there is no standalone
+#     libomp.dylib whose current-SDK `minos` would force the wheel target up.
+#   * Symbols: libomp's object code references only ancient, stable libSystem
+#     symbols (pthread_*, mach_*, sysctlbyname, __tlv_bootstrap, dlsym), so a
+#     current-SDK build still runs on our old deployment targets. The nm guard
+#     below fails the build if a future libomp ever uses a newer-only symbol.
 #
-# This mirrors scikit-learn's approach. See their build script for reference:
-# https://github.com/scikit-learn/scikit-learn/blob/main/build_tools/wheels/build_wheels.sh
+# Requirement: libomp >= 12. Our C extensions use
+# `#pragma omp for schedule(dynamic, ...)`, which modern clang lowers into a call
+# to __kmpc_dispatch_deinit, first added to the libomp runtime in LLVM 12.
+# Homebrew's libomp is far newer, so this is always satisfied.
 
 set -euxo pipefail
 
@@ -24,24 +31,30 @@ if [[ $(uname) == "Darwin" ]]; then
         # arm64 wheels: matches SciPy's minimum (kernel-panic workaround).
         # https://github.com/scipy/scipy/issues/14688
         export MACOSX_DEPLOYMENT_TARGET=12.0
-        # conda-forge build metadata: __osx >=11.0 — compatible with target 12.0.
-        OPENMP_URL="https://anaconda.org/conda-forge/llvm-openmp/19.1.7/download/osx-arm64/llvm-openmp-19.1.7-hdb05f8b_1.conda"
     else
         # x86_64 wheels: matches CPython 3.12's documented minimum.
         export MACOSX_DEPLOYMENT_TARGET=10.13
-        # conda-forge build metadata: __osx >=10.13 — compatible with target 10.13.
-        OPENMP_URL="https://anaconda.org/conda-forge/llvm-openmp/19.1.7/download/osx-64/llvm-openmp-19.1.7-ha54dae1_1.conda"
     fi
 
-    # Use conda purely as a tarball extractor for the pinned llvm-openmp.
-    conda create -y -n build "$OPENMP_URL"
+    # Static-link Homebrew's libomp into the extension (setup.py reads
+    # LIBOMP_PREFIX and links <prefix>/lib/libomp.a). `brew install` is a no-op
+    # if libomp is already present on the runner image.
+    brew install libomp
+    LIBOMP_PREFIX="$(brew --prefix libomp)"
+    export LIBOMP_PREFIX
 
-    # setup.py reads LIBOMP_PREFIX to wire up the include / library / rpath
-    # flags for the C extensions. The rpath it adds is what lets delocate
-    # vendor libomp.dylib into the wheel at repair time.
-    export LIBOMP_PREFIX="$CONDA/envs/build"
+    # Guard: our deployment target is older than the SDK Homebrew built libomp
+    # against. That is safe only because libomp references no newer-only macOS
+    # APIs. Fail loudly at build time if that ever stops being true, instead of
+    # discovering it via crash reports from users on older macOS.
+    if nm -u "$LIBOMP_PREFIX/lib/libomp.a" \
+        | grep -qiE 'os_unfair_lock|os_log|os_workgroup|pthread_jit|mach_msg2'; then
+        echo "ERROR: libomp.a references a newer-only macOS API; revisit the" \
+             "deployment target or pin an older libomp." >&2
+        exit 1
+    fi
 
-    # Ensure system clang is used rather than anything conda put on PATH.
+    # Ensure system clang is used rather than anything on PATH.
     export CC=/usr/bin/clang
     export CXX=/usr/bin/clang++
 fi

--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,7 @@ class BuildExt(_build_ext):
 
 
 def get_base_flags() -> dict[str, list[str]]:
-    """Get compiler/linker flags for extensions that do NOT use OpenMP.
-
-    Used for the ``conversion`` and ``linear`` extensions, which contain no
-    ``#pragma omp`` / ``omp_*`` usage. Keeping libomp off their link lines means
-    they introduce no OpenMP runtime into the process (important on macOS, where
-    a second libomp image triggers weak-symbol coalescing crashes against other
-    libraries' OpenMP runtimes — see ``get_openmp_flags``).
-    """
+    """Get compiler/linker flags for extensions that do NOT use OpenMP."""
     if sys.platform == "win32":  # Windows (MSVC)
         return {
             "extra_compile_args": ["/std:c++17", "/O2"],
@@ -62,8 +55,7 @@ def get_openmp_flags() -> dict[str, list[str]]:
     dyld's process-wide weak-symbol coalescing. This prevents the cross-image
     crash where another library's OpenMP barrier (e.g. xgboost via Homebrew
     libomp) lands in shapiq's vendored libomp with a mismatched struct layout.
-    Linux and Windows do not have this dyld coalescing problem and keep dynamic
-    OpenMP.
+    Linux and Windows do not have this dyld coalescing problem and keep dynamic OpenMP.
     """
     if sys.platform == "win32":  # Windows (MSVC)
         return {

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,43 @@ class BuildExt(_build_ext):
         self.include_dirs.append(np.get_include())
 
 
+def get_base_flags() -> dict[str, list[str]]:
+    """Get compiler/linker flags for extensions that do NOT use OpenMP.
+
+    Used for the ``conversion`` and ``linear`` extensions, which contain no
+    ``#pragma omp`` / ``omp_*`` usage. Keeping libomp off their link lines means
+    they introduce no OpenMP runtime into the process (important on macOS, where
+    a second libomp image triggers weak-symbol coalescing crashes against other
+    libraries' OpenMP runtimes — see ``get_openmp_flags``).
+    """
+    if sys.platform == "win32":  # Windows (MSVC)
+        return {
+            "extra_compile_args": ["/std:c++17", "/O2"],
+            "extra_link_args": [],
+            "include_dirs": [],
+            "library_dirs": [],
+        }
+    # macOS and Linux
+    return {
+        "extra_compile_args": ["-std=c++17", "-O3", "-ffast-math"],
+        "extra_link_args": [],
+        "include_dirs": [],
+        "library_dirs": [],
+    }
+
+
 def get_openmp_flags() -> dict[str, list[str]]:
-    """Get OpenMP compiler and linker flags based on platform."""
+    """Get OpenMP compiler and linker flags based on platform.
+
+    Used only for the ``interventional`` extension, the only one that uses
+    OpenMP. On macOS, libomp is linked STATICALLY with its symbols hidden so the
+    extension carries a private OpenMP runtime that does not participate in
+    dyld's process-wide weak-symbol coalescing. This prevents the cross-image
+    crash where another library's OpenMP barrier (e.g. xgboost via Homebrew
+    libomp) lands in shapiq's vendored libomp with a mismatched struct layout.
+    Linux and Windows do not have this dyld coalescing problem and keep dynamic
+    OpenMP.
+    """
     if sys.platform == "win32":  # Windows (MSVC)
         return {
             "extra_compile_args": ["/std:c++17", "/openmp", "/O2"],
@@ -49,8 +84,8 @@ def get_openmp_flags() -> dict[str, list[str]]:
         for prefix in candidates:
             include_dir = prefix / "include"
             library_dir = prefix / "lib"
-            libomp_dylib = library_dir / "libomp.dylib"
-            if include_dir.exists() and libomp_dylib.exists():
+            libomp_archive = library_dir / "libomp.a"
+            if include_dir.exists() and libomp_archive.exists():
                 return {
                     "extra_compile_args": [
                         "-std=c++17",
@@ -58,26 +93,32 @@ def get_openmp_flags() -> dict[str, list[str]]:
                         "-fopenmp",
                         "-O3",
                         "-ffast-math",
+                        # Hide our own (algorithms::*) symbols; only _PyInit_cext
+                        # is exported via the linker allowlist below.
+                        "-fvisibility=hidden",
                     ],
-                    # Link libomp by ABSOLUTE PATH (not -lomp). With
-                    # setuptools' default -undefined dynamic_lookup, a
-                    # plain -lomp gets silently dropped from the
-                    # LC_LOAD_DYLIB entries and the resulting wheel fails
-                    # to load libomp at runtime ("symbol not found in
-                    # flat namespace"). Passing the dylib path positionally
-                    # forces the load command to be recorded. The -rpath
-                    # then lets delocate find and vendor libomp into the
-                    # wheel during repair.
                     "extra_link_args": [
-                        str(libomp_dylib),
-                        f"-Wl,-rpath,{library_dir}",
+                        # Static-link the libomp archive AND hide every symbol it
+                        # contributes (-load_hidden). Hidden symbols never enter
+                        # the export table, so dyld cannot coalesce them with any
+                        # other libomp image in the process. No LC_LOAD_DYLIB for
+                        # libomp is recorded, so delocate vendors nothing.
+                        f"-Wl,-load_hidden,{libomp_archive}",
+                        # Drop libomp objects not reachable from the __kmpc_*
+                        # entry points we actually call, bounding the size added
+                        # to this single extension.
+                        "-Wl,-dead_strip",
+                        # Belt-and-suspenders allowlist: export only the module
+                        # init symbol. Closes the coalescing surface even if a
+                        # weak libomp symbol slipped past -load_hidden.
+                        "-Wl,-exported_symbol,_PyInit_cext",
                     ],
                     "include_dirs": [str(include_dir)],
                 }
         msg = (
-            "OpenMP support on macOS requires libomp. Either install it via "
-            "Homebrew (`brew install libomp`) or set LIBOMP_PREFIX to a "
-            "directory containing include/omp.h and lib/libomp.dylib."
+            "OpenMP support on macOS requires a static libomp (libomp.a). Either "
+            "install it via Homebrew (`brew install libomp`) or set LIBOMP_PREFIX "
+            "to a directory containing include/omp.h and lib/libomp.a."
         )
         raise RuntimeError(msg)
     # Linux and others
@@ -99,7 +140,8 @@ ext_modules = [
             "src/shapiq/tree/conversion/cext/catboost_json.cc",
         ],
         language="c++",
-        **get_openmp_flags(),
+        # No OpenMP: this extension contains no #pragma omp / omp_* usage.
+        **get_base_flags(),
     ),
     Extension(
         "shapiq.tree.interventional.cext",
@@ -107,6 +149,7 @@ ext_modules = [
             "src/shapiq/tree/interventional/cext/cext.cc",
         ],
         language="c++",
+        # The only extension that uses OpenMP (static+hidden libomp on macOS).
         **get_openmp_flags(),
     ),
     Extension(
@@ -115,7 +158,8 @@ ext_modules = [
             "src/shapiq/tree/linear/cext/cext.cc",
         ],
         language="c++",
-        **get_openmp_flags(),
+        # No OpenMP: this extension contains no #pragma omp / omp_* usage.
+        **get_base_flags(),
     ),
 ]
 

--- a/src/shapiq/tree/interventional/explainer.py
+++ b/src/shapiq/tree/interventional/explainer.py
@@ -12,19 +12,7 @@ from shapiq.game_theory.indices import get_computation_index
 from shapiq.interaction_values import InteractionValues
 from shapiq.tree.validation import validate_tree_model
 
-# NOTE: the compiled ``.cext`` module is imported lazily inside the methods that
-# use it (see ``_preprocess_boolean_tree`` and ``explain_function``). It links a
-# private, statically-embedded OpenMP runtime on macOS; importing it at module
-# top level would pull that runtime into the process at ``import shapiq`` time,
-# which is undesirable for users who never run the interventional explainer. This
-# mirrors the lazy import in ``shapiq.tree.linear.explainer``.
-
-# The dense `compute_interactions_flatten` path allocates a result buffer of
-# sum(C(n, k) for k in 1..max_order) doubles, plus one such buffer per OpenMP
-# thread inside the order-2/3 leaf-parallel kernels. Above this threshold we
-# redirect to the sparse `compute_interactions_batched_sparse` path, which only
-# materializes interactions actually touched by tree paths. 1_000_000 entries
-# = 8 MB per thread — comfortably below typical RAM budgets.
+# Maximal budget, for which we still use the flatten path: max_order=3 for n_features up to 100, or max_order=4 for n_features up to 20.
 _DENSE_FLATTEN_MAX_RESULT_SIZE = 1_000_000
 
 

--- a/src/shapiq/tree/interventional/explainer.py
+++ b/src/shapiq/tree/interventional/explainer.py
@@ -12,11 +12,12 @@ from shapiq.game_theory.indices import get_computation_index
 from shapiq.interaction_values import InteractionValues
 from shapiq.tree.validation import validate_tree_model
 
-from .cext import (
-    compute_interactions_batched_sparse,  # ty: ignore[unresolved-import]
-    compute_interactions_flatten,  # ty: ignore[unresolved-import]
-    preprocess_boolean_trees,  # ty: ignore[unresolved-import]
-)
+# NOTE: the compiled ``.cext`` module is imported lazily inside the methods that
+# use it (see ``_preprocess_boolean_tree`` and ``explain_function``). It links a
+# private, statically-embedded OpenMP runtime on macOS; importing it at module
+# top level would pull that runtime into the process at ``import shapiq`` time,
+# which is undesirable for users who never run the interventional explainer. This
+# mirrors the lazy import in ``shapiq.tree.linear.explainer``.
 
 # The dense `compute_interactions_flatten` path allocates a result buffer of
 # sum(C(n, k) for k in 1..max_order) doubles, plus one such buffer per OpenMP
@@ -264,6 +265,8 @@ class InterventionalTreeExplainer:
 
     def _preprocess_boolean_tree(self) -> None:
         """Gather E and R statistics for boolean tree mode using C++ BitSet DFS."""
+        from .cext import preprocess_boolean_trees  # ty: ignore[unresolved-import]
+
         self.n_features = self.reference_data.shape[1]
 
         # Prepare tree arrays for C++
@@ -450,6 +453,11 @@ class InterventionalTreeExplainer:
             empty-set entry ``()`` set to ``self.baseline_value``, even though
             ``min_order`` reports ``1``.
         """
+        from .cext import (
+            compute_interactions_batched_sparse,  # ty: ignore[unresolved-import]
+            compute_interactions_flatten,  # ty: ignore[unresolved-import]
+        )
+
         if not self.bool_tree and not self._use_sparse_path:
             self._preprocess_tree(x)
         computation_index = get_computation_index(self.index)

--- a/tests/shapiq/tests_unit/test_native_extension_isolation.py
+++ b/tests/shapiq/tests_unit/test_native_extension_isolation.py
@@ -1,0 +1,145 @@
+"""Regression tests for native-extension / OpenMP-runtime isolation.
+
+Background: on macOS, shapiq's compiled extensions used to each vendor a separate
+``libomp.dylib``. macOS coalesces *weak* symbols across the whole process, so a
+second libomp image (e.g. xgboost's Homebrew libomp) could cross into shapiq's
+copy mid-barrier and crash (``EXC_BAD_ACCESS``). The fixes guarded here:
+
+* Only the ``interventional`` extension uses OpenMP, and it is imported lazily so
+  ``import shapiq`` pulls no OpenMP runtime into the process.
+* On macOS that extension links libomp statically with hidden symbols, so it
+  exports only ``_PyInit_cext`` and carries no dynamic ``libomp`` load command.
+* The ``conversion`` and ``linear`` extensions link no libomp at all.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+
+import pytest
+
+# Extensions that must never carry a dynamic libomp dependency.
+_ALL_CEXT = (
+    "shapiq.tree.interventional.cext",
+    "shapiq.tree.conversion.cext",
+    "shapiq.tree.linear.cext",
+)
+
+# Symbol-name fragments that must never be exported from the interventional
+# extension (statically-linked OpenMP runtime + our own internal symbols).
+_FORBIDDEN_EXPORT_FRAGMENTS = ("kmp", "omp", "GOMP", "algorithms")
+
+
+def _cext_path(module_name: str) -> str:
+    """Return the on-disk path of a compiled extension without importing it."""
+    spec = importlib.util.find_spec(module_name)
+    assert spec is not None and spec.origin is not None, f"{module_name} not found"
+    return spec.origin
+
+
+def _run_python(code: str, env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    """Run ``code`` in a fresh interpreter and capture the result.
+
+    Used for checks that must observe a clean process (import order) or that may
+    hard-crash via a native segfault, which cannot be caught in-process.
+    """
+    import os
+
+    env = os.environ.copy()
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+        check=False,
+    )
+
+
+def test_import_shapiq_does_not_load_interventional_cext():
+    """``import shapiq`` must not eagerly load the OpenMP-linked interventional cext."""
+    result = _run_python(
+        "import shapiq, sys;"
+        "assert 'shapiq.tree.interventional.cext' not in sys.modules,"
+        " 'interventional cext loaded eagerly';"
+        "print('OK')"
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "OK" in result.stdout
+
+
+def test_interventional_cext_loads_only_on_use():
+    """Running the interventional explainer triggers the lazy cext import."""
+    result = _run_python(
+        "import sys;"
+        "import numpy as np;"
+        "from sklearn.tree import DecisionTreeRegressor;"
+        "import shapiq;"
+        "from shapiq.tree import InterventionalTreeExplainer;"
+        "assert 'shapiq.tree.interventional.cext' not in sys.modules;"
+        "X = np.random.RandomState(0).rand(40, 4);"
+        "y = X[:, 0] + X[:, 1];"
+        "m = DecisionTreeRegressor(max_depth=3).fit(X, y);"
+        "expl = InterventionalTreeExplainer(m, X, index='SV', max_order=1, debug=False);"
+        "expl.explain_function(X[0]);"
+        "assert 'shapiq.tree.interventional.cext' in sys.modules, 'cext never loaded';"
+        "print('OK')"
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "OK" in result.stdout
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS static+hidden linking check")
+def test_interventional_cext_exports_only_module_init():
+    """The interventional cext must export only ``_PyInit_cext`` (no OpenMP symbols)."""
+    path = _cext_path("shapiq.tree.interventional.cext")
+    out = subprocess.run(["nm", "-gU", path], capture_output=True, text=True, check=True).stdout
+    exported = [line.split()[-1] for line in out.splitlines() if line.strip()]
+    assert "_PyInit_cext" in exported, f"module init not exported; got {exported}"
+    leaked = [sym for sym in exported if any(frag in sym for frag in _FORBIDDEN_EXPORT_FRAGMENTS)]
+    assert not leaked, f"forbidden symbols exported (coalescing surface): {leaked}"
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS dynamic-linkage check")
+@pytest.mark.parametrize("module_name", _ALL_CEXT)
+def test_cext_has_no_dynamic_libomp(module_name):
+    """No shapiq extension may carry a dynamic ``libomp`` load command on macOS."""
+    path = _cext_path(module_name)
+    out = subprocess.run(["otool", "-L", path], capture_output=True, text=True, check=True).stdout
+    assert "libomp" not in out, f"{module_name} links a dynamic libomp:\n{out}"
+
+
+@pytest.mark.parametrize("omp_threads", [None, "1"])
+def test_shapiq_xgboost_openmp_coexistence(omp_threads):
+    """shapiq + xgboost must not crash when both OpenMP-using paths run.
+
+    Imports shapiq *first* (the historically crashing order), then fits a
+    multi-threaded XGBoost model and runs an interventional explanation. A libomp
+    coalescing failure manifests as a hard segfault, so this runs in a subprocess
+    and asserts a clean exit.
+    """
+    pytest.importorskip("xgboost")
+    code = (
+        "import shapiq;"  # import shapiq (and its libomp) first
+        "import numpy as np;"
+        "import xgboost as xgb;"
+        "from shapiq.tree import InterventionalTreeExplainer;"
+        "rng = np.random.RandomState(0);"
+        "X = rng.rand(128, 6); y = X[:, 0] + X[:, 1] * X[:, 2];"
+        "m = xgb.XGBRegressor(n_estimators=8, max_depth=3, n_jobs=4).fit(X, y);"
+        "expl = InterventionalTreeExplainer(m, X, index='SV', max_order=1, debug=False);"
+        "expl.explain_function(X[0]);"
+        "print('OK')"
+    )
+    env_extra = {} if omp_threads is None else {"OMP_NUM_THREADS": omp_threads}
+    result = _run_python(code, env_extra=env_extra)
+    assert result.returncode == 0, (
+        f"coexistence crashed (rc={result.returncode}); "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "OK" in result.stdout
+    assert "Error #15" not in result.stderr, f"OpenMP duplicate-runtime abort:\n{result.stderr}"


### PR DESCRIPTION
## Motivation and Context

This PR closes issue #536 by statically linking OpenMP into shapiq to resolve dynamic linking issues on MacOS. The bug occurred when multiple OpenMP versions were installed on a local Mac.

## Public API Changes

-   [X] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

I have locally build the MacOS wheel and tested shapiq + xgboost.
No errors occured.

## Checklist

-   [X] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [X] An entry has been added to `CHANGELOG.md` (if relevant for users).
-   [X] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.
