### PR TITLE
fix(tree): LinearTreeSHAP no longer mutates the caller-owned TreeModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bugfix
+
+- Fixes `LinearTreeSHAP` mutating a caller-owned `TreeModel` in place during construction (`reduce_feature_complexity()` remapped the feature ids of the passed object, silently corrupting other explainers sharing it). The validated tree is now deep-copied before reduction. [#544](https://github.com/mmschlk/shapiq/issues/544)
+
 ## v1.5.1 (2026-05-30)
 
 ### Bugfix

--- a/src/shapiq/tree/linear/explainer.py
+++ b/src/shapiq/tree/linear/explainer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -78,7 +79,10 @@ class LinearTreeSHAP:
                 given depth. Defaults to :func:`numpy.polynomial.chebyshev.chebpts2`.
         """
         self.clf = model
-        self._tree = validate_tree_model(model, class_label=None)[0]
+        # validate_tree_model returns TreeModel inputs by reference; deepcopy before
+        # reduce_feature_complexity() so a caller-owned (possibly shared) TreeModel is
+        # never mutated in place.
+        self._tree = copy.deepcopy(validate_tree_model(model, class_label=None)[0])
         self._relevant_features: np.ndarray = np.array(list(self._tree.feature_ids), dtype=int)
         self._tree.reduce_feature_complexity()
         self._n_nodes: int = self._tree.n_nodes

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_bugfix.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_bugfix.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from shapiq.tree import TreeExplainer, TreeModel, TreeSHAPIQ
+from shapiq.tree.linear import LinearTreeSHAP
 
 _LIGHTGBM_UBUNTU_BYTES_FILE = (
     Path(__file__).parent.parent.parent.parent / "data" / "models" / "lightgbm_ubuntu.bytes"
@@ -822,3 +823,30 @@ def test_xgb_ubjson_skip_single_value_truncated_raises():
     truncated = buf[:empty_idx] + b"[#i\x01D"  # count=1, type='D', no payload bytes
     with pytest.raises(RuntimeError, match=r"End of stream|Unexpected end of UBJSON"):
         parse_xgboost_ubjson(truncated, -1, 0.0)
+
+
+def test_linear_tree_shap_does_not_mutate_caller_tree_model():
+    """Test that constructing LinearTreeSHAP leaves the passed TreeModel untouched.
+
+    Regression test for https://github.com/mmschlk/shapiq/issues/544: validate_tree_model
+    returns TreeModel inputs by reference, and LinearTreeSHAP called
+    reduce_feature_complexity() on the result, remapping the caller's feature ids in place.
+    """
+    tree = TreeModel(
+        children_left=np.array([1, 3, -1, -1, -1]),
+        children_right=np.array([2, 4, -1, -1, -1]),
+        children_missing=np.array([1, 3, -1, -1, -1]),
+        # splits on features 3 and 1 only (a strict subset of the data's features)
+        features=np.array([3, 1, -2, -2, -2]),
+        thresholds=np.array([0.5, 0.5, np.nan, np.nan, np.nan]),
+        values=np.array([0.0, 0.0, 2.0, -1.0, 1.0]),
+        node_sample_weight=np.array([10.0, 6.0, 4.0, 3.0, 3.0]),
+    )
+    features_before = tree.features.copy()
+
+    explainer = LinearTreeSHAP(tree)
+
+    assert np.array_equal(tree.features, features_before)
+    # the explainer still works on its private reduced copy
+    explanation = explainer.explain_function(np.array([0.0, 0.0, 0.0, 1.0]))
+    assert np.isfinite(explanation.values).all()


### PR DESCRIPTION
Fixes #544.

### What was wrong

Constructing a `LinearTreeSHAP` explainer silently mutated the `TreeModel` passed to it: `validate_tree_model` returns `TreeModel` inputs **by reference**, and the constructor then called `reduce_feature_complexity()` on that result, rewriting its `features` / `feature_ids` / `n_features_in_tree` in place. A user inspecting the model afterwards — or reusing it with another explainer — read corrupted feature ids (e.g. the real ids `[5, 7]` overwritten with internal `[0, 1]`). See #544 for an end-to-end sklearn reproduction. `TreeSHAPIQ` already deep-copies before its own `reduce_feature_complexity()`; `LinearTreeSHAP` was the inconsistent one.

### Fix

Deepcopy the validated tree before reducing — one line in `src/shapiq/tree/linear/explainer.py`, matching `TreeSHAPIQ`. The deepcopy is a one-time construction cost on a single `TreeModel` (a handful of NumPy arrays), negligible next to the N-matrix setup that follows.

### Testing

- New regression test `test_linear_tree_shap_does_not_mutate_caller_tree_model` in `test_tree_bugfix.py`: snapshots `TreeModel.features`, constructs `LinearTreeSHAP`, asserts the caller's object is untouched and the explainer still works on its private reduced copy. Verified red without the fix, green with it.
- Full `tests_tree_explainer` suite passes; `ruff check` / `ruff format` clean on the changed files (zero new findings vs `main`).
