### PR TITLE
Add ShaplEIG: Bayesian experimental design approximator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ src/shapiq/_version.py
 docs/source/auto_examples/
 docs/source/sg_execution_times.rst
 docs/source/generated/
+
+# Local debug / scratch scripts (not public)
+scripts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- adds the `ShaplEIG` approximator in `shapiq.approximator.shapleig` for Shapley value estimation via Bayesian experimental design: a Gaussian process surrogate with a weighted Hamming kernel is fit on the queried coalition values, and the next coalition is selected by maximizing the closed-form expected information gain about the Shapley values. Requires the new optional `shapleig` dependency group (`pip install shapiq[shapleig]` — torch, gpytorch, botorch, linear-operator); the optional dependencies are imported lazily in the constructor.
+
 ## v1.5.2 (2026-06-12)
 
 ### Highlights of new Features

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -364,3 +364,9 @@
   eprinttype = {arXiv},
   eprint     = {2505.17495}
 }
+@article{rundel2026shapleig,
+  title={ShaplEIG: Bayesian Experimental Design for Shapley Value Estimation},
+  author={Rundel, David and Fumagalli, Fabian and Muschalik, Maximilian and Bischl, Bernd and Feurer, Matthias},
+  journal={arXiv preprint arXiv:2606.02247},
+  year={2026}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,15 @@ proxy = [
     "catboost",
     "smac", # SMAC HPO for proxy models
 ]
+shapleig = [
+    # required by shapiq.approximator.shapleig (ShaplEIG)
+    # NOTE: pinned to the exact versions the reference implementation was
+    # developed and validated against; loose ranges can be discussed.
+    "torch==2.9.1",
+    "gpytorch==1.14",
+    "botorch==0.14.0",
+    "linear_operator==0.6",
+]
 
 [tool.coverage.report]
 exclude_also = [
@@ -159,6 +168,19 @@ exclude = [
 # Exclude a variety of commonly ignored directories.
 # Note to developers: If you add a new ignore at least put a comment next to it why it is ignored
 [tool.ruff.lint.per-file-ignores]
+"src/shapiq/approximator/shapleig/_shapley_math.py" = [
+    # controlled verbatim copy of the validated reference implementation in
+    # the ShaplEIG research repository; kept in sync, not restyled
+    "ANN001", "ANN202",  # reference code is fully typed via annotations where it matters
+    "FBT001", "FBT002",  # boolean positional args of internal helpers
+    "N815",              # tensor names follow the paper notation (train_X, ...)
+    "PERF401",           # explicit loops mirror the published algorithm
+    "RUF002", "RUF003",  # mathematical notation in docstrings/comments
+    "S101",              # shape/consistency asserts of the math core
+]
+"src/shapiq/approximator/shapleig/_kernels.py" = [
+    "FBT001", "FBT002",  # signature dictated by gpytorch's Kernel.forward
+]
 "src/shapiq/typing.py" = [
     "A005",  # we want to be similar to other libraries that also shadow typing
     "D102",  # we don't need docstrings for protocol stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,12 +75,12 @@ proxy = [
 ]
 shapleig = [
     # required by shapiq.approximator.shapleig (ShaplEIG)
-    # NOTE: pinned to the exact versions the reference implementation was
-    # developed and validated against; loose ranges can be discussed.
-    "torch==2.9.1",
-    "gpytorch==1.14",
-    "botorch==0.14.0",
-    "linear_operator==0.6",
+    # NOTE: lower bounds are the versions the reference implementation was
+    # developed and validated against.
+    "torch>=2.9.1",
+    "gpytorch>=1.14",
+    "botorch>=0.14.0",
+    "linear_operator>=0.6",  # also a transitive gpytorch dependency, but imported directly
 ]
 
 [tool.coverage.report]

--- a/src/shapiq/__init__.py
+++ b/src/shapiq/__init__.py
@@ -29,6 +29,7 @@ from .approximator import (
     RegressionFBII,
     RegressionFSII,
     RegressionMSR,
+    ShaplEIG,
     StratifiedSamplingSV,
     UnbiasedKernelSHAP,
     kADDSHAP,
@@ -112,6 +113,7 @@ __all__ = [
     "UnbiasedKernelSHAP",
     "SPEX",
     "ProxySHAP",
+    "ShaplEIG",
     "ProxySPEX",
     "RegressionMSR",
     # explainers

--- a/src/shapiq/approximator/__init__.py
+++ b/src/shapiq/approximator/__init__.py
@@ -21,9 +21,6 @@ from .regression import (
     kADDSHAP,
 )
 
-# ShaplEIG needs no import guard: its optional dependencies (the `shapleig`
-# extra) are imported in its constructor, which raises an informative
-# ImportError when they are missing.
 try:
     from .shapleig import ShaplEIG
 except ImportError as _e:

--- a/src/shapiq/approximator/__init__.py
+++ b/src/shapiq/approximator/__init__.py
@@ -21,6 +21,11 @@ from .regression import (
     kADDSHAP,
 )
 
+# ShaplEIG needs no import guard: its optional dependencies (the `shapleig`
+# extra) are imported in its constructor, which raises an informative
+# ImportError when they are missing.
+from .shapleig import ShaplEIG
+
 try:
     from .sparse import SPEX
 except ImportError as _e:
@@ -48,6 +53,7 @@ SV_APPROXIMATORS: list[Approximator.__class__] = [
     SPEX,
     RegressionMSR,
     ProxySPEX,
+    ShaplEIG,
 ]
 
 # contains all SI approximators
@@ -119,6 +125,7 @@ __all__ = [
     "ProxySPEX",
     "ProxySHAP",
     "RegressionMSR",
+    "ShaplEIG",
     "SHAPIQ",
     "SVARM",
     "SVARMIQ",

--- a/src/shapiq/approximator/__init__.py
+++ b/src/shapiq/approximator/__init__.py
@@ -24,7 +24,19 @@ from .regression import (
 # ShaplEIG needs no import guard: its optional dependencies (the `shapleig`
 # extra) are imported in its constructor, which raises an informative
 # ImportError when they are missing.
-from .shapleig import ShaplEIG
+try:
+    from .shapleig import ShaplEIG
+except ImportError as _e:
+
+    class ShaplEIG(Approximator):
+        """Placeholder raised when the optional ``shapleig`` extra is not installed."""
+
+        _import_error = _e
+
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            """Raise an informative ImportError pointing to the missing extra."""
+            raise self._import_error
+
 
 try:
     from .sparse import SPEX
@@ -37,8 +49,7 @@ except ImportError as _e:
 
         def __init__(self, *_args: object, **_kwargs: object) -> None:
             """Raise an informative ImportError pointing to the missing extra."""
-            msg = "SPEX requires the 'sparse' extra: pip install shapiq[sparse]"
-            raise ImportError(msg) from self._import_error
+            raise self._import_error
 
 
 # contains all SV approximators

--- a/src/shapiq/approximator/shapleig/__init__.py
+++ b/src/shapiq/approximator/shapleig/__init__.py
@@ -1,0 +1,8 @@
+"""ShaplEIG: Bayesian experimental design approximator for Shapley values.
+
+Requires the optional ``shapleig`` extra (``pip install shapiq[shapleig]``).
+"""
+
+from .shapleig import ShaplEIG
+
+__all__ = ["ShaplEIG"]

--- a/src/shapiq/approximator/shapleig/_error.py
+++ b/src/shapiq/approximator/shapleig/_error.py
@@ -1,0 +1,10 @@
+"""Import error handling for ShaplEIG."""
+
+from __future__ import annotations
+
+_shapleig_msg = (
+    "ShaplEIG requires the optional dependencies torch, gpytorch, "
+    "botorch, and linear-operator but they are not installed. "
+    "Install them with: pip install 'shapiq[shapleig]'"
+)
+_shapleig_import_error = ImportError(_shapleig_msg)

--- a/src/shapiq/approximator/shapleig/_shapley_math.py
+++ b/src/shapiq/approximator/shapleig/_shapley_math.py
@@ -1,4 +1,4 @@
-"""Shapley-value math core for ShaplEIG (ESP-accelerated, tensor-in/tensor-out).
+r"""Shapley-value math core for ShaplEIG (ESP-accelerated, tensor-in/tensor-out).
 
 Maintainer note: this module is a controlled copy of the validated reference
 implementation from the ShaplEIG research codebase (the code accompanying the
@@ -14,12 +14,13 @@ players regardless of the 2^p coalition space.
 
 Notation (paper: "ShaplEIG: Bayesian Experimental Design for Shapley Value
 Estimation"):
-    p   number of players;  t  number of queried coalitions (training points)
-    A   the (p × 2^p) Shapley affine operator (implicit)
-    K   weighted Hamming product kernel over binary coalitions
-    A_KZW   = A · K(Z, W)            (p × |W|), computed via ESP
-    AKZZA   = A · K(Z, Z) · Aᵀ       (p × p),   computed via ESP
-    AEA     = A · Σ_ν · Aᵀ (unscaled posterior property covariance)
+
+- ``p``: number of players; ``t``: number of queried coalitions (training points).
+- :math:`A`: the (:math:`p \times 2^p`) Shapley affine operator (implicit).
+- :math:`K`: weighted Hamming product kernel over binary coalitions.
+- ``A_KZW`` :math:`= A K(Z, W)` (:math:`p \times |W|`), computed via ESP.
+- ``AKZZA`` :math:`= A K(Z, Z) A^\top` (:math:`p \times p`), computed via ESP.
+- ``AEA`` :math:`= A \Sigma_\nu A^\top` (unscaled posterior property covariance).
 """
 
 from __future__ import annotations
@@ -119,11 +120,13 @@ class GPTensors:
 def kernel_alpha_beta(
     lengthscales: torch.Tensor, outputscale: torch.Tensor, dtype: torch.dtype = DTYPE
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Per-player match/mismatch kernel factors of the Hamming product kernel.
+    r"""Per-player match/mismatch kernel factors of the Hamming product kernel.
 
-    The weighted Hamming kernel k(z, w) = s · exp(-mean_d 1[z_d ≠ w_d]/ℓ_d)
-    factorizes as prod_d f_d with f_d = α_d if z_d = w_d else β_d, where the
-    outputscale s is distributed evenly across players (α_d = s^{1/p}).
+    The weighted Hamming kernel
+    :math:`k(z, w) = s \exp(-\mathrm{mean}_d\, \mathbb{1}[z_d \neq w_d]/\ell_d)`
+    factorizes as :math:`\prod_d f_d` with :math:`f_d = \alpha_d` if
+    :math:`z_d = w_d` else :math:`\beta_d`, where the outputscale :math:`s` is
+    distributed evenly across players (:math:`\alpha_d = s^{1/p}`).
     """
     ls = lengthscales.detach().reshape(-1).to(dtype)
     p = ls.numel()
@@ -140,7 +143,7 @@ def hamming_kernel(
     lengthscales: torch.Tensor,
     outputscale: torch.Tensor,
 ) -> torch.Tensor:
-    """Dense weighted Hamming product kernel matrix s · exp(-mean(δ/ℓ)).
+    r"""Dense weighted Hamming product kernel matrix :math:`s \exp(-\mathrm{mean}(\delta/\ell))`.
 
     Pure-tensor counterpart of the surrogate's kernel module (botorch's
     ``CategoricalKernel``): the math core takes plain lengthscale/outputscale
@@ -164,12 +167,13 @@ def a_kzw(
     outputscale: torch.Tensor,
     chunk_size: int = 1024,
 ) -> torch.Tensor:
-    """Compute A · K(Z, W) for binary coalitions ``W`` (shape (T, p)) → (p, T).
+    r"""Compute :math:`A K(Z, W)` for binary coalitions ``W`` (shape (T, p)), giving (p, T).
 
-    **Vanilla (paper) ESP route, in coefficient representation**: for each w,
-    the generating polynomial ∏_r (γ_r + δ_r ζ) is built incrementally as
-    prefix and suffix coefficient tables (max-normalized per step, log-scale
-    tracked); per player j the prefix(j)·suffix(j+1) product is formed by
+    **Vanilla (paper) ESP route, in coefficient representation**: for each
+    :math:`w`, the generating polynomial :math:`\prod_r (\gamma_r + \delta_r \zeta)`
+    is built incrementally as prefix and suffix coefficient tables
+    (max-normalized per step, log-scale tracked); per player :math:`j` the
+    :math:`\mathrm{prefix}(j)\,\mathrm{suffix}(j+1)` product is formed by
     convolution and contracted with the Shapley size weights (Theorem B.1).
     This is the variant published with the paper.
     """
@@ -255,7 +259,7 @@ def _shapley_weights_signed(
 
 
 def _shapley_w_in_out(p: int, dtype: torch.dtype, device) -> tuple[torch.Tensor, torch.Tensor]:
-    """Unsigned Shapley size weights without the 1/p factor (applied as 1/p² outside)."""
+    r"""Unsigned Shapley size weights without the :math:`1/p` factor (applied as :math:`1/p^2` outside)."""
     w_in = torch.zeros(p + 1, dtype=dtype, device=device)
     w_out = torch.zeros(p + 1, dtype=dtype, device=device)
     for a in range(1, p + 1):
@@ -267,12 +271,14 @@ def _shapley_w_in_out(p: int, dtype: torch.dtype, device) -> tuple[torch.Tensor,
 
 @torch.no_grad()
 def akzza(lengthscales: torch.Tensor, outputscale: torch.Tensor) -> torch.Tensor:
-    """Compute A · K(Z, Z) · Aᵀ (p × p) via bivariate generating polynomials.
+    r"""Compute :math:`A K(Z, Z) A^\top` (:math:`p \times p`) via bivariate generating polynomials.
 
-    For each player pair (i, j) the double sum over coalition pairs collapses
-    into a contraction of prefix/suffix coefficient tables of the bivariate
-    generating polynomial ∏_r (α_r + β_r ζ₁ + β_r ζ₂ + α_r ζ₁ζ₂); tables are
-    max-normalized per step with log-scale tracking for numerical stability.
+    For each player pair :math:`(i, j)` the double sum over coalition pairs
+    collapses into a contraction of prefix/suffix coefficient tables of the
+    bivariate generating polynomial
+    :math:`\prod_r (\alpha_r + \beta_r \zeta_1 + \beta_r \zeta_2 + \alpha_r \zeta_1\zeta_2)`;
+    tables are max-normalized per step with log-scale tracking for numerical
+    stability.
     """
     alpha, beta = kernel_alpha_beta(lengthscales, outputscale)
     p = alpha.numel()
@@ -420,7 +426,7 @@ _psd_chol = psd_chol
 
 
 def noisy_train_kernel(gp_tensors: GPTensors) -> torch.Tensor:
-    """K(X, X) + σ² I on the training coalitions (standardized space)."""
+    r"""Noisy train kernel :math:`K(X, X) + \sigma^2 I` on the training coalitions (standardized space)."""
     K = hamming_kernel(
         gp_tensors.train_X,
         gp_tensors.train_X,
@@ -436,10 +442,10 @@ def a_sigma_w(
     K_XX_noisy_chol: torch.Tensor,
     K_XW: torch.Tensor,
 ) -> torch.Tensor:
-    """A · Σ_ν · 1_W = A_KZW − A_KZX · (K_XX + σ²I)⁻¹ · K_XW (unscaled).
+    r"""Unscaled :math:`A \Sigma_\nu 1_W = A\_KZW - A\_KZX\,(K_{XX} + \sigma^2 I)^{-1} K_{XW}`.
 
-    The second term is evaluated as ``(K_XWᵀ @ sol)ᵀ`` — the same accumulation
-    order linear_operator's lazy matmul uses — for bit-parity with the legacy
+    The second term is evaluated as ``(K_XW.T @ sol).T`` -- the same accumulation
+    order linear_operator's lazy matmul uses -- for bit-parity with the legacy
     implementation.
     """
     sol = torch.cholesky_solve(A_KZX.T, K_XX_noisy_chol, upper=False)
@@ -447,7 +453,7 @@ def a_sigma_w(
 
 
 def aea(AKA: torch.Tensor, A_KZX: torch.Tensor, K_XX_noisy_chol: torch.Tensor) -> torch.Tensor:
-    """A · Σ_ν · Aᵀ (unscaled): AKZZA − A_KZX (K+σ²I)⁻¹ A_KZXᵀ, symmetrized."""
+    r"""Unscaled :math:`A \Sigma_\nu A^\top`: :math:`AKZZA - A\_KZX\,(K+\sigma^2 I)^{-1} A\_KZX^\top`, symmetrized."""
     Y = torch.linalg.solve_triangular(K_XX_noisy_chol, A_KZX.T, upper=False)
     out = AKA - Y.T @ Y
     return 0.5 * (out + out.T)
@@ -456,10 +462,12 @@ def aea(AKA: torch.Tensor, A_KZX: torch.Tensor, K_XX_noisy_chol: torch.Tensor) -
 def affine_posterior_mean(
     A_KZX: torch.Tensor, gp_tensors: GPTensors, K_XX_noisy_chol: torch.Tensor
 ) -> torch.Tensor:
-    """Posterior property mean A μ_ν in the original output scale.
+    r"""Posterior property mean :math:`A \mu_\nu` in the original output scale.
 
-    The constant-mean / row-sum-zero structure of A makes all prior-mean terms
-    vanish, leaving A_KZX (K+σ²I)⁻¹ (y_std − m) rescaled by the empirical std.
+    The constant-mean / row-sum-zero structure of :math:`A` makes all
+    prior-mean terms vanish, leaving
+    :math:`A\_KZX\,(K+\sigma^2 I)^{-1}\,(y_\mathrm{std} - m)` rescaled by the
+    empirical std.
     """
     resid = (gp_tensors.train_y_std - gp_tensors.mean_const).reshape(-1, 1)
     sol = torch.cholesky_solve(resid, K_XX_noisy_chol, upper=False).reshape(-1)
@@ -488,7 +496,7 @@ def shapleig_utilities(
     noisy_var_diag: torch.Tensor,
     emp_std: torch.Tensor,
 ) -> torch.Tensor:
-    """Closed-form GOODE EIG per candidate: −log(1 − qᵀ(AΣAᵀ)⁻¹q / Var[y])."""
+    r"""Closed-form GOODE EIG per candidate: :math:`-\log(1 - q^\top (A\Sigma A^\top)^{-1} q / \mathrm{Var}[y])`."""
     L = _psd_chol(AEA_unscaled)
     Y = torch.linalg.solve_triangular(L, B_unscaled, upper=False)
     Q_diag = Y.square().sum(dim=0) * emp_std**2

--- a/src/shapiq/approximator/shapleig/_shapley_math.py
+++ b/src/shapiq/approximator/shapleig/_shapley_math.py
@@ -1,0 +1,533 @@
+"""Shapley-value math core for ShaplEIG (ESP-accelerated, tensor-in/tensor-out).
+
+Maintainer note: this module is a controlled copy of the validated reference
+implementation from the ShaplEIG research codebase (the code accompanying the
+paper). Changes are developed and validated there first, then ported here
+verbatim.
+
+All functions are pure: they take plain tensors (kernel lengthscales, outputscale,
+binary training coalitions, standardized targets, noise) and never touch a GP
+object. The Shapley weights are baked into the generating-polynomial (elementary
+symmetric polynomial, ESP) math — no explicit affine matrix ``A`` or coalition
+enumeration ``Z`` is ever formed, so everything is O(poly(p)) in the number of
+players regardless of the 2^p coalition space.
+
+Notation (paper: "ShaplEIG: Bayesian Experimental Design for Shapley Value
+Estimation"):
+    p   number of players;  t  number of queried coalitions (training points)
+    A   the (p × 2^p) Shapley affine operator (implicit)
+    K   weighted Hamming product kernel over binary coalitions
+    A_KZW   = A · K(Z, W)            (p × |W|), computed via ESP
+    AKZZA   = A · K(Z, Z) · Aᵀ       (p × p),   computed via ESP
+    AEA     = A · Σ_ν · Aᵀ (unscaled posterior property covariance)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+from linear_operator.utils.cholesky import psd_safe_cholesky
+
+DTYPE = torch.float64
+
+__all__ = [
+    "GPTensors",
+    "ShaplEIGCache",
+    "a_kzw",
+    "a_sigma_w",
+    "aea",
+    "affine_posterior_mean",
+    "akzza",
+    "hamming_kernel",
+    "kernel_alpha_beta",
+    "noisy_posterior_variance",
+    "shapleig_utilities",
+]
+
+
+# ---------------------------------------------------------------------------
+# Plain tensors extracted from a fitted GP (the §4.0 seam)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GPTensors:
+    """Everything the SV math needs from a fitted Hamming GP, as plain tensors.
+
+    All quantities live in the *standardized* output space of the GP except
+    ``emp_mean`` / ``emp_std`` which describe the standardization itself.
+    """
+
+    train_X: torch.Tensor  # (t, p) binary coalitions
+    train_y_std: torch.Tensor  # (t,) standardized targets
+    lengthscales: torch.Tensor  # (p,)
+    outputscale: torch.Tensor  # scalar
+    noise: torch.Tensor  # scalar likelihood noise (standardized space)
+    mean_const: torch.Tensor  # scalar constant mean (standardized space)
+    emp_mean: torch.Tensor  # scalar empirical mean of raw targets
+    emp_std: torch.Tensor  # scalar empirical std of raw targets
+
+    @staticmethod
+    def from_botorch(model) -> GPTensors:
+        """Extract tensors from a (botorch) ``SingleTaskGP``-like model.
+
+        This is the only place that reaches into model internals; the math
+        below never does.
+        """
+        with torch.no_grad():
+            noise = model.likelihood.noise.detach().reshape(-1).to(DTYPE)
+            assert torch.allclose(noise, noise[0]), (
+                "GPTensors assumes homoskedastic noise; got per-point noise levels that differ."
+            )
+            train_X = model.train_inputs[0].detach().to(DTYPE)
+            if hasattr(model, "input_transform"):
+                # The stored train_inputs are already transformed in eval mode;
+                # in train mode botorch stores raw inputs. Normalize via the
+                # transform to be safe (idempotent for binary identity cases).
+                train_X = model.input_transform(train_X).to(DTYPE)
+            return GPTensors(
+                train_X=train_X,
+                train_y_std=model.train_targets.detach().to(DTYPE).reshape(-1),
+                lengthscales=model.covar_module.base_kernel.lengthscale.detach()
+                .reshape(-1)
+                .to(DTYPE),
+                outputscale=model.covar_module.outputscale.detach().to(DTYPE),
+                noise=noise[0],
+                mean_const=model.mean_module.constant.detach().to(DTYPE),
+                emp_mean=model.outcome_transform.means.detach().reshape(-1)[0].to(DTYPE),
+                emp_std=model.outcome_transform.stdvs.detach().reshape(-1)[0].to(DTYPE),
+            )
+
+    @property
+    def p(self) -> int:
+        """Number of players (input dimension)."""
+        return self.train_X.shape[1]
+
+
+# ---------------------------------------------------------------------------
+# Kernel primitives
+# ---------------------------------------------------------------------------
+
+
+def kernel_alpha_beta(
+    lengthscales: torch.Tensor, outputscale: torch.Tensor, dtype: torch.dtype = DTYPE
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-player match/mismatch kernel factors of the Hamming product kernel.
+
+    The weighted Hamming kernel k(z, w) = s · exp(-mean_d 1[z_d ≠ w_d]/ℓ_d)
+    factorizes as prod_d f_d with f_d = α_d if z_d = w_d else β_d, where the
+    outputscale s is distributed evenly across players (α_d = s^{1/p}).
+    """
+    ls = lengthscales.detach().reshape(-1).to(dtype)
+    p = ls.numel()
+    s = outputscale.detach().to(dtype=dtype, device=ls.device)
+    factor = s.pow(1.0 / p)
+    alpha = torch.full((p,), factor.item(), dtype=dtype, device=ls.device)
+    beta = torch.exp(-torch.ones(p, dtype=dtype, device=ls.device) / (ls * p)) * factor
+    return alpha, beta
+
+
+def hamming_kernel(
+    X1: torch.Tensor,
+    X2: torch.Tensor,
+    lengthscales: torch.Tensor,
+    outputscale: torch.Tensor,
+) -> torch.Tensor:
+    """Dense weighted Hamming product kernel matrix s · exp(-mean(δ/ℓ)).
+
+    Pure-tensor counterpart of the surrogate's kernel module (botorch's
+    ``CategoricalKernel``): the math core takes plain lengthscale/outputscale
+    tensors and never touches gpytorch kernel objects.
+    """
+    ls = lengthscales.reshape(-1).to(X1.dtype)
+    delta = (X1.unsqueeze(-2) != X2.unsqueeze(-3)).to(X1.dtype)
+    dists = (delta / ls).mean(-1)
+    return outputscale.to(X1.dtype) * torch.exp(-dists)
+
+
+# ---------------------------------------------------------------------------
+# ESP-accelerated A · K(Z, W)
+# ---------------------------------------------------------------------------
+
+
+@torch.no_grad()
+def a_kzw(
+    W: torch.Tensor,
+    lengthscales: torch.Tensor,
+    outputscale: torch.Tensor,
+    chunk_size: int = 1024,
+) -> torch.Tensor:
+    """Compute A · K(Z, W) for binary coalitions ``W`` (shape (T, p)) → (p, T).
+
+    **Vanilla (paper) ESP route, in coefficient representation**: for each w,
+    the generating polynomial ∏_r (γ_r + δ_r ζ) is built incrementally as
+    prefix and suffix coefficient tables (max-normalized per step, log-scale
+    tracked); per player j the prefix(j)·suffix(j+1) product is formed by
+    convolution and contracted with the Shapley size weights (Theorem B.1).
+    This is the variant published with the paper.
+    """
+    assert W.ndim == 2
+    alpha, beta = kernel_alpha_beta(lengthscales, outputscale)
+    chunks = []
+    for start in range(0, W.shape[0], chunk_size):
+        chunks.append(_a_kz_batch_coeff(W[start : start + chunk_size], alpha, beta))
+    return torch.cat(chunks, dim=1)
+
+
+def _a_kz_batch_coeff(batch: torch.Tensor, alpha: torch.Tensor, beta: torch.Tensor) -> torch.Tensor:
+    dtype = alpha.dtype
+    device = alpha.device
+    batch = batch.to(device=device, dtype=dtype)
+    batch_size, p = batch.shape
+    tiny = torch.finfo(dtype).tiny
+
+    gamma = torch.where(batch == 0, alpha.unsqueeze(0), beta.unsqueeze(0))
+    delta = torch.where(batch == 0, beta.unsqueeze(0), alpha.unsqueeze(0))
+    w_in, w_out = _shapley_weights_signed(p, dtype=dtype, device=device)
+
+    # Step 1: prefix and suffix coefficient tables across factor products
+    # (forward and backward direction), max-normalized with log-scale tracking.
+    def get_iter_coeff_tables(suffix: bool = False):
+        _coeff_tables: list[torch.Tensor] = [torch.empty(0)] * (p + 1)
+        _log_scales = torch.zeros((p + 1, batch_size), dtype=dtype, device=device)
+        _coeff_tables[0 if not suffix else p] = torch.ones(
+            (batch_size, 1), dtype=dtype, device=device
+        )
+        _range = range(p) if not suffix else range(p - 1, -1, -1)
+        for r in _range:
+            prev_index = r if not suffix else r + 1
+            next_index = r + 1 if not suffix else r
+            prev_table = _coeff_tables[prev_index]
+            curr_table = torch.zeros(
+                (batch_size, prev_table.shape[1] + 1), dtype=dtype, device=device
+            )
+            curr_table[:, :-1] += gamma[:, r : r + 1] * prev_table
+            curr_table[:, 1:] += delta[:, r : r + 1] * prev_table
+            scales = curr_table.abs().amax(dim=1).clamp_min(tiny)
+            _coeff_tables[next_index] = curr_table / scales.unsqueeze(1)
+            _log_scales[next_index, :] = _log_scales[prev_index, :] + torch.log(scales)
+        return _coeff_tables, _log_scales
+
+    prefix_coeffs, prefix_log_scales = get_iter_coeff_tables(suffix=False)
+    suffix_coeffs, suffix_log_scales = get_iter_coeff_tables(suffix=True)
+
+    # Step 2: per player j, convolve prefix(j) with suffix(j+1) and contract
+    # with the Shapley weights (Theorem B.1), undoing the normalization scales.
+    out = torch.empty((p, batch_size), dtype=dtype, device=device)
+    for j in range(p):
+        prefix_table = prefix_coeffs[j]
+        suffix_table = suffix_coeffs[j + 1]
+        suffix_table_len = suffix_table.shape[1]
+
+        d = torch.zeros((batch_size, p), dtype=dtype, device=device)
+        for i in range(prefix_table.shape[1]):
+            d[:, i : i + suffix_table_len] += prefix_table[:, i : i + 1] * suffix_table
+
+        total_scale = torch.exp(prefix_log_scales[j] + suffix_log_scales[j + 1])
+        out[j, :] = (delta[:, j] * (d @ w_in[1:]) + gamma[:, j] * (d @ w_out[:-1])) * total_scale
+
+    return out.contiguous()
+
+
+def _shapley_weights_signed(
+    p: int, dtype: torch.dtype, device
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Signed Shapley size weights incl. the 1/p factor (w_out negative)."""
+    w_in = torch.zeros(p + 1, dtype=dtype, device=device)
+    w_out = torch.zeros(p + 1, dtype=dtype, device=device)
+    for k in range(1, p + 1):
+        w_in[k] = 1.0 / (math.comb(p - 1, k - 1) * p)
+    for k in range(p):
+        w_out[k] = -1.0 / (math.comb(p - 1, k) * p)
+    return w_in, w_out
+
+
+# ---------------------------------------------------------------------------
+# ESP-accelerated A · K(Z, Z) · Aᵀ
+# ---------------------------------------------------------------------------
+
+
+def _shapley_w_in_out(p: int, dtype: torch.dtype, device) -> tuple[torch.Tensor, torch.Tensor]:
+    """Unsigned Shapley size weights without the 1/p factor (applied as 1/p² outside)."""
+    w_in = torch.zeros(p + 1, dtype=dtype, device=device)
+    w_out = torch.zeros(p + 1, dtype=dtype, device=device)
+    for a in range(1, p + 1):
+        w_in[a] = 1.0 / math.comb(p - 1, a - 1)
+    for a in range(p):
+        w_out[a] = 1.0 / math.comb(p - 1, a)
+    return w_in, w_out
+
+
+@torch.no_grad()
+def akzza(lengthscales: torch.Tensor, outputscale: torch.Tensor) -> torch.Tensor:
+    """Compute A · K(Z, Z) · Aᵀ (p × p) via bivariate generating polynomials.
+
+    For each player pair (i, j) the double sum over coalition pairs collapses
+    into a contraction of prefix/suffix coefficient tables of the bivariate
+    generating polynomial ∏_r (α_r + β_r ζ₁ + β_r ζ₂ + α_r ζ₁ζ₂); tables are
+    max-normalized per step with log-scale tracking for numerical stability.
+    """
+    alpha, beta = kernel_alpha_beta(lengthscales, outputscale)
+    p = alpha.numel()
+    dtype = alpha.dtype
+    device = alpha.device
+    tiny = torch.finfo(dtype).tiny
+
+    w_in, w_out = _shapley_w_in_out(p, dtype=dtype, device=device)
+
+    # Shifted weight vectors contracted into the tables' trailing dimension.
+    O0 = w_out.clone()
+    O1 = torch.zeros(p + 1, dtype=dtype, device=device)
+    O1[:p] = w_out[1:]
+    I1 = torch.zeros(p + 1, dtype=dtype, device=device)
+    I1[:p] = w_in[1:]
+    I2 = torch.zeros(p + 1, dtype=dtype, device=device)
+    I2[: p - 1] = w_in[2:]
+
+    LEFT_T = torch.stack([O0, O1, I1, I2]).T.contiguous()  # (p+1, 4)
+    RIGHT_T = torch.stack([O0, O1, I1, I2]).T.contiguous()  # (p+1, 4)
+
+    ps = p + 1
+    alpha_cpu = alpha.tolist()
+    beta_cpu = beta.tolist()
+
+    P_left_curr = torch.zeros((ps, ps, 4), dtype=dtype, device=device)
+    P_left_new = torch.empty_like(P_left_curr)
+    suffix_contr_i = torch.zeros((p, ps, ps, 4), dtype=dtype, device=device)
+    suffix_log_i = torch.zeros(p, dtype=dtype, device=device)
+    S_right_prev = torch.zeros((ps, ps, 4), dtype=dtype, device=device)
+    S_right_new = torch.empty_like(S_right_prev)
+
+    AKZZA = torch.zeros((p, p), dtype=dtype, device=device)
+
+    for i in range(p):
+        factors_wo_i = [r for r in range(p) if r != i]
+        nf = len(factors_wo_i)
+
+        S_right_prev.zero_()
+        S_right_new.zero_()
+        suffix_contr_i.zero_()
+        suffix_log_i.zero_()
+
+        S_right_prev[0, :, :] = RIGHT_T
+        log_S = 0.0
+
+        # Backward pass: contracted suffix tables for all split points.
+        for k in range(nf - 1, -1, -1):
+            r = factors_wo_i[k]
+            a_j, b_j = alpha[r], beta[r]
+
+            S_right_new = a_j * S_right_prev
+            S_right_new[1:, :, :] += b_j * S_right_prev[:-1, :, :]
+            S_right_new[:, :-1, :] += b_j * S_right_prev[:, 1:, :]
+            S_right_new[1:, :-1, :] += a_j * S_right_prev[:-1, 1:, :]
+
+            s_new = S_right_new.abs().max().clamp_min(tiny)
+            S_right_new = S_right_new / s_new
+            log_S = log_S + s_new.log().item()
+
+            suffix_contr_i[k] = S_right_new
+            suffix_log_i[k] = log_S
+            S_right_prev = S_right_new
+
+        # Diagonal entry (i, i).
+        P_left_curr.zero_()
+        P_left_curr[:, 0, :] = LEFT_T
+        log_P = 0.0
+
+        contracted_diag = torch.einsum("abl,abr->lr", P_left_curr, suffix_contr_i[0])
+        scale_diag = log_P + suffix_log_i[0].item()
+
+        ai_v = alpha_cpu[i]
+        bi_v = beta_cpu[i]
+        diag_val = ai_v * (contracted_diag[2, 2] + contracted_diag[0, 0]) - bi_v * (
+            contracted_diag[2, 0] + contracted_diag[0, 2]
+        )
+        AKZZA[i, i] = diag_val.item() * math.exp(scale_diag) / (p * p)
+
+        # Forward pass: off-diagonal entries (i, j) for j < i (symmetric fill).
+        for m in range(nf):
+            j = factors_wo_i[m]
+
+            if j > i:
+                continue
+
+            aj_v = alpha_cpu[j]
+            bj_v = beta_cpu[j]
+
+            if m < nf - 1:
+                s_idx = m + 1
+                contracted = torch.einsum("abl,abr->lr", P_left_curr, suffix_contr_i[s_idx])
+                scale = log_P + suffix_log_i[s_idx].item()
+            else:
+                contracted = torch.einsum("bl,br->lr", P_left_curr[0, :, :], RIGHT_T)
+                scale = log_P
+
+            val = (
+                (
+                    ai_v * aj_v * contracted[0, 0]
+                    + bi_v * aj_v * contracted[0, 1]
+                    - ai_v * bj_v * contracted[0, 2]
+                    - bi_v * bj_v * contracted[0, 3]
+                    + ai_v * bj_v * contracted[1, 0]
+                    + bi_v * bj_v * contracted[1, 1]
+                    - ai_v * aj_v * contracted[1, 2]
+                    - bi_v * aj_v * contracted[1, 3]
+                    - bi_v * aj_v * contracted[2, 0]
+                    - ai_v * aj_v * contracted[2, 1]
+                    + bi_v * bj_v * contracted[2, 2]
+                    + ai_v * bj_v * contracted[2, 3]
+                    - bi_v * bj_v * contracted[3, 0]
+                    - ai_v * bj_v * contracted[3, 1]
+                    + bi_v * aj_v * contracted[3, 2]
+                    + ai_v * aj_v * contracted[3, 3]
+                ).item()
+                * math.exp(scale)
+                / (p * p)
+            )
+
+            AKZZA[i, j] = val
+            AKZZA[j, i] = val
+
+            a_j, b_j = alpha[j], beta[j]
+            P_left_new = a_j * P_left_curr
+            P_left_new[:-1, :, :] += b_j * P_left_curr[1:, :, :]
+            P_left_new[:, 1:, :] += b_j * P_left_curr[:, :-1, :]
+            P_left_new[:-1, 1:, :] += a_j * P_left_curr[1:, :-1, :]
+
+            s_new = P_left_new.abs().max().clamp_min(tiny)
+            P_left_new = P_left_new / s_new
+            log_P = log_P + s_new.log().item()
+            P_left_curr = P_left_new
+
+    return AKZZA
+
+
+def psd_chol(M: torch.Tensor) -> torch.Tensor:
+    """Jitter-escalating Cholesky; identical routine to the legacy implementation."""
+    return psd_safe_cholesky(M)
+
+
+#: Backwards-compatible private alias (the reference implementation uses it).
+_psd_chol = psd_chol
+
+
+def noisy_train_kernel(gp_tensors: GPTensors) -> torch.Tensor:
+    """K(X, X) + σ² I on the training coalitions (standardized space)."""
+    K = hamming_kernel(
+        gp_tensors.train_X,
+        gp_tensors.train_X,
+        gp_tensors.lengthscales,
+        gp_tensors.outputscale,
+    )
+    return K + gp_tensors.noise * torch.eye(K.shape[0], dtype=K.dtype, device=K.device)
+
+
+def a_sigma_w(
+    A_KZW: torch.Tensor,
+    A_KZX: torch.Tensor,
+    K_XX_noisy_chol: torch.Tensor,
+    K_XW: torch.Tensor,
+) -> torch.Tensor:
+    """A · Σ_ν · 1_W = A_KZW − A_KZX · (K_XX + σ²I)⁻¹ · K_XW (unscaled).
+
+    The second term is evaluated as ``(K_XWᵀ @ sol)ᵀ`` — the same accumulation
+    order linear_operator's lazy matmul uses — for bit-parity with the legacy
+    implementation.
+    """
+    sol = torch.cholesky_solve(A_KZX.T, K_XX_noisy_chol, upper=False)
+    return A_KZW - (K_XW.mT @ sol).mT
+
+
+def aea(AKA: torch.Tensor, A_KZX: torch.Tensor, K_XX_noisy_chol: torch.Tensor) -> torch.Tensor:
+    """A · Σ_ν · Aᵀ (unscaled): AKZZA − A_KZX (K+σ²I)⁻¹ A_KZXᵀ, symmetrized."""
+    Y = torch.linalg.solve_triangular(K_XX_noisy_chol, A_KZX.T, upper=False)
+    out = AKA - Y.T @ Y
+    return 0.5 * (out + out.T)
+
+
+def affine_posterior_mean(
+    A_KZX: torch.Tensor, gp_tensors: GPTensors, K_XX_noisy_chol: torch.Tensor
+) -> torch.Tensor:
+    """Posterior property mean A μ_ν in the original output scale.
+
+    The constant-mean / row-sum-zero structure of A makes all prior-mean terms
+    vanish, leaving A_KZX (K+σ²I)⁻¹ (y_std − m) rescaled by the empirical std.
+    """
+    resid = (gp_tensors.train_y_std - gp_tensors.mean_const).reshape(-1, 1)
+    sol = torch.cholesky_solve(resid, K_XX_noisy_chol, upper=False).reshape(-1)
+    return (A_KZX @ sol) * gp_tensors.emp_std
+
+
+def noisy_posterior_variance(
+    W: torch.Tensor, gp_tensors: GPTensors, K_XX_noisy_chol: torch.Tensor
+) -> torch.Tensor:
+    """Diag Var[y(w)] at candidate coalitions, in the original output scale."""
+    K_XW = hamming_kernel(
+        gp_tensors.train_X,
+        W.to(gp_tensors.train_X.dtype),
+        gp_tensors.lengthscales,
+        gp_tensors.outputscale,
+    )
+    Y = torch.linalg.solve_triangular(K_XX_noisy_chol, K_XW, upper=False)
+    prior_diag = gp_tensors.outputscale + gp_tensors.noise  # k(w, w) = outputscale
+    var_std = prior_diag - Y.square().sum(dim=0)
+    return var_std * gp_tensors.emp_std**2
+
+
+def shapleig_utilities(
+    AEA_unscaled: torch.Tensor,
+    B_unscaled: torch.Tensor,
+    noisy_var_diag: torch.Tensor,
+    emp_std: torch.Tensor,
+) -> torch.Tensor:
+    """Closed-form GOODE EIG per candidate: −log(1 − qᵀ(AΣAᵀ)⁻¹q / Var[y])."""
+    L = _psd_chol(AEA_unscaled)
+    Y = torch.linalg.solve_triangular(L, B_unscaled, upper=False)
+    Q_diag = Y.square().sum(dim=0) * emp_std**2
+    R = (Q_diag / noisy_var_diag.clamp_min(1e-30)).clamp(min=0.0, max=1.0 - 1e-12)
+    return -torch.log1p(-R)
+
+
+# ---------------------------------------------------------------------------
+# Explicit cache for the incremental no-refit fast path
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ShaplEIGCache:
+    """State reused across BED iterations when GP hyperparameters are frozen.
+
+    Replaces the hidden ``object.__setattr__`` mutation cluster of the legacy
+    implementation: every recycled quantity is an explicit field here.
+    """
+
+    A_KZX: torch.Tensor | None = None  # (p, t)   A · K(Z, X_train)
+    A_KZW: torch.Tensor | None = None  # (p, S)   A · K(Z, candidates)
+    AKA: torch.Tensor | None = None  # (p, p)   A · K(Z,Z) · Aᵀ (HP-only)
+    AEA_unscaled: torch.Tensor | None = None  # (p, p) property covariance (unscaled)
+    K_chol: torch.Tensor | None = None  # (t, t)  chol(K(X,X) + σ²I), current data/HPs
+    candidates: torch.Tensor | None = None  # (S, p) candidate set of the last call
+    num_candidates: int | None = None
+
+    def reset(self) -> None:
+        """Invalidate all cached quantities."""
+        self.A_KZX = None
+        self.A_KZW = None
+        self.AKA = None
+        self.AEA_unscaled = None
+        self.K_chol = None
+        self.candidates = None
+        self.num_candidates = None
+
+    def append_train_column(self, new_col: torch.Tensor) -> None:
+        """Append the A.K(Z,x) column of a newly queried point to A_KZX."""
+        assert self.A_KZX is not None
+        self.A_KZX = torch.cat([self.A_KZX, new_col.reshape(-1, 1)], dim=1)
+
+    def drop_candidate_column(self, idx: int) -> None:
+        """Remove a selected candidate column from A_KZW."""
+        assert self.A_KZW is not None
+        self.A_KZW = torch.cat([self.A_KZW[:, :idx], self.A_KZW[:, idx + 1 :]], dim=1)

--- a/src/shapiq/approximator/shapleig/_shapley_math.py
+++ b/src/shapiq/approximator/shapleig/_shapley_math.py
@@ -27,8 +27,13 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
-import torch
-from linear_operator.utils.cholesky import psd_safe_cholesky
+try:
+    import torch
+    from linear_operator.utils.cholesky import psd_safe_cholesky
+except ImportError as err:
+    from ._error import _shapleig_import_error
+
+    raise _shapleig_import_error from err
 
 DTYPE = torch.float64
 

--- a/src/shapiq/approximator/shapleig/_surrogate.py
+++ b/src/shapiq/approximator/shapleig/_surrogate.py
@@ -75,23 +75,34 @@ class HammingGP:
         }
         self.amount_restarts = amount_restarts
 
-        # The model must be CONSTRUCTED under a float64 default dtype: torch
-        # creates parameters, prior/constraint buffers, and the constraints'
-        # initial values in the default dtype before botorch casts the model
-        # to the (float64) data. Under a float32 default these starting
-        # values are truncated and L-BFGS converges to (slightly) different
-        # hyperparameters, changing the coalition selections. The default is
-        # restored right after construction; all downstream computations are
-        # float64 because the data and parameters are.
-        previous_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(torch.float64)
+        torch_default_dtype = torch.get_default_dtype()
         try:
+            # The model must be CONSTRUCTED under a float64 default dtype: torch
+            # creates parameters, prior/constraint buffers, and the constraints'
+            # initial values in the default dtype before botorch casts the model
+            # to the (float64) data. Under a float32 default these starting
+            # values are truncated and L-BFGS converges to (slightly) different
+            # hyperparameters, changing the coalition selections. The default is
+            # restored right after construction; all downstream computations are
+            # float64 because the data and parameters are
+            torch.set_default_dtype(torch.float64)
             self._build(train_X, train_Y)
         finally:
-            torch.set_default_dtype(previous_dtype)
+            torch.set_default_dtype(torch_default_dtype)
 
     def _build(self, train_X: torch.Tensor, train_Y: torch.Tensor) -> None:
         """Construct the botorch model (called under float64 default dtype)."""
+        if torch.get_default_dtype() is not torch.float64:
+            msg = (
+                "HammingGP._build must run under a float64 default dtype "
+                f"(found {torch.get_default_dtype()}); it is invoked from "
+                "__init__ inside a torch.set_default_dtype(torch.float64) "
+                "context. Constructing under float32 truncates the model's "
+                "parameter/prior/constraint initial values and silently "
+                "changes the fitted hyperparameters."
+            )
+            raise RuntimeError(msg)
+
         fixed_noise_level = self._init_kwargs["fixed_noise_level"]
         min_lengthscale = self._init_kwargs["min_lengthscale"]
         min_inferred_noise_level = self._init_kwargs["min_inferred_noise_level"]

--- a/src/shapiq/approximator/shapleig/_surrogate.py
+++ b/src/shapiq/approximator/shapleig/_surrogate.py
@@ -75,6 +75,27 @@ class HammingGP:
         }
         self.amount_restarts = amount_restarts
 
+        # The model must be CONSTRUCTED under a float64 default dtype: torch
+        # creates parameters, prior/constraint buffers, and the constraints'
+        # initial values in the default dtype before botorch casts the model
+        # to the (float64) data. Under a float32 default these starting
+        # values are truncated and L-BFGS converges to (slightly) different
+        # hyperparameters, changing the coalition selections. The default is
+        # restored right after construction; all downstream computations are
+        # float64 because the data and parameters are.
+        previous_dtype = torch.get_default_dtype()
+        torch.set_default_dtype(torch.float64)
+        try:
+            self._build(train_X, train_Y)
+        finally:
+            torch.set_default_dtype(previous_dtype)
+
+    def _build(self, train_X: torch.Tensor, train_Y: torch.Tensor) -> None:
+        """Construct the botorch model (called under float64 default dtype)."""
+        fixed_noise_level = self._init_kwargs["fixed_noise_level"]
+        min_lengthscale = self._init_kwargs["min_lengthscale"]
+        min_inferred_noise_level = self._init_kwargs["min_inferred_noise_level"]
+
         d = train_X.shape[-1]
         lengthscale_prior = LogNormalPrior(loc=math.sqrt(2) + math.log(d) * 0.5, scale=math.sqrt(3))
         # Over binary inputs, botorch's CategoricalKernel is exactly the

--- a/src/shapiq/approximator/shapleig/_surrogate.py
+++ b/src/shapiq/approximator/shapleig/_surrogate.py
@@ -1,0 +1,160 @@
+"""Hamming-kernel GP surrogate over binary coalition vectors.
+
+Flat, self-contained surrogate for the ShaplEIG approximator (the research
+repository uses a richer surrogate hierarchy; this copy keeps only what
+ShaplEIG needs). It fits directly on binary coalition vectors — no input
+transform — and exposes the fitted state as plain tensors via
+:meth:`HammingGP.tensors`, which is the only surface the Shapley math core
+consumes.
+
+Maintainer note: this module is a controlled copy of the validated reference
+implementation from the ShaplEIG research codebase (the code accompanying the
+paper). Changes are developed and validated there first, then ported here.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+import torch
+from botorch.fit import fit_gpytorch_mll
+from botorch.models.gp_regression_mixed import SingleTaskGP
+from botorch.models.kernels.categorical import CategoricalKernel
+from botorch.models.transforms import Standardize
+from gpytorch.constraints.constraints import GreaterThan
+from gpytorch.kernels import ScaleKernel
+from gpytorch.likelihoods.gaussian_likelihood import GaussianLikelihood
+from gpytorch.mlls import ExactMarginalLogLikelihood
+from gpytorch.priors.torch_priors import LogNormalPrior
+
+from ._shapley_math import GPTensors
+
+log = logging.getLogger(__name__)
+
+
+class HammingGP:
+    """Exact single-output GP with a scaled Hamming product kernel."""
+
+    def __init__(
+        self,
+        train_X: torch.Tensor,
+        train_Y: torch.Tensor,
+        *,
+        fixed_noise_level: float | None = 1e-6,
+        min_lengthscale: float = 1e-6,
+        min_inferred_noise_level: float = 1e-4,
+        amount_restarts: int = 5,
+    ) -> None:
+        """Build the GP on binary coalitions ``train_X`` and values ``train_Y``.
+
+        Args:
+            train_X: Binary coalition matrix of shape ``(t, n_players)``.
+            train_Y: Coalition values of shape ``(t, 1)``.
+            fixed_noise_level: Fixed observation noise for (near-)noiseless
+                games, in STANDARDIZED output units (i.e. relative to Var(y)):
+                the GP runs with exactly this noise variance after output
+                standardization, independent of the output scale. Must be
+                >= 1e-6 (gpytorch's hard floor). ``None`` infers the noise via
+                a ``GaussianLikelihood``.
+            min_lengthscale: Lower bound for the per-player ARD lengthscales.
+            min_inferred_noise_level: Lower noise bound when noise is learned.
+            amount_restarts: Maximum number of L-BFGS-B fitting attempts.
+        """
+        self._init_kwargs: dict = {
+            "fixed_noise_level": fixed_noise_level,
+            "min_lengthscale": min_lengthscale,
+            "min_inferred_noise_level": min_inferred_noise_level,
+            "amount_restarts": amount_restarts,
+        }
+        self.amount_restarts = amount_restarts
+
+        d = train_X.shape[-1]
+        lengthscale_prior = LogNormalPrior(loc=math.sqrt(2) + math.log(d) * 0.5, scale=math.sqrt(3))
+        # Over binary inputs, botorch's CategoricalKernel is exactly the
+        # weighted Hamming product kernel k(x,x') = exp(-mean_d 1[x_d != x'_d] / l_d).
+        base_kernel = CategoricalKernel(
+            ard_num_dims=d,
+            lengthscale_prior=lengthscale_prior,
+            lengthscale_constraint=GreaterThan(
+                min_lengthscale,
+                initial_value=max(lengthscale_prior.mode, min_lengthscale),
+            ),
+        )
+        covar_module = ScaleKernel(base_kernel)
+
+        if fixed_noise_level is not None:
+            # Pre-scale by std(y)^2 (replicating botorch's Standardize stdvs,
+            # incl. its small-std fallback) so that the noise is EXACTLY
+            # `fixed_noise_level` in standardized units after the transform.
+            stdvs = train_Y.std(dim=0, keepdim=True)
+            stdvs = torch.where(stdvs >= 1e-8, stdvs, torch.ones_like(stdvs))
+            train_Yvar = torch.full_like(train_Y, fixed_noise_level) * stdvs.pow(2)
+            likelihood = None
+        else:
+            train_Yvar = None
+            noise_prior = LogNormalPrior(loc=-4.0, scale=1.0)
+            likelihood = GaussianLikelihood(
+                noise_prior=noise_prior,
+                noise_constraint=GreaterThan(
+                    min_inferred_noise_level,
+                    initial_value=max(noise_prior.mode, min_inferred_noise_level),
+                ),
+            )
+
+        self._model = SingleTaskGP(
+            train_X=train_X,
+            train_Y=train_Y,
+            train_Yvar=train_Yvar,
+            likelihood=likelihood,
+            covar_module=covar_module,
+            outcome_transform=Standardize(m=1),
+        )
+
+    def fit(self) -> None:
+        """MAP hyperparameter fit (L-BFGS-B with restarts)."""
+        mll = ExactMarginalLogLikelihood(self._model.likelihood, self._model)
+        try:
+            # Stop at the first successful attempt (do not run all attempts
+            # and pick the best) — as in the reference implementation.
+            fit_gpytorch_mll(
+                mll,
+                max_attempts=self.amount_restarts,
+                pick_best_of_all_attempts=False,
+            )
+        except Exception:
+            # Keep running with the current hyperparameters, but make the
+            # failure visible.
+            log.exception(
+                "GP hyperparameter fit failed (with %d attempts); continuing "
+                "with current hyperparameters.",
+                self.amount_restarts,
+            )
+
+    def update_data(self, train_X: torch.Tensor, train_Y: torch.Tensor) -> None:
+        """Rebuild on new data, warmstarting from the current hyperparameters."""
+        old_model = self._model
+        was_eval = not old_model.training
+        rebuilt = HammingGP(train_X, train_Y, **self._init_kwargs)
+        source = dict(old_model.named_parameters())
+        with torch.no_grad():
+            for name, target in rebuilt._model.named_parameters():
+                src = source.get(name)
+                if src is not None and src.shape == target.shape:
+                    target.copy_(src.detach())
+        if was_eval:
+            rebuilt._model.eval()
+        self.__dict__.update(rebuilt.__dict__)
+
+    def posterior_variance_diag(
+        self, X: torch.Tensor, *, observation_noise: bool = False
+    ) -> torch.Tensor:
+        """Marginal posterior variances of ``X`` via the gpytorch posterior."""
+        with torch.no_grad():
+            posterior = self._model.posterior(X, observation_noise=observation_noise)
+            mvn = posterior.mvn  # ty: ignore[unresolved-attribute]
+            return mvn.lazy_covariance_matrix.diagonal(dim1=-2, dim2=-1)
+
+    def tensors(self) -> GPTensors:
+        """Plain-tensor view of the fitted surrogate, consumed by the math core."""
+        return GPTensors.from_botorch(self._model)

--- a/src/shapiq/approximator/shapleig/_surrogate.py
+++ b/src/shapiq/approximator/shapleig/_surrogate.py
@@ -17,18 +17,24 @@ from __future__ import annotations
 import logging
 import math
 
-import torch
-from botorch.fit import fit_gpytorch_mll
-from botorch.models.gp_regression_mixed import SingleTaskGP
-from botorch.models.kernels.categorical import CategoricalKernel
-from botorch.models.transforms import Standardize
-from gpytorch.constraints.constraints import GreaterThan
-from gpytorch.kernels import ScaleKernel
-from gpytorch.likelihoods.gaussian_likelihood import GaussianLikelihood
-from gpytorch.mlls import ExactMarginalLogLikelihood
-from gpytorch.priors.torch_priors import LogNormalPrior
+try:
+    import torch
+    from botorch.fit import fit_gpytorch_mll
+    from botorch.models.gp_regression_mixed import SingleTaskGP
+    from botorch.models.kernels.categorical import CategoricalKernel
+    from botorch.models.transforms import Standardize
+    from gpytorch.constraints.constraints import GreaterThan
+    from gpytorch.kernels import ScaleKernel
+    from gpytorch.likelihoods.gaussian_likelihood import GaussianLikelihood
+    from gpytorch.mlls import ExactMarginalLogLikelihood
+    from gpytorch.priors.torch_priors import LogNormalPrior
 
-from ._shapley_math import GPTensors
+    from ._shapley_math import GPTensors
+except ImportError as err:
+    from ._error import _shapleig_import_error
+
+    raise _shapleig_import_error from err
+
 
 log = logging.getLogger(__name__)
 

--- a/src/shapiq/approximator/shapleig/shapleig.py
+++ b/src/shapiq/approximator/shapleig/shapleig.py
@@ -1,0 +1,451 @@
+"""ShaplEIG: Bayesian experimental design for Shapley value estimation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+
+from shapiq.approximator.base import Approximator
+from shapiq.approximator.sampling import CoalitionSampler
+from shapiq.interaction_values import InteractionValues
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import torch
+
+    from shapiq.game import Game
+    from shapiq.typing import CoalitionMatrix, GameValues
+
+    from . import _shapley_math as sm
+    from ._surrogate import HammingGP
+
+ValidShaplEIGIndices = Literal["SV"]
+
+
+class ShaplEIG(Approximator[ValidShaplEIGIndices]):
+    """Bayesian experimental design (BED) approximator for Shapley values.
+
+    ShaplEIG fits a Gaussian process surrogate with a weighted Hamming product
+    kernel on the queried coalition values and sequentially selects the next
+    coalition to evaluate by maximizing the closed-form expected information
+    gain (EIG) about the Shapley values. The Shapley structure is handled via
+    elementary-symmetric-polynomial (ESP) identities of the kernel's
+    generating polynomials, so the full ``2^n`` coalition space is never
+    enumerated and each iteration costs only polynomial time in ``n``.
+    (``n``, shapiq's number of players, is denoted ``p`` in the paper.)
+
+    The returned :class:`~shapiq.interaction_values.InteractionValues` contain
+    the posterior-mean Shapley value estimates (order 1, index ``"SV"``).
+
+    Requires the optional ``shapleig`` extra
+    (``pip install shapiq[shapleig]``) for torch / gpytorch / botorch.
+
+    Example:
+        >>> from shapiq_games.synthetic import DummyGame
+        >>> from shapiq.approximator import ShaplEIG
+        >>> game = DummyGame(n=7, interaction=(1, 2))
+        >>> approximator = ShaplEIG(n=7, random_state=42, show_progress=False)
+        >>> values = approximator.approximate(budget=50, game=game)
+        >>> values.index, values.max_order
+        ('SV', 1)
+
+    References:
+        Rundel, D., et al. (2026). ShaplEIG: Bayesian Experimental Design for
+        Shapley Value Estimation.
+    """
+
+    valid_indices: tuple[ValidShaplEIGIndices, ...] = ("SV",)
+
+    def __init__(
+        self,
+        n: int,
+        *,
+        initial_design_size: int | None = None,
+        max_candidates: int | None = 1024,
+        refit: str = "every_iteration",
+        warmstart: bool = False,
+        show_progress: bool = True,
+        random_state: int | None = None,
+    ) -> None:
+        """Initialize the ShaplEIG approximator.
+
+        Args:
+            n: Number of players.
+            initial_design_size: Number of coalitions in the initial design
+                (drawn with the coalition sampler before the BED loop starts).
+                Defaults to ``n + 1``.
+            max_candidates: Maximum size of the sampled candidate set the EIG
+                is optimized over; games with fewer coalitions outside the
+                initial design fall back to the exhaustive candidate set (all
+                not-yet-evaluated coalitions). ``None`` forces the exhaustive
+                candidate set, which is feasible only for ``n <= 16``.
+                Defaults to ``1024``, as in the reference paper.
+            refit: When to refit the GP hyperparameters: ``"every_iteration"``
+                (default) or the staged schedule ``"init_64_factor_4"`` (every
+                iteration for the first 64, then every 8th for 128, every
+                16th for 256, every 32nd afterwards) for large budgets. The
+                final surrogate is always refit.
+            warmstart: If ``True``, hyperparameter refits start from the
+                previous iteration's fitted hyperparameters instead of fresh
+                initial values.
+            show_progress: Whether to display a tqdm progress bar over the
+                BED iterations.
+            random_state: Random state seeding both the coalition sampling
+                and the GP hyperparameter fitting. Defaults to ``None``.
+        """
+        # Optional dependencies of the `shapleig` extra: import in the
+        # constructor (never at package import time) so that a missing extra
+        # fails immediately with an actionable message.
+        try:
+            import torch  # noqa: F401
+
+            from . import (
+                _shapley_math,  # noqa: F401  (torch, linear-operator)
+                _surrogate,  # noqa: F401  (botorch, gpytorch)
+            )
+        except ImportError as err:
+            msg = (
+                "ShaplEIG requires the optional dependencies torch, gpytorch, "
+                "botorch, and linear-operator but they are not installed. "
+                "Install them with: pip install 'shapiq[shapleig]'"
+            )
+            raise ImportError(msg) from err
+
+        # ShaplEIG selects coalitions adaptively (EIG argmax), so the base
+        # class's sampling configuration must not suggest otherwise. Sampling
+        # enters only through the initial design and the candidate set, whose
+        # internal samplers follow the protocol of the reference paper
+        # (uniform coalition-size weights + pairing trick, `_coalition_sampler`).
+        super().__init__(
+            n=n,
+            max_order=1,
+            index="SV",
+            min_order=0,
+            sampling_weights=None,
+            pairing_trick=False,
+            random_state=random_state,
+        )
+        self.initial_design_size = (
+            int(initial_design_size) if initial_design_size is not None else n + 1
+        )
+        self.max_candidates = int(max_candidates) if max_candidates is not None else None
+        self.refit = refit
+        self.warmstart = warmstart
+        self.show_progress = show_progress
+
+    def approximate(
+        self,
+        budget: int,
+        game: Game | Callable[[CoalitionMatrix], GameValues],
+        **_: dict,
+    ) -> InteractionValues:
+        """Run the BED loop and return posterior-mean Shapley value estimates.
+
+        Args:
+            budget: Total number of game evaluations (initial design plus one
+                evaluation per BED iteration).
+            game: The game to approximate, as a callable mapping a binary
+                coalition matrix of shape ``(m, n)`` to ``m`` values.
+
+        Returns:
+            The estimated Shapley values as ``InteractionValues``.
+        """
+        if budget <= self.initial_design_size:
+            msg = (
+                f"Budget ({budget}) must exceed the initial design size "
+                f"({self.initial_design_size})."
+            )
+            raise ValueError(msg)
+
+        import torch
+
+        # The ESP math and the GP fitting require double precision throughout
+        # (float32 intermediates change fitted hyperparameters and thereby
+        # selections). Enforce float64 locally and restore the user's default.
+        previous_dtype = torch.get_default_dtype()
+        torch.set_default_dtype(torch.float64)
+        try:
+            return self._approximate(budget=budget, game=game)
+        finally:
+            torch.set_default_dtype(previous_dtype)
+
+    def _approximate(
+        self,
+        *,
+        budget: int,
+        game: Game | Callable[[CoalitionMatrix], GameValues],
+    ) -> InteractionValues:
+        """BED loop body (runs under enforced float64, see `approximate`)."""
+        import torch
+
+        from . import _shapley_math as sm
+
+        iterations = budget - self.initial_design_size
+
+        # Seed the GP hyperparameter fitting; the coalition sampling is seeded
+        # through `self._random_state` when the design samplers are built
+        # (kept current by `set_random_state`).
+        if self._random_state is not None:
+            torch.manual_seed(self._random_state)
+
+        archive_X, candidate_set = self._generate_design(iterations)
+        archive_Y = self._evaluate(game, archive_X)
+        baseline_value = self._baseline_value(game, archive_X, archive_Y)
+
+        gp = self._surrogate(archive_X, archive_Y)
+        cache = sm.ShaplEIGCache()
+
+        iterator = range(iterations)
+        if self.show_progress:
+            from tqdm import tqdm
+
+            iterator = tqdm(iterator, desc="ShaplEIG", unit="it")
+
+        best_idx: int | None = None
+        refit = True
+        for iteration_idx in iterator:
+            # --- surrogate (rebuild on refit — cold-started unless
+            # `warmstart`; hyperparameters frozen otherwise) ---
+            refit = self._refit_scheduled(iteration_idx)
+            if iteration_idx > 0:
+                if refit and not self.warmstart:
+                    gp = self._surrogate(archive_X, archive_Y)
+                else:
+                    gp.update_data(archive_X, archive_Y)
+            if refit:
+                gp.fit()
+
+            # --- EIG over the candidates; select and query ---
+            utilities = self._eig(
+                gp,
+                cache,
+                candidate_set,
+                no_refit_step=(iteration_idx > 0 and not refit),
+                prev_selected_idx=best_idx,
+            )
+            best_idx = int(torch.argmax(utilities))
+            new_x = candidate_set[best_idx : best_idx + 1]
+            new_y = self._evaluate(game, new_x)
+
+            archive_X = torch.cat([archive_X, new_x], dim=0)
+            archive_Y = torch.cat([archive_Y, new_y], dim=0)
+            candidate_set = torch.cat([candidate_set[:best_idx], candidate_set[best_idx + 1 :]])
+
+        # --- final surrogate (always refit) and posterior-mean SVs ---
+        if self.warmstart:
+            gp.update_data(archive_X, archive_Y)
+        else:
+            gp = self._surrogate(archive_X, archive_Y)
+        gp.fit()
+        gp_tensors = gp.tensors()
+        K_chol = sm.psd_chol(sm.noisy_train_kernel(gp_tensors))
+        A_KZX = sm.a_kzw(gp_tensors.train_X, gp_tensors.lengthscales, gp_tensors.outputscale)
+        shapley_values = sm.affine_posterior_mean(A_KZX, gp_tensors, K_chol)
+
+        # NOTE (future work, coordinated with the maintainers): the surrogate
+        # posterior also provides the marginal SV variances,
+        #   AEA = sm.aea(sm.akzza(ls, s), A_KZX, K_chol)  # noqa: ERA001
+        #   sv_variances = AEA.diagonal() * gp_tensors.emp_std**2  # noqa: ERA001
+        # Expose them via an `approximate_with_variance` once
+        # `InteractionValues` supports uncertainty information.
+
+        values = np.zeros(self.n + 1)
+        values[0] = baseline_value
+        values[1:] = shapley_values.numpy()
+        interaction_lookup: dict[tuple[int, ...], int] = {(): 0}
+        interaction_lookup |= {(i,): i + 1 for i in range(self.n)}
+        return InteractionValues(
+            values=values,
+            index="SV",
+            max_order=1,
+            min_order=0,
+            n_players=self.n,
+            interaction_lookup=interaction_lookup,
+            # Always flagged as estimated: even when the budget covers all
+            # 2^n coalitions, the GP posterior mean is subject to numerical
+            # inaccuracies (the estimator is consistent, not exact).
+            estimated=True,
+            estimation_budget=budget,
+            baseline_value=float(baseline_value),
+            target_index=self.index,
+        )
+
+    # ------------------------------------------------------------------
+    # building blocks
+    # ------------------------------------------------------------------
+
+    def _generate_design(self, iterations: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """Draw the initial design and the candidate set (binary, float64).
+
+        Both draws come from fresh, identically seeded coalition samplers
+        (:meth:`_coalition_sampler`):
+
+        - the initial design sampler draws exactly ``initial_design_size``
+          coalitions — its composition therefore does not depend on the
+          candidate budget;
+        - the candidate sampler draws the combined budget, keeping the first
+          ``candidate_size`` coalitions not already in the initial design.
+        """
+        import torch
+
+        init_size = self.initial_design_size
+        if self.max_candidates is None:
+            if self.n > 16:
+                msg = (
+                    "An exhaustive candidate set is infeasible for more than 16 "
+                    f"players (n={self.n}); set `max_candidates` to optimize the "
+                    "EIG over a sampled candidate subset instead."
+                )
+                raise ValueError(msg)
+            candidate_size = 2**self.n - init_size
+        else:
+            # `max_candidates` is an upper bound: small games fall back to the
+            # exhaustive candidate set (all coalitions outside the initial
+            # design).
+            candidate_size = min(self.max_candidates, 2**self.n - init_size)
+        if candidate_size < iterations:
+            msg = (
+                f"Budget requires {iterations} BED iterations but only "
+                f"{candidate_size} candidate coalitions are available; reduce "
+                "the budget (or increase `max_candidates` if the candidate set "
+                "is not already exhaustive)."
+            )
+            raise ValueError(msg)
+
+        initial_sampler = self._coalition_sampler()
+        initial_sampler.sample(init_size)
+        initial_design = torch.tensor(initial_sampler.coalitions_matrix)
+
+        candidate_sampler = self._coalition_sampler()
+        candidate_sampler.sample(init_size + candidate_size)
+        candidates = torch.tensor(candidate_sampler.coalitions_matrix)
+        in_initial_design = (
+            (candidates[:, None, :] == initial_design[None, :, :]).all(dim=2).any(dim=1)
+        )
+        candidates = candidates[~in_initial_design][:candidate_size, :]
+
+        return initial_design.to(torch.float64), candidates.to(torch.float64)
+
+    def _coalition_sampler(self) -> CoalitionSampler:
+        """Fresh seeded sampler with the reference design protocol.
+
+        Uniform coalition-size weights and the pairing trick, as in the
+        reference paper. A fresh sampler per draw keeps repeated
+        ``approximate`` calls on the same instance deterministic.
+        """
+        return CoalitionSampler(
+            n_players=self.n,
+            sampling_weights=np.ones(self.n + 1),
+            pairing_trick=True,
+            random_state=self._random_state,
+        )
+
+    def _surrogate(self, train_X: torch.Tensor, train_Y: torch.Tensor) -> HammingGP:
+        """Fresh (cold-start) surrogate on the current archive.
+
+        Uses the validated reference settings throughout (standardized fixed
+        noise ``1e-6``, minimum lengthscale ``1e-6``, 5 fitting attempts).
+        """
+        from ._surrogate import HammingGP
+
+        return HammingGP(train_X, train_Y)
+
+    def _refit_scheduled(self, iteration_idx: int) -> bool:
+        """Whether the GP hyperparameters are refit at this iteration."""
+        if self.refit == "every_iteration":
+            return True
+        if self.refit == "init_64_factor_4":
+            if iteration_idx < 64:
+                return True
+            if iteration_idx < 64 + 128:
+                return iteration_idx % 8 == 0
+            if iteration_idx < 64 + 128 + 256:
+                return iteration_idx % 16 == 0
+            return iteration_idx % 32 == 0
+        msg = f"Unknown refit schedule {self.refit!r}."
+        raise ValueError(msg)
+
+    def _eig(
+        self,
+        gp: HammingGP,
+        cache: sm.ShaplEIGCache,
+        candidates: torch.Tensor,
+        *,
+        no_refit_step: bool,
+        prev_selected_idx: int | None,
+    ) -> torch.Tensor:
+        """EIG utilities of the candidates under the current surrogate.
+
+        In a no-refit step the hyperparameters are unchanged: the cached
+        A·K(Z,Z)·Aᵀ is reused, the column of the last queried coalition is
+        appended to A·K(Z,X), and the selected candidate's column is dropped
+        from A·K(Z,W).
+        """
+        from . import _shapley_math as sm
+
+        gp_tensors = gp.tensors()
+        K_chol = sm.psd_chol(sm.noisy_train_kernel(gp_tensors))
+
+        if no_refit_step:
+            if prev_selected_idx is None:
+                msg = "No-refit steps require the previously selected index."
+                raise RuntimeError(msg)
+            new_col = sm.a_kzw(
+                gp_tensors.train_X[-1:],
+                gp_tensors.lengthscales,
+                gp_tensors.outputscale,
+            )[:, 0]
+            cache.append_train_column(new_col)
+            cache.drop_candidate_column(prev_selected_idx)
+            A_KZX, A_KZW, AKA = cache.A_KZX, cache.A_KZW, cache.AKA
+            if A_KZX is None or A_KZW is None or AKA is None:
+                msg = "No-refit step requires a populated cache."
+                raise RuntimeError(msg)
+        else:
+            A_KZX = sm.a_kzw(gp_tensors.train_X, gp_tensors.lengthscales, gp_tensors.outputscale)
+            A_KZW = sm.a_kzw(candidates, gp_tensors.lengthscales, gp_tensors.outputscale)
+            AKA = sm.akzza(gp_tensors.lengthscales, gp_tensors.outputscale)
+            cache.A_KZX, cache.A_KZW, cache.AKA = A_KZX, A_KZW, AKA
+
+        K_XW = sm.hamming_kernel(
+            gp_tensors.train_X,
+            candidates,
+            gp_tensors.lengthscales,
+            gp_tensors.outputscale,
+        )
+        B = sm.a_sigma_w(A_KZW, A_KZX, K_chol, K_XW)
+        AEA = sm.aea(AKA, A_KZX, K_chol)
+        noisy_var_diag = gp.posterior_variance_diag(candidates, observation_noise=True)
+        return sm.shapleig_utilities(AEA, B, noisy_var_diag, gp_tensors.emp_std)
+
+    @staticmethod
+    def _evaluate(
+        game: Game | Callable[[CoalitionMatrix], GameValues],
+        coalitions: torch.Tensor,
+    ) -> torch.Tensor:
+        """Query the game on binary coalitions; values as a ``(m, 1)`` tensor."""
+        import torch
+
+        values = game(coalitions.numpy().astype(bool))
+        return torch.as_tensor(values, dtype=torch.float64).reshape(-1, 1)
+
+    def _baseline_value(
+        self,
+        game: Game | Callable[[CoalitionMatrix], GameValues],
+        archive_X: torch.Tensor,
+        archive_Y: torch.Tensor,
+    ) -> float:
+        """Empty-coalition value (the game's baseline value).
+
+        The coalition sampler's border trick always places the empty coalition
+        in the initial design, so its value is read from the archive; querying
+        the game directly is a safety net only.
+        """
+        import torch
+
+        empty_rows = (archive_X.sum(dim=1) == 0).nonzero()
+        if len(empty_rows) > 0:
+            return float(archive_Y[int(empty_rows[0]), 0])
+        return float(self._evaluate(game, torch.zeros((1, self.n)))[0, 0])

--- a/src/shapiq/approximator/shapleig/shapleig.py
+++ b/src/shapiq/approximator/shapleig/shapleig.py
@@ -250,7 +250,7 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
             estimation_budget=budget,
             baseline_value=float(baseline_value),
             target_index=self.index,
-        ), np.zeros(self.n)  # TODO(david): return the correct variances once supported  # noqa: TD003
+        ), sv_variances.numpy()
 
     # ------------------------------------------------------------------
     # building blocks

--- a/src/shapiq/approximator/shapleig/shapleig.py
+++ b/src/shapiq/approximator/shapleig/shapleig.py
@@ -145,30 +145,25 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         Returns:
             The estimated Shapley values as ``InteractionValues``.
         """
+        # The ESP math and the GP fitting require double precision throughout
+        # (float32 intermediates change fitted hyperparameters and thereby
+        # selections). Enforce float64 locally and restore the user's default.
+        interactions,_ = self.approximate_with_variance(budget=budget, game=game)
+        return interactions
+
+    def approximate_with_variance(
+        self,
+        *,
+        budget: int,
+        game: Game | Callable[[CoalitionMatrix], GameValues],
+    ) -> tuple[InteractionValues, np.ndarray]:
+        """BED loop body (runs under enforced float64, see `approximate`)."""
         if budget <= self.initial_design_size:
             msg = (
                 f"Budget ({budget}) must exceed the initial design size "
                 f"({self.initial_design_size})."
             )
             raise ValueError(msg)
-
-        # The ESP math and the GP fitting require double precision throughout
-        # (float32 intermediates change fitted hyperparameters and thereby
-        # selections). Enforce float64 locally and restore the user's default.
-        previous_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(torch.float64)
-        try:
-            return self._approximate(budget=budget, game=game)
-        finally:
-            torch.set_default_dtype(previous_dtype)
-
-    def _approximate(
-        self,
-        *,
-        budget: int,
-        game: Game | Callable[[CoalitionMatrix], GameValues],
-    ) -> InteractionValues:
-        """BED loop body (runs under enforced float64, see `approximate`)."""
         iterations = budget - self.initial_design_size
 
         # Seed the GP hyperparameter fitting; the coalition sampling is seeded
@@ -231,8 +226,8 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
 
         # NOTE (future work, coordinated with the maintainers): the surrogate
         # posterior also provides the marginal SV variances,
-        #   AEA = sm.aea(sm.akzza(ls, s), A_KZX, K_chol)  # noqa: ERA001
-        #   sv_variances = AEA.diagonal() * gp_tensors.emp_std**2  # noqa: ERA001
+        AEA = sm.aea(sm.akzza(ls, s), A_KZX, K_chol) # TODO: compute the correct AEA
+        sv_variances = AEA.diagonal() * gp_tensors.emp_std**2 
         # Expose them via an `approximate_with_variance` once
         # `InteractionValues` supports uncertainty information.
 
@@ -255,7 +250,7 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
             estimation_budget=budget,
             baseline_value=float(baseline_value),
             target_index=self.index,
-        )
+        ), np.zeros(self.n)  # TODO(david): return the correct variances once supported  # noqa: TD003
 
     # ------------------------------------------------------------------
     # building blocks

--- a/src/shapiq/approximator/shapleig/shapleig.py
+++ b/src/shapiq/approximator/shapleig/shapleig.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
@@ -45,6 +46,8 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
 
     The returned :class:`~shapiq.interaction_values.InteractionValues` contain
     the posterior-mean Shapley value estimates (order 1, index ``"SV"``).
+    :meth:`approximate_with_variance` additionally returns the marginal
+    posterior variances of the Shapley values.
 
     Requires the optional ``shapleig`` extra
     (``pip install shapiq[shapleig]``) for torch / gpytorch / botorch.
@@ -87,13 +90,21 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
                 is optimized over; games with fewer coalitions outside the
                 initial design fall back to the exhaustive candidate set (all
                 not-yet-evaluated coalitions). ``None`` forces the exhaustive
-                candidate set, which is feasible only for ``n <= 16``.
-                Defaults to ``1024``, as in the reference paper.
+                candidate set (very costly for more than ~16 players).
+                Defaults to ``1024``, as in the reference paper. Choose this
+                clearly larger than the budget of the ``approximate`` call:
+                one candidate is consumed per iteration, so with
+                ``max_candidates`` close to the budget (almost) every
+                candidate is evaluated eventually and the adaptive selection
+                degenerates to the candidate sampling distribution.
             refit: When to refit the GP hyperparameters: ``"every_iteration"``
                 (default) or the staged schedule ``"init_64_factor_4"`` (every
                 iteration for the first 64, then every 8th for 128, every
                 16th for 256, every 32nd afterwards) for large budgets. The
-                final surrogate is always refit.
+                final surrogate is always refit. Note that for many players
+                and large training sets the hyperparameter refit is the
+                dominant per-iteration cost, so the staged schedule
+                substantially reduces wall-clock time at large budgets.
             warmstart: If ``True``, hyperparameter refits start from the
                 previous iteration's fitted hyperparameters instead of fresh
                 initial values.
@@ -102,22 +113,19 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
             random_state: Random state seeding both the coalition sampling
                 and the GP hyperparameter fitting. Defaults to ``None``.
         """
-        # Optional dependencies of the `shapleig` extra: import in the
-        # constructor (never at package import time) so that a missing extra
-        # fails immediately with an actionable message.
-
-        # ShaplEIG selects coalitions adaptively (EIG argmax), so the base
-        # class's sampling configuration must not suggest otherwise. Sampling
-        # enters only through the initial design and the candidate set, whose
-        # internal samplers follow the protocol of the reference paper
-        # (uniform coalition-size weights + pairing trick, `_coalition_sampler`).
+        # ShaplEIG selects coalitions adaptively (EIG argmax); the base
+        # class's sampler is used only for the initial design and the
+        # candidate set, with the sampling protocol of the reference paper
+        # (uniform coalition-size weights + pairing trick). The candidate
+        # draw replaces `self._sampler` with a freshly seeded equivalent
+        # (`_reset_sampler`) so it is independent of the initial-design draw.
         super().__init__(
             n=n,
             max_order=1,
             index="SV",
             min_order=0,
-            sampling_weights=None,
-            pairing_trick=False,
+            sampling_weights=np.ones(n + 1),
+            pairing_trick=True,
             random_state=random_state,
         )
         self.initial_design_size = (
@@ -145,10 +153,7 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         Returns:
             The estimated Shapley values as ``InteractionValues``.
         """
-        # The ESP math and the GP fitting require double precision throughout
-        # (float32 intermediates change fitted hyperparameters and thereby
-        # selections). Enforce float64 locally and restore the user's default.
-        interactions,_ = self.approximate_with_variance(budget=budget, game=game)
+        interactions, _sv_variances = self.approximate_with_variance(budget=budget, game=game)
         return interactions
 
     def approximate_with_variance(
@@ -157,7 +162,21 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         budget: int,
         game: Game | Callable[[CoalitionMatrix], GameValues],
     ) -> tuple[InteractionValues, np.ndarray]:
-        """BED loop body (runs under enforced float64, see `approximate`)."""
+        """Run the BED loop and return SV estimates with posterior variances.
+
+        Args:
+            budget: Total number of game evaluations (initial design plus one
+                evaluation per BED iteration).
+            game: The game to approximate, as a callable mapping a binary
+                coalition matrix of shape ``(m, n)`` to ``m`` values.
+
+        Returns:
+            A tuple of the estimated Shapley values as ``InteractionValues``
+            (the posterior means) and an array of shape ``(n,)`` with the
+            marginal posterior variances of the ``n`` players' Shapley values
+            (the diagonal of the SV posterior covariance, on the scale of the
+            game values).
+        """
         if budget <= self.initial_design_size:
             msg = (
                 f"Budget ({budget}) must exceed the initial design size "
@@ -172,7 +191,18 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         if self._random_state is not None:
             torch.manual_seed(self._random_state)
 
-        archive_X, candidate_set = self._generate_design(iterations)
+        archive_X, candidate_set = self._generate_design()
+        if candidate_set.shape[0] < iterations:
+            msg = (
+                f"The budget ({budget}) requires {iterations} BED iterations but "
+                f"only {candidate_set.shape[0]} candidate coalitions are "
+                f"available; capping at {candidate_set.shape[0]} iterations (the "
+                "remaining budget is not spent). Increase `max_candidates` to "
+                "use the full budget."
+            )
+            warnings.warn(msg, stacklevel=2)
+            iterations = candidate_set.shape[0]
+
         archive_Y = self._evaluate(game, archive_X)
         baseline_value = self._baseline_value(game, archive_X, archive_Y)
 
@@ -224,12 +254,11 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         A_KZX = sm.a_kzw(gp_tensors.train_X, gp_tensors.lengthscales, gp_tensors.outputscale)
         shapley_values = sm.affine_posterior_mean(A_KZX, gp_tensors, K_chol)
 
-        # NOTE (future work, coordinated with the maintainers): the surrogate
-        # posterior also provides the marginal SV variances,
-        AEA = sm.aea(sm.akzza(ls, s), A_KZX, K_chol) # TODO: compute the correct AEA
-        sv_variances = AEA.diagonal() * gp_tensors.emp_std**2 
-        # Expose them via an `approximate_with_variance` once
-        # `InteractionValues` supports uncertainty information.
+        # Marginal SV variances: the diagonal of the SV posterior covariance
+        # A * Sigma * A^T, rescaled from the GP's standardized output space
+        # back to the original scale of the game values.
+        AEA = sm.aea(sm.akzza(gp_tensors.lengthscales, gp_tensors.outputscale), A_KZX, K_chol)
+        sv_variances = AEA.diagonal() * gp_tensors.emp_std**2
 
         values = np.zeros(self.n + 1)
         values[0] = baseline_value
@@ -245,9 +274,11 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
             interaction_lookup=interaction_lookup,
             # Always flagged as estimated: even when the budget covers all
             # 2^n coalitions, the GP posterior mean is subject to numerical
-            # inaccuracies (the estimator is consistent, not exact).
+            # inaccuracies.
             estimated=True,
-            estimation_budget=budget,
+            # The budget actually spent (smaller than the requested budget
+            # only when the iterations were capped by the candidate-set size).
+            estimation_budget=self.initial_design_size + iterations,
             baseline_value=float(baseline_value),
             target_index=self.index,
         ), sv_variances.numpy()
@@ -256,49 +287,43 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
     # building blocks
     # ------------------------------------------------------------------
 
-    def _generate_design(self, iterations: int) -> tuple[torch.Tensor, torch.Tensor]:
+    def _generate_design(self) -> tuple[torch.Tensor, torch.Tensor]:
         """Draw the initial design and the candidate set (binary, float64).
 
-        Both draws come from fresh, identically seeded coalition samplers
-        (:meth:`_coalition_sampler`):
+        Both draws come from ``self._sampler``:
 
-        - the initial design sampler draws exactly ``initial_design_size``
+        - the initial design draw uses exactly ``initial_design_size``
           coalitions — its composition therefore does not depend on the
           candidate budget;
-        - the candidate sampler draws the combined budget, keeping the first
-          ``candidate_size`` coalitions not already in the initial design.
+        - the candidate draw first replaces the sampler with a freshly seeded
+          equivalent (:meth:`_reset_sampler`), so it restarts from the same
+          seed independently of the initial-design draw; it uses the combined
+          budget, keeping the first ``candidate_size`` coalitions not already
+          in the initial design.
         """
         init_size = self.initial_design_size
         if self.max_candidates is None:
             if self.n > 16:
                 msg = (
-                    "An exhaustive candidate set is infeasible for more than 16 "
-                    f"players (n={self.n}); set `max_candidates` to optimize the "
-                    "EIG over a sampled candidate subset instead."
+                    f"Optimizing the EIG over the exhaustive candidate set (all "
+                    f"2^{self.n} - {init_size} not-yet-evaluated coalitions) is "
+                    f"very costly for n={self.n} players; consider setting "
+                    "`max_candidates` to a sampled candidate subset instead."
                 )
-                raise ValueError(msg)
+                warnings.warn(msg, stacklevel=2)
             candidate_size = 2**self.n - init_size
         else:
             # `max_candidates` is an upper bound: small games fall back to the
             # exhaustive candidate set (all coalitions outside the initial
             # design).
             candidate_size = min(self.max_candidates, 2**self.n - init_size)
-        if candidate_size < iterations:
-            msg = (
-                f"Budget requires {iterations} BED iterations but only "
-                f"{candidate_size} candidate coalitions are available; reduce "
-                "the budget (or increase `max_candidates` if the candidate set "
-                "is not already exhaustive)."
-            )
-            raise ValueError(msg)
 
-        initial_sampler = self._coalition_sampler()
-        initial_sampler.sample(init_size)
-        initial_design = torch.tensor(initial_sampler.coalitions_matrix)
+        self._sampler.sample(init_size)
+        initial_design = torch.tensor(self._sampler.coalitions_matrix)
 
-        candidate_sampler = self._coalition_sampler()
-        candidate_sampler.sample(init_size + candidate_size)
-        candidates = torch.tensor(candidate_sampler.coalitions_matrix)
+        self._reset_sampler()
+        self._sampler.sample(init_size + candidate_size)
+        candidates = torch.tensor(self._sampler.coalitions_matrix)
         in_initial_design = (
             (candidates[:, None, :] == initial_design[None, :, :]).all(dim=2).any(dim=1)
         )
@@ -306,14 +331,14 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
 
         return initial_design.to(torch.float64), candidates.to(torch.float64)
 
-    def _coalition_sampler(self) -> CoalitionSampler:
-        """Fresh seeded sampler with the reference design protocol.
+    def _reset_sampler(self) -> None:
+        """Replace ``self._sampler`` with a freshly seeded equivalent.
 
-        Uniform coalition-size weights and the pairing trick, as in the
-        reference paper. A fresh sampler per draw keeps repeated
-        ``approximate`` calls on the same instance deterministic.
+        The new sampler is constructed with the same arguments as the one
+        built by the base class, so the next ``sample()`` call restarts from
+        the seed, independent of any previous draws.
         """
-        return CoalitionSampler(
+        self._sampler = CoalitionSampler(
             n_players=self.n,
             sampling_weights=np.ones(self.n + 1),
             pairing_trick=True,

--- a/src/shapiq/approximator/shapleig/shapleig.py
+++ b/src/shapiq/approximator/shapleig/shapleig.py
@@ -95,7 +95,7 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
                 candidate is evaluated eventually and the adaptive selection
                 degenerates to the candidate sampling distribution.
             refit: When to refit the GP hyperparameters: ``"every_iteration"``
-                (default) or the staged schedule ``"init_64_factor_4"`` (every
+                (default) or the staged schedule ``"decaying"`` (every
                 iteration for the first 64, then every 8th for 128, every
                 16th for 256, every 32nd afterwards) for large budgets. The
                 final surrogate is always refit. Note that for many players
@@ -354,7 +354,7 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         """Whether the GP hyperparameters are refit at this iteration."""
         if self.refit == "every_iteration":
             return True
-        if self.refit == "init_64_factor_4":
+        if self.refit == "decaying":
             if iteration_idx < 64:
                 return True
             if iteration_idx < 64 + 128:

--- a/src/shapiq/approximator/shapleig/shapleig.py
+++ b/src/shapiq/approximator/shapleig/shapleig.py
@@ -5,21 +5,28 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
+from tqdm import tqdm
 
 from shapiq.approximator.base import Approximator
 from shapiq.approximator.sampling import CoalitionSampler
 from shapiq.interaction_values import InteractionValues
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
+try:
     import torch
-
-    from shapiq.game import Game
-    from shapiq.typing import CoalitionMatrix, GameValues
 
     from . import _shapley_math as sm
     from ._surrogate import HammingGP
+
+except ImportError as err:
+    from ._error import _shapleig_import_error
+
+    raise _shapleig_import_error from err
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from shapiq.game import Game
+    from shapiq.typing import CoalitionMatrix, GameValues
 
 ValidShaplEIGIndices = Literal["SV"]
 
@@ -98,20 +105,6 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         # Optional dependencies of the `shapleig` extra: import in the
         # constructor (never at package import time) so that a missing extra
         # fails immediately with an actionable message.
-        try:
-            import torch  # noqa: F401
-
-            from . import (
-                _shapley_math,  # noqa: F401  (torch, linear-operator)
-                _surrogate,  # noqa: F401  (botorch, gpytorch)
-            )
-        except ImportError as err:
-            msg = (
-                "ShaplEIG requires the optional dependencies torch, gpytorch, "
-                "botorch, and linear-operator but they are not installed. "
-                "Install them with: pip install 'shapiq[shapleig]'"
-            )
-            raise ImportError(msg) from err
 
         # ShaplEIG selects coalitions adaptively (EIG argmax), so the base
         # class's sampling configuration must not suggest otherwise. Sampling
@@ -159,8 +152,6 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
             )
             raise ValueError(msg)
 
-        import torch
-
         # The ESP math and the GP fitting require double precision throughout
         # (float32 intermediates change fitted hyperparameters and thereby
         # selections). Enforce float64 locally and restore the user's default.
@@ -178,10 +169,6 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         game: Game | Callable[[CoalitionMatrix], GameValues],
     ) -> InteractionValues:
         """BED loop body (runs under enforced float64, see `approximate`)."""
-        import torch
-
-        from . import _shapley_math as sm
-
         iterations = budget - self.initial_design_size
 
         # Seed the GP hyperparameter fitting; the coalition sampling is seeded
@@ -199,8 +186,6 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
 
         iterator = range(iterations)
         if self.show_progress:
-            from tqdm import tqdm
-
             iterator = tqdm(iterator, desc="ShaplEIG", unit="it")
 
         best_idx: int | None = None
@@ -288,8 +273,6 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         - the candidate sampler draws the combined budget, keeping the first
           ``candidate_size`` coalitions not already in the initial design.
         """
-        import torch
-
         init_size = self.initial_design_size
         if self.max_candidates is None:
             if self.n > 16:
@@ -348,8 +331,6 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         Uses the validated reference settings throughout (standardized fixed
         noise ``1e-6``, minimum lengthscale ``1e-6``, 5 fitting attempts).
         """
-        from ._surrogate import HammingGP
-
         return HammingGP(train_X, train_Y)
 
     def _refit_scheduled(self, iteration_idx: int) -> bool:
@@ -383,8 +364,6 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         appended to A·K(Z,X), and the selected candidate's column is dropped
         from A·K(Z,W).
         """
-        from . import _shapley_math as sm
-
         gp_tensors = gp.tensors()
         K_chol = sm.psd_chol(sm.noisy_train_kernel(gp_tensors))
 
@@ -426,8 +405,6 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         coalitions: torch.Tensor,
     ) -> torch.Tensor:
         """Query the game on binary coalitions; values as a ``(m, 1)`` tensor."""
-        import torch
-
         values = game(coalitions.numpy().astype(bool))
         return torch.as_tensor(values, dtype=torch.float64).reshape(-1, 1)
 
@@ -443,8 +420,6 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         in the initial design, so its value is read from the archive; querying
         the game directly is a safety net only.
         """
-        import torch
-
         empty_rows = (archive_X.sum(dim=1) == 0).nonzero()
         if len(empty_rows) > 0:
             return float(archive_Y[int(empty_rows[0]), 0])

--- a/src/shapiq/approximator/shapleig/shapleig.py
+++ b/src/shapiq/approximator/shapleig/shapleig.py
@@ -43,6 +43,7 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
     generating polynomials, so the full ``2^n`` coalition space is never
     enumerated and each iteration costs only polynomial time in ``n``.
     (``n``, shapiq's number of players, is denoted ``p`` in the paper.)
+    For more information, see Rundel et al. (2026) :cite:t:`rundel2026shapleig`.
 
     The returned :class:`~shapiq.interaction_values.InteractionValues` contain
     the posterior-mean Shapley value estimates (order 1, index ``"SV"``).
@@ -60,10 +61,6 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         >>> values = approximator.approximate(budget=50, game=game)
         >>> values.index, values.max_order
         ('SV', 1)
-
-    References:
-        Rundel, D., et al. (2026). ShaplEIG: Bayesian Experimental Design for
-        Shapley Value Estimation.
     """
 
     valid_indices: tuple[ValidShaplEIGIndices, ...] = ("SV",)
@@ -377,12 +374,12 @@ class ShaplEIG(Approximator[ValidShaplEIGIndices]):
         no_refit_step: bool,
         prev_selected_idx: int | None,
     ) -> torch.Tensor:
-        """EIG utilities of the candidates under the current surrogate.
+        r"""EIG utilities of the candidates under the current surrogate.
 
         In a no-refit step the hyperparameters are unchanged: the cached
-        A·K(Z,Z)·Aᵀ is reused, the column of the last queried coalition is
-        appended to A·K(Z,X), and the selected candidate's column is dropped
-        from A·K(Z,W).
+        :math:`A K(Z, Z) A^\top` is reused, the column of the last queried
+        coalition is appended to :math:`A K(Z, X)`, and the selected
+        candidate's column is dropped from :math:`A K(Z, W)`.
         """
         gp_tensors = gp.tensors()
         K_chol = sm.psd_chol(sm.noisy_train_kernel(gp_tensors))

--- a/tests/shapiq/tests_unit/tests_approximators/test_approximator_shapleig.py
+++ b/tests/shapiq/tests_unit/tests_approximators/test_approximator_shapleig.py
@@ -92,20 +92,41 @@ def test_budget_must_exceed_initial_design():
         approximator.approximate(budget=N_PLAYERS + 1, game=dummy_game)
 
 
-def test_exhaustive_candidates_require_small_n():
-    """`max_candidates=None` (exhaustive candidates) is limited to n <= 16."""
-    approximator = ShaplEIG(n=17, max_candidates=None, show_progress=False)
-    with pytest.raises(ValueError, match="max_candidates"):
-        approximator.approximate(budget=20, game=dummy_game)
+def test_exhaustive_candidates_warn_for_large_n():
+    """`max_candidates=None` warns for n > 16 (exhaustive candidates are costly)."""
+    approximator = ShaplEIG(n=17, max_candidates=None, random_state=0, show_progress=False)
+    # only the design generation: the exhaustive EIG itself is (as the warning
+    # says) too costly to run in a unit test.
+    with pytest.warns(UserWarning, match="very costly"):
+        initial_design, candidates = approximator._generate_design()
+    assert initial_design.shape == (18, 17)
+    assert candidates.shape == (2**17 - 18, 17)
 
 
-def test_max_candidates_is_clamped_to_exhaustive():
-    """`max_candidates` is an upper bound: small games fall back to exhaustive."""
-    approximator = ShaplEIG(n=N_PLAYERS, max_candidates=1024, show_progress=False)
-    # 2^7 - 8 = 120 candidates exist; a budget needing 121 iterations must
-    # report the clamped (exhaustive) candidate count, not 1024.
-    with pytest.raises(ValueError, match="only 120 candidate"):
-        approximator.approximate(budget=129, game=dummy_game)
+def test_iterations_capped_at_candidate_set_size():
+    """Too-small candidate sets cap the iterations with a warning, not an error."""
+    approximator = ShaplEIG(n=N_PLAYERS, max_candidates=10, random_state=0, show_progress=False)
+    # budget 20 requires 12 iterations, but only 10 candidates exist.
+    with pytest.warns(UserWarning, match="capping"):
+        estimates = approximator.approximate(budget=20, game=dummy_game)
+    assert isinstance(estimates, InteractionValues)
+    # the reported budget is the one actually spent: 8 (initial) + 10 (capped)
+    assert estimates.estimation_budget == 18
+
+
+def test_approximate_with_variance():
+    """`approximate_with_variance` returns SVs plus marginal posterior variances."""
+    approximator = ShaplEIG(n=N_PLAYERS, random_state=0, show_progress=False)
+    estimates, variances = approximator.approximate_with_variance(budget=20, game=dummy_game)
+    assert isinstance(estimates, InteractionValues)
+    assert variances.shape == (N_PLAYERS,)
+    assert np.all(variances >= 0.0)
+    # `approximate` returns the same point estimates (it delegates internally)
+    same = ShaplEIG(n=N_PLAYERS, random_state=0, show_progress=False).approximate(
+        budget=20, game=dummy_game
+    )
+    for i in range(N_PLAYERS):
+        assert estimates[(i,)] == same[(i,)]
 
 
 def test_sampled_candidate_subset():

--- a/tests/shapiq/tests_unit/tests_approximators/test_approximator_shapleig.py
+++ b/tests/shapiq/tests_unit/tests_approximators/test_approximator_shapleig.py
@@ -1,0 +1,123 @@
+"""Tests for the ShaplEIG approximator."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("botorch")
+
+from shapiq.approximator.shapleig import ShaplEIG
+from shapiq.game_theory.exact import ExactComputer
+from shapiq.interaction_values import InteractionValues
+
+N_PLAYERS = 7
+INTERACTIONS = {(), (1,), (1, 2), (0, 3, 4)}
+
+
+def dummy_game(X):
+    """Deterministic sum-of-unanimity game over N_PLAYERS players."""
+    return np.array(
+        [sum(1.0 for interaction in INTERACTIONS if all(x[i] for i in interaction)) for x in X]
+    )
+
+
+@pytest.fixture(scope="module")
+def exact_sv():
+    """Exact Shapley values of the dummy game."""
+    exact_computer = ExactComputer(game=dummy_game, n_players=N_PLAYERS)
+    return exact_computer(index="SV", order=1)
+
+
+def test_initialization_defaults():
+    """ShaplEIG initializes with the documented defaults."""
+    approximator = ShaplEIG(n=9)
+    assert approximator.n == 9
+    assert approximator.index == "SV"
+    assert approximator.max_order == 1
+    assert approximator.initial_design_size == 10  # n + 1
+    assert approximator.max_candidates == 1024
+    assert approximator.valid_indices == ("SV",)
+
+
+def test_approximate_output_format():
+    """The output is a valid order-1 SV InteractionValues object."""
+    approximator = ShaplEIG(n=N_PLAYERS, random_state=0, show_progress=False)
+    estimates = approximator.approximate(budget=20, game=dummy_game)
+
+    assert isinstance(estimates, InteractionValues)
+    assert estimates.index == "SV"
+    assert estimates.max_order == 1
+    assert estimates.min_order == 0
+    assert estimates.n_players == N_PLAYERS
+    assert estimates.estimated
+    assert estimates.estimation_budget == 20
+    # the empty coalition carries the baseline value
+    assert estimates[()] == pytest.approx(estimates.baseline_value)
+    assert estimates.baseline_value == pytest.approx(1.0)  # () in INTERACTIONS
+
+
+def test_determinism():
+    """Same random_state -> identical estimates."""
+
+    def run():
+        return ShaplEIG(n=N_PLAYERS, random_state=42, show_progress=False).approximate(
+            budget=20, game=dummy_game
+        )
+
+    first, second = run(), run()
+    for i in range(N_PLAYERS):
+        assert first[(i,)] == second[(i,)]
+
+
+def test_convergence_to_exact(exact_sv):
+    """Estimates approach the exact Shapley values as the budget grows."""
+    errors = {}
+    for budget in (15, 100):
+        approximator = ShaplEIG(n=N_PLAYERS, random_state=0, show_progress=False)
+        estimates = approximator.approximate(budget=budget, game=dummy_game)
+        errors[budget] = float(
+            np.mean([abs(estimates[(i,)] - exact_sv[(i,)]) for i in range(N_PLAYERS)])
+        )
+    # near-exhaustive budget (100 of 2^7 = 128 coalitions) must be accurate
+    assert errors[100] < 1e-2
+    assert errors[100] <= errors[15]
+
+
+def test_budget_must_exceed_initial_design():
+    """Budgets not exceeding the initial design are rejected."""
+    approximator = ShaplEIG(n=N_PLAYERS, show_progress=False)
+    with pytest.raises(ValueError, match="must exceed"):
+        approximator.approximate(budget=N_PLAYERS + 1, game=dummy_game)
+
+
+def test_exhaustive_candidates_require_small_n():
+    """`max_candidates=None` (exhaustive candidates) is limited to n <= 16."""
+    approximator = ShaplEIG(n=17, max_candidates=None, show_progress=False)
+    with pytest.raises(ValueError, match="max_candidates"):
+        approximator.approximate(budget=20, game=dummy_game)
+
+
+def test_max_candidates_is_clamped_to_exhaustive():
+    """`max_candidates` is an upper bound: small games fall back to exhaustive."""
+    approximator = ShaplEIG(n=N_PLAYERS, max_candidates=1024, show_progress=False)
+    # 2^7 - 8 = 120 candidates exist; a budget needing 121 iterations must
+    # report the clamped (exhaustive) candidate count, not 1024.
+    with pytest.raises(ValueError, match="only 120 candidate"):
+        approximator.approximate(budget=129, game=dummy_game)
+
+
+def test_sampled_candidate_subset():
+    """A sampled candidate subset (`max_candidates`) yields valid estimates."""
+    approximator = ShaplEIG(n=N_PLAYERS, max_candidates=32, random_state=0, show_progress=False)
+    estimates = approximator.approximate(budget=15, game=dummy_game)
+    assert isinstance(estimates, InteractionValues)
+    assert estimates.estimated
+
+
+def test_warmstart_run():
+    """Warmstarted hyperparameter refits yield valid estimates."""
+    approximator = ShaplEIG(n=N_PLAYERS, warmstart=True, random_state=0, show_progress=False)
+    estimates = approximator.approximate(budget=15, game=dummy_game)
+    assert isinstance(estimates, InteractionValues)

--- a/uv.lock
+++ b/uv.lock
@@ -228,6 +228,26 @@ css = [
 ]
 
 [[package]]
+name = "botorch"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gpytorch" },
+    { name = "linear-operator" },
+    { name = "multipledispatch" },
+    { name = "pyre-extensions" },
+    { name = "pyro-ppl" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+    { name = "torch" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/2d/e6abecf418346f35d88b14df31b0ed78d7f9ddca2e7f817739552a060574/botorch-0.14.0.tar.gz", hash = "sha256:7c6ca67e086a90a4b99afc4bc66317fc7d1638d644e4ed8f553ea7b125392cb7", size = 2476296, upload-time = "2025-05-06T15:58:31.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/a2/d55a31ac94b4f0695694650cd80a5a2823c0adc1a0b8a0a99a20f5bfae37/botorch-0.14.0-py3-none-any.whl", hash = "sha256:01264a4cd78b2d812f40626e90d97b421cb14252225c3836c7bff826082e52f9", size = 738313, upload-time = "2025-05-06T15:58:29.617Z" },
+]
+
+[[package]]
 name = "catboost"
 version = "1.2.10"
 source = { registry = "https://pypi.org/simple" }
@@ -603,29 +623,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cuda-bindings"
-version = "12.9.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
-    { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991, upload-time = "2025-10-21T14:51:56.535Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/af/6dfd8f2ed90b1d4719bc053ff8940e494640fe4212dc3dd72f383e4992da/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686", size = 11922703, upload-time = "2025-10-21T14:52:03.585Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/19/90ac264acc00f6df8a49378eedec9fd2db3061bf9263bf9f39fd3d8377c3/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d80bffc357df9988dca279734bc9674c3934a654cab10cadeed27ce17d8635ee", size = 11924658, upload-time = "2025-10-21T14:52:10.411Z" },
-]
-
-[[package]]
-name = "cuda-pathfinder"
-version = "1.4.2"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/de/8ca2b613042550dcf9ef50c596c8b1f602afda92cf9032ac28a73f6ee410/cuda_pathfinder-1.4.2-py3-none-any.whl", hash = "sha256:eb354abc20278f8609dc5b666a24648655bef5613c6dfe78a238a6fd95566754", size = 44779, upload-time = "2026-03-10T21:57:30.974Z" },
-]
-
-[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -947,6 +944,22 @@ wheels = [
 ]
 
 [[package]]
+name = "gpytorch"
+version = "1.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaxtyping" },
+    { name = "linear-operator" },
+    { name = "mpmath" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/70/7e925758468f924ffc6da9f6007b1d92e37455212d451c6c771cfa1c37fd/gpytorch-1.14.tar.gz", hash = "sha256:032cc11e6a46e1e4bc7763fcef318cc830aceaea85a7289f27b2288c7a339a8d", size = 2472710, upload-time = "2025-01-29T16:03:36.926Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/58/ac756b7c9b7daec0382d7c8e0b2c70819df227826edd8aa5bce115470d5a/gpytorch-1.14-py3-none-any.whl", hash = "sha256:9b17ff7bd70dc39c3a3c03eb2bb9a87aa4b840c26e71ac68d120b96487bf5a12", size = 277740, upload-time = "2025-01-29T16:03:32.334Z" },
+]
+
+[[package]]
 name = "graphviz"
 version = "0.21"
 source = { registry = "https://pypi.org/simple" }
@@ -1230,6 +1243,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
+]
+
+[[package]]
+name = "jaxtyping"
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/c1/091b8852bd7cbf50bd655543c8506033cf4029300c67f8c176c1286879a9/jaxtyping-0.3.11.tar.gz", hash = "sha256:b09c14acf6686feb9e0df5b0d8c6e7c5b6f8d36bf059ee54cd522a186c2ef050", size = 46489, upload-time = "2026-06-13T18:35:23.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/38/c66bbdc5047f4776c2bd3e47e5295a350e3fa44d5b8942105e71c2a876a0/jaxtyping-0.3.11-py3-none-any.whl", hash = "sha256:8a4bedc4e3f963fa82df41bd13c7ebc2bad925601eb48614c65798f21329d4e3", size = 56593, upload-time = "2026-06-13T18:35:22.01Z" },
 ]
 
 [[package]]
@@ -1653,6 +1678,21 @@ wheels = [
 ]
 
 [[package]]
+name = "linear-operator"
+version = "0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaxtyping" },
+    { name = "mpmath" },
+    { name = "scipy" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/e9/c900e42b989e5778d0a28bb28aa63a5cef4f7e2f1af34b9de6157da77913/linear_operator-0.6.tar.gz", hash = "sha256:a9e2663879f1a2b28631bf7ef34892c4e5749893e711c8ef0ab0a39aff70a654", size = 185103, upload-time = "2025-01-28T23:13:58.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/c7/8a27fd8e182c611d4bf0aa9f0ea9046a7c843901d0f06c8cdcb599840a38/linear_operator-0.6-py3-none-any.whl", hash = "sha256:b7c30ce0f6599e19c1cb970e00811828df98783b20c1dd2f765928415012f41c", size = 176344, upload-time = "2025-01-28T23:13:56.666Z" },
+]
+
+[[package]]
 name = "llvmlite"
 version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1946,6 +1986,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/ce/011ffcd8b919f55196ec53f12ae162e21c879d95afba226894314ff62c07/msgpack-1.2.0-cp314-cp314t-win32.whl", hash = "sha256:378caf74c4c718dfc17590ce68a6d710ed398ff6fcf08237de23b77755730b55", size = 70782, upload-time = "2026-06-11T04:16:07.105Z" },
     { url = "https://files.pythonhosted.org/packages/57/a8/9b8791ca96b1be6b9f659c718271e2cb7f99f73f58aad2dd0b30f750f6c0/msgpack-1.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:553b42598165c4dd3235994fd6e4b0dfb1ce5f3fd33d94ba9609442643015f38", size = 77899, upload-time = "2026-06-11T04:16:08.353Z" },
     { url = "https://files.pythonhosted.org/packages/5b/04/3fa2dffb87bf598696b86bde7cd642d0a7590520c3fa24cd19611dfebeb7/msgpack-1.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2825bb1da548d214ab8a810906b7dd69a10f3838b615a2cc46e5172d3cb44f6e", size = 71004, upload-time = "2026-06-11T04:16:09.556Z" },
+]
+
+[[package]]
+name = "multipledispatch"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/3e/a62c3b824c7dec33c4a1578bcc842e6c30300051033a4e5975ed86cc2536/multipledispatch-1.0.0.tar.gz", hash = "sha256:5c839915465c68206c3e9c473357908216c28383b425361e5d144594bf85a7e0", size = 12385, upload-time = "2023-06-27T16:45:11.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl", hash = "sha256:0c53cd8b077546da4e48869f49b13164bebafd0c2a5afceb6bb6a316e7fb46e4", size = 12818, upload-time = "2023-06-27T16:45:09.418Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -2308,10 +2366,10 @@ wheels = [
 
 [[package]]
 name = "nvidia-nvshmem-cu12"
-version = "3.4.5"
+version = "3.3.20"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/6c/99acb2f9eb85c29fc6f3a7ac4dccfd992e22666dd08a642b303311326a97/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d00f26d3f9b2e3c3065be895e3059d6479ea5c638a3f38c9fec49b1b9dd7c1e5", size = 124657145, upload-time = "2025-08-04T20:25:19.995Z" },
 ]
 
 [[package]]
@@ -2867,6 +2925,44 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyre-extensions"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+    { name = "typing-inspect" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/53/5bc2532536e921c48366ad1047c1344ccef6afa5e84053f0f6e20a453767/pyre_extensions-0.0.32.tar.gz", hash = "sha256:5396715f14ea56c4d5fd0a88c57ca7e44faa468f905909edd7de4ad90ed85e55", size = 10852, upload-time = "2024-11-22T19:26:44.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/7a/9812cb8be9828ab688203c5ac5f743c60652887f0c00995a6f6f19f912bd/pyre_extensions-0.0.32-py3-none-any.whl", hash = "sha256:a63ba6883ab02f4b1a9f372ed4eb4a2f4c6f3d74879aa2725186fdfcfe3e5c68", size = 12766, upload-time = "2024-11-22T19:26:42.465Z" },
+]
+
+[[package]]
+name = "pyro-api"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/d7/a0812f5c16b0d4464f80a64a44626c5fe200098070be0f32436dbb662775/pyro-api-0.1.2.tar.gz", hash = "sha256:a1b900d9580aa1c2fab3b123ab7ff33413744da7c5f440bd4aadc4d40d14d920", size = 7349, upload-time = "2020-05-15T16:17:41.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/81/957ae78e6398460a7230b0eb9b8f1cb954c5e913e868e48d89324c68cec7/pyro_api-0.1.2-py3-none-any.whl", hash = "sha256:10e0e42e9e4401ce464dab79c870e50dfb4f413d326fa777f3582928ef9caf8f", size = 11981, upload-time = "2020-05-15T16:17:40.492Z" },
+]
+
+[[package]]
+name = "pyro-ppl"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "opt-einsum" },
+    { name = "pyro-api" },
+    { name = "torch" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/2e/3bcba8688d58f8dc954cef6831c19d52b6017b035d783685d67cd99fa351/pyro_ppl-1.9.1.tar.gz", hash = "sha256:5e1596de276c038a3f77d2580a90d0a97126e0104900444a088eee620bb0d65e", size = 570861, upload-time = "2024-06-02T00:37:39.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/37/def183a2a2c8619d92649d62fe0622c4c6c62f60e4151e8fbaa409e7d5ab/pyro_ppl-1.9.1-py3-none-any.whl", hash = "sha256:91fb2c8740d9d3bd548180ac5ecfa04552ed8c471a1ab66870180663b8f09852", size = 755956, upload-time = "2024-06-02T00:37:37.486Z" },
 ]
 
 [[package]]
@@ -3586,6 +3682,12 @@ proxy = [
     { name = "smac" },
     { name = "xgboost" },
 ]
+shapleig = [
+    { name = "botorch" },
+    { name = "gpytorch" },
+    { name = "linear-operator" },
+    { name = "torch" },
+]
 sparse = [
     { name = "galois" },
     { name = "sparse-transform" },
@@ -3660,11 +3762,14 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "botorch", marker = "extra == 'shapleig'", specifier = "==0.14.0" },
     { name = "catboost", marker = "extra == 'proxy'" },
     { name = "colour" },
     { name = "galois", marker = "extra == 'sparse'" },
+    { name = "gpytorch", marker = "extra == 'shapleig'", specifier = "==1.14" },
     { name = "joblib" },
     { name = "lightgbm", marker = "extra == 'proxy'" },
+    { name = "linear-operator", marker = "extra == 'shapleig'", specifier = "==0.6" },
     { name = "matplotlib" },
     { name = "networkx" },
     { name = "numpy" },
@@ -3675,10 +3780,11 @@ requires-dist = [
     { name = "scipy" },
     { name = "smac", marker = "extra == 'proxy'" },
     { name = "sparse-transform", marker = "extra == 'sparse'" },
+    { name = "torch", marker = "extra == 'shapleig'", specifier = "==2.9.1" },
     { name = "tqdm" },
     { name = "xgboost", marker = "extra == 'proxy'" },
 ]
-provides-extras = ["sparse", "proxy"]
+provides-extras = ["sparse", "proxy", "shapleig"]
 
 [package.metadata.requires-dev]
 all-ml = [
@@ -4194,10 +4300,9 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.10.0"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
@@ -4223,38 +4328,31 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
-    { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/5c/dee910b87c4d5c0fcb41b50839ae04df87c1cfc663cf1b5fca7ea565eeaa/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6d3707a61863d1c4d6ebba7be4ca320f42b869ee657e9b2c21c736bf17000294", size = 79498198, upload-time = "2026-01-21T16:24:34.704Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/6f/f2e91e34e3fcba2e3fc8d8f74e7d6c22e74e480bbd1db7bc8900fdf3e95c/torch-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5c4d217b14741e40776dd7074d9006fd28b8a97ef5654db959d8635b2fe5f29b", size = 146004247, upload-time = "2026-01-21T16:24:29.335Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fb/5160261aeb5e1ee12ee95fe599d0541f7c976c3701d607d8fc29e623229f/torch-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6b71486353fce0f9714ca0c9ef1c850a2ae766b409808acd58e9678a3edb7738", size = 915716445, upload-time = "2026-01-21T16:22:45.353Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/16/502fb1b41e6d868e8deb5b0e3ae926bbb36dab8ceb0d1b769b266ad7b0c3/torch-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2ee399c644dc92ef7bc0d4f7e74b5360c37cdbe7c5ba11318dda49ffac2bc57", size = 113757050, upload-time = "2026-01-21T16:24:19.204Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/0b/39929b148f4824bc3ad6f9f72a29d4ad865bcf7ebfc2fa67584773e083d2/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:3202429f58309b9fa96a614885eace4b7995729f44beb54d3e4a47773649d382", size = 79851305, upload-time = "2026-01-21T16:24:09.209Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/14/21fbce63bc452381ba5f74a2c0a959fdf5ad5803ccc0c654e752e0dbe91a/torch-2.10.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:aae1b29cd68e50a9397f5ee897b9c24742e9e306f88a807a27d617f07adb3bd8", size = 146005472, upload-time = "2026-01-21T16:22:29.022Z" },
-    { url = "https://files.pythonhosted.org/packages/54/fd/b207d1c525cb570ef47f3e9f836b154685011fce11a2f444ba8a4084d042/torch-2.10.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6021db85958db2f07ec94e1bc77212721ba4920c12a18dc552d2ae36a3eb163f", size = 915612644, upload-time = "2026-01-21T16:21:47.019Z" },
-    { url = "https://files.pythonhosted.org/packages/36/53/0197f868c75f1050b199fe58f9bf3bf3aecac9b4e85cc9c964383d745403/torch-2.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff43db38af76fda183156153983c9a096fc4c78d0cd1e07b14a2314c7f01c2c8", size = 113997015, upload-time = "2026-01-21T16:23:00.767Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/13/e76b4d9c160e89fff48bf16b449ea324bda84745d2ab30294c37c2434c0d/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:cdf2a523d699b70d613243211ecaac14fe9c5df8a0b0a9c02add60fb2a413e0f", size = 79498248, upload-time = "2026-01-21T16:23:09.315Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/93/716b5ac0155f1be70ed81bacc21269c3ece8dba0c249b9994094110bfc51/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:bf0d9ff448b0218e0433aeb198805192346c4fd659c852370d5cc245f602a06a", size = 79464992, upload-time = "2026-01-21T16:23:05.162Z" },
-    { url = "https://files.pythonhosted.org/packages/69/2b/51e663ff190c9d16d4a8271203b71bc73a16aa7619b9f271a69b9d4a936b/torch-2.10.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:233aed0659a2503b831d8a67e9da66a62c996204c0bba4f4c442ccc0c68a3f60", size = 146018567, upload-time = "2026-01-21T16:22:23.393Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/cd/4b95ef7f293b927c283db0b136c42be91c8ec6845c44de0238c8c23bdc80/torch-2.10.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:682497e16bdfa6efeec8cde66531bc8d1fbbbb4d8788ec6173c089ed3cc2bfe5", size = 915721646, upload-time = "2026-01-21T16:21:16.983Z" },
-    { url = "https://files.pythonhosted.org/packages/56/97/078a007208f8056d88ae43198833469e61a0a355abc0b070edd2c085eb9a/torch-2.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:6528f13d2a8593a1a412ea07a99812495bec07e9224c28b2a25c0a30c7da025c", size = 113752373, upload-time = "2026-01-21T16:22:13.471Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/94/71994e7d0d5238393df9732fdab607e37e2b56d26a746cb59fdb415f8966/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f5ab4ba32383061be0fb74bda772d470140a12c1c3b58a0cfbf3dae94d164c28", size = 79850324, upload-time = "2026-01-21T16:22:09.494Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/65/1a05346b418ea8ccd10360eef4b3e0ce688fba544e76edec26913a8d0ee0/torch-2.10.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:716b01a176c2a5659c98f6b01bf868244abdd896526f1c692712ab36dbaf9b63", size = 146006482, upload-time = "2026-01-21T16:22:18.42Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/b9/5f6f9d9e859fc3235f60578fa64f52c9c6e9b4327f0fe0defb6de5c0de31/torch-2.10.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d8f5912ba938233f86361e891789595ff35ca4b4e2ac8fe3670895e5976731d6", size = 915613050, upload-time = "2026-01-21T16:20:49.035Z" },
-    { url = "https://files.pythonhosted.org/packages/66/4d/35352043ee0eaffdeff154fad67cd4a31dbed7ff8e3be1cc4549717d6d51/torch-2.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:71283a373f0ee2c89e0f0d5f446039bdabe8dbc3c9ccf35f0f784908b0acd185", size = 113995816, upload-time = "2026-01-21T16:22:05.312Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/27/07c645c7673e73e53ded71705045d6cb5bae94c4b021b03aa8d03eee90ab/torch-2.9.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:da5f6f4d7f4940a173e5572791af238cb0b9e21b1aab592bd8b26da4c99f1cd6", size = 104126592, upload-time = "2025-11-12T15:20:41.62Z" },
+    { url = "https://files.pythonhosted.org/packages/19/17/e377a460603132b00760511299fceba4102bd95db1a0ee788da21298ccff/torch-2.9.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:27331cd902fb4322252657f3902adf1c4f6acad9dcad81d8df3ae14c7c4f07c4", size = 899742281, upload-time = "2025-11-12T15:22:17.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1a/64f5769025db846a82567fa5b7d21dba4558a7234ee631712ee4771c436c/torch-2.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:81a285002d7b8cfd3fdf1b98aa8df138d41f1a8334fd9ea37511517cedf43083", size = 110940568, upload-time = "2025-11-12T15:21:18.689Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ab/07739fd776618e5882661d04c43f5b5586323e2f6a2d7d84aac20d8f20bd/torch-2.9.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:c0d25d1d8e531b8343bea0ed811d5d528958f1dcbd37e7245bc686273177ad7e", size = 74479191, upload-time = "2025-11-12T15:21:25.816Z" },
+    { url = "https://files.pythonhosted.org/packages/20/60/8fc5e828d050bddfab469b3fe78e5ab9a7e53dda9c3bdc6a43d17ce99e63/torch-2.9.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c29455d2b910b98738131990394da3e50eea8291dfeb4b12de71ecf1fdeb21cb", size = 104135743, upload-time = "2025-11-12T15:21:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/6d3f80e6918213babddb2a37b46dbb14c15b14c5f473e347869a51f40e1f/torch-2.9.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:524de44cd13931208ba2c4bde9ec7741fd4ae6bfd06409a604fc32f6520c2bc9", size = 899749493, upload-time = "2025-11-12T15:24:36.356Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/47/c7843d69d6de8938c1cbb1eba426b1d48ddf375f101473d3e31a5fc52b74/torch-2.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:545844cc16b3f91e08ce3b40e9c2d77012dd33a48d505aed34b7740ed627a1b2", size = 110944162, upload-time = "2025-11-12T15:21:53.151Z" },
+    { url = "https://files.pythonhosted.org/packages/28/0e/2a37247957e72c12151b33a01e4df651d9d155dd74d8cfcbfad15a79b44a/torch-2.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5be4bf7496f1e3ffb1dd44b672adb1ac3f081f204c5ca81eba6442f5f634df8e", size = 74830751, upload-time = "2025-11-12T15:21:43.792Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f7/7a18745edcd7b9ca2381aa03353647bca8aace91683c4975f19ac233809d/torch-2.9.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:30a3e170a84894f3652434b56d59a64a2c11366b0ed5776fab33c2439396bf9a", size = 104142929, upload-time = "2025-11-12T15:21:48.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/dd/f1c0d879f2863ef209e18823a988dc7a1bf40470750e3ebe927efdb9407f/torch-2.9.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8301a7b431e51764629208d0edaa4f9e4c33e6df0f2f90b90e261d623df6a4e2", size = 899748978, upload-time = "2025-11-12T15:23:04.568Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/9f/6986b83a53b4d043e36f3f898b798ab51f7f20fdf1a9b01a2720f445043d/torch-2.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:2e1c42c0ae92bf803a4b2409fdfed85e30f9027a66887f5e7dcdbc014c7531db", size = 111176995, upload-time = "2025-11-12T15:22:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/40/60/71c698b466dd01e65d0e9514b5405faae200c52a76901baf6906856f17e4/torch-2.9.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:2c14b3da5df416cf9cb5efab83aa3056f5b8cd8620b8fde81b4987ecab730587", size = 74480347, upload-time = "2025-11-12T15:21:57.648Z" },
+    { url = "https://files.pythonhosted.org/packages/48/50/c4b5112546d0d13cc9eaa1c732b823d676a9f49ae8b6f97772f795874a03/torch-2.9.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1edee27a7c9897f4e0b7c14cfc2f3008c571921134522d5b9b5ec4ebbc69041a", size = 74433245, upload-time = "2025-11-12T15:22:39.027Z" },
+    { url = "https://files.pythonhosted.org/packages/81/c9/2628f408f0518b3bae49c95f5af3728b6ab498c8624ab1e03a43dd53d650/torch-2.9.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:19d144d6b3e29921f1fc70503e9f2fc572cde6a5115c0c0de2f7ca8b1483e8b6", size = 104134804, upload-time = "2025-11-12T15:22:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/28/fc/5bc91d6d831ae41bf6e9e6da6468f25330522e92347c9156eb3f1cb95956/torch-2.9.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c432d04376f6d9767a9852ea0def7b47a7bbc8e7af3b16ac9cf9ce02b12851c9", size = 899747132, upload-time = "2025-11-12T15:23:36.068Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5d/e8d4e009e52b6b2cf1684bde2a6be157b96fb873732542fb2a9a99e85a83/torch-2.9.1-cp314-cp314-win_amd64.whl", hash = "sha256:d187566a2cdc726fc80138c3cdb260970fab1c27e99f85452721f7759bbd554d", size = 110934845, upload-time = "2025-11-12T15:22:48.367Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b2/2d15a52516b2ea3f414643b8de68fa4cb220d3877ac8b1028c83dc8ca1c4/torch-2.9.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cb10896a1f7fedaddbccc2017ce6ca9ecaaf990f0973bdfcf405439750118d2c", size = 74823558, upload-time = "2025-11-12T15:22:43.392Z" },
+    { url = "https://files.pythonhosted.org/packages/86/5c/5b2e5d84f5b9850cd1e71af07524d8cbb74cba19379800f1f9f7c997fc70/torch-2.9.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0a2bd769944991c74acf0c4ef23603b9c777fdf7637f115605a4b2d8023110c7", size = 104145788, upload-time = "2025-11-12T15:23:52.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8c/3da60787bcf70add986c4ad485993026ac0ca74f2fc21410bc4eb1bb7695/torch-2.9.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:07c8a9660bc9414c39cac530ac83b1fb1b679d7155824144a40a54f4a47bfa73", size = 899735500, upload-time = "2025-11-12T15:24:08.788Z" },
+    { url = "https://files.pythonhosted.org/packages/db/2b/f7818f6ec88758dfd21da46b6cd46af9d1b3433e53ddbb19ad1e0da17f9b/torch-2.9.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c88d3299ddeb2b35dcc31753305612db485ab6f1823e37fb29451c8b2732b87e", size = 111163659, upload-time = "2025-11-12T15:23:20.009Z" },
 ]
 
 [[package]]
 name = "torchvision"
-version = "0.25.0"
+version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -4262,26 +4360,26 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/3a/6ea0d73f49a9bef38a1b3a92e8dd455cea58470985d25635beab93841748/torchvision-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2abe430c90b1d5e552680037d68da4eb80a5852ebb1c811b2b89d299b10573b", size = 1874920, upload-time = "2026-01-21T16:27:45.348Z" },
-    { url = "https://files.pythonhosted.org/packages/51/f8/c0e1ef27c66e15406fece94930e7d6feee4cb6374bbc02d945a630d6426e/torchvision-0.25.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b75deafa2dfea3e2c2a525559b04783515e3463f6e830cb71de0fb7ea36fe233", size = 2344556, upload-time = "2026-01-21T16:27:40.125Z" },
-    { url = "https://files.pythonhosted.org/packages/68/2f/f24b039169db474e8688f649377de082a965fbf85daf4e46c44412f1d15a/torchvision-0.25.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f25aa9e380865b11ea6e9d99d84df86b9cc959f1a007cd966fc6f1ab2ed0e248", size = 8072351, upload-time = "2026-01-21T16:27:21.074Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/16/8f650c2e288977cf0f8f85184b90ee56ed170a4919347fc74ee99286ed6f/torchvision-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:f9c55ae8d673ab493325d1267cbd285bb94d56f99626c00ac4644de32a59ede3", size = 4303059, upload-time = "2026-01-21T16:27:11.08Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/5b/1562a04a6a5a4cf8cf40016a0cdeda91ede75d6962cff7f809a85ae966a5/torchvision-0.25.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:24e11199e4d84ba9c5ee7825ebdf1cd37ce8deec225117f10243cae984ced3ec", size = 1874918, upload-time = "2026-01-21T16:27:39.02Z" },
-    { url = "https://files.pythonhosted.org/packages/36/b1/3d6c42f62c272ce34fcce609bb8939bdf873dab5f1b798fd4e880255f129/torchvision-0.25.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5f271136d2d2c0b7a24c5671795c6e4fd8da4e0ea98aeb1041f62bc04c4370ef", size = 2309106, upload-time = "2026-01-21T16:27:30.624Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/60/59bb9c8b67cce356daeed4cb96a717caa4f69c9822f72e223a0eae7a9bd9/torchvision-0.25.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:855c0dc6d37f462482da7531c6788518baedca1e0847f3df42a911713acdfe52", size = 8071522, upload-time = "2026-01-21T16:27:29.392Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a5/9a9b1de0720f884ea50dbf9acb22cbe5312e51d7b8c4ac6ba9b51efd9bba/torchvision-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:cef0196be31be421f6f462d1e9da1101be7332d91984caa6f8022e6c78a5877f", size = 4321911, upload-time = "2026-01-21T16:27:35.195Z" },
-    { url = "https://files.pythonhosted.org/packages/52/99/dca81ed21ebaeff2b67cc9f815a20fdaa418b69f5f9ea4c6ed71721470db/torchvision-0.25.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a8f8061284395ce31bcd460f2169013382ccf411148ceb2ee38e718e9860f5a7", size = 1896209, upload-time = "2026-01-21T16:27:32.159Z" },
-    { url = "https://files.pythonhosted.org/packages/28/cc/2103149761fdb4eaed58a53e8437b2d716d48f05174fab1d9fcf1e2a2244/torchvision-0.25.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:146d02c9876858420adf41f3189fe90e3d6a409cbfa65454c09f25fb33bf7266", size = 2310735, upload-time = "2026-01-21T16:27:22.327Z" },
-    { url = "https://files.pythonhosted.org/packages/76/ad/f4c985ad52ddd3b22711c588501be1b330adaeaf6850317f66751711b78c/torchvision-0.25.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c4d395cb2c4a2712f6eb93a34476cdf7aae74bb6ea2ea1917f858e96344b00aa", size = 8089557, upload-time = "2026-01-21T16:27:27.666Z" },
-    { url = "https://files.pythonhosted.org/packages/63/cc/0ea68b5802e5e3c31f44b307e74947bad5a38cc655231d845534ed50ddb8/torchvision-0.25.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5e6b449e9fa7d642142c0e27c41e5a43b508d57ed8e79b7c0a0c28652da8678c", size = 4344260, upload-time = "2026-01-21T16:27:17.018Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1f/fa839532660e2602b7e704d65010787c5bb296258b44fa8b9c1cd6175e7d/torchvision-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:620a236288d594dcec7634c754484542dc0a5c1b0e0b83a34bda5e91e9b7c3a1", size = 1896193, upload-time = "2026-01-21T16:27:24.785Z" },
-    { url = "https://files.pythonhosted.org/packages/80/ed/d51889da7ceaf5ff7a0574fb28f9b6b223df19667265395891f81b364ab3/torchvision-0.25.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b5e7f50002a8145a98c5694a018e738c50e2972608310c7e88e1bd4c058f6ce", size = 2309331, upload-time = "2026-01-21T16:27:19.97Z" },
-    { url = "https://files.pythonhosted.org/packages/90/a5/f93fcffaddd8f12f9e812256830ec9c9ca65abbf1bc369379f9c364d1ff4/torchvision-0.25.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:632db02300e83793812eee4f61ae6a2686dab10b4cfd628b620dc47747aa9d03", size = 8088713, upload-time = "2026-01-21T16:27:15.281Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/eb/d0096eed5690d962853213f2ee00d91478dfcb586b62dbbb449fb8abc3a6/torchvision-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:d1abd5ed030c708f5dbf4812ad5f6fbe9384b63c40d6bd79f8df41a4a759a917", size = 4325058, upload-time = "2026-01-21T16:27:26.165Z" },
-    { url = "https://files.pythonhosted.org/packages/97/36/96374a4c7ab50dea9787ce987815614ccfe988a42e10ac1a2e3e5b60319a/torchvision-0.25.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ad9a8a5877782944d99186e4502a614770fe906626d76e9cd32446a0ac3075f2", size = 1896207, upload-time = "2026-01-21T16:27:23.383Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e2/7abb10a867db79b226b41da419b63b69c0bd5b82438c4a4ed50e084c552f/torchvision-0.25.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:40a122c3cf4d14b651f095e0f672b688dde78632783fc5cd3d4d5e4f6a828563", size = 2310741, upload-time = "2026-01-21T16:27:18.712Z" },
-    { url = "https://files.pythonhosted.org/packages/08/e6/0927784e6ffc340b6676befde1c60260bd51641c9c574b9298d791a9cda4/torchvision-0.25.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:846890161b825b38aa85fc37fb3ba5eea74e7091ff28bab378287111483b6443", size = 8089772, upload-time = "2026-01-21T16:27:14.048Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/37/e7ca4ec820d434c0f23f824eb29f0676a0c3e7a118f1514f5b949c3356da/torchvision-0.25.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f07f01d27375ad89d72aa2b3f2180f07da95dd9d2e4c758e015c0acb2da72977", size = 4425879, upload-time = "2026-01-21T16:27:12.579Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/18e2c6b9538a045f60718a0c5a058908ccb24f88fde8e6f0fc12d5ff7bd3/torchvision-0.24.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e48bf6a8ec95872eb45763f06499f87bd2fb246b9b96cb00aae260fda2f96193", size = 1891433, upload-time = "2025-11-12T15:25:03.232Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/43/600e5cfb0643d10d633124f5982d7abc2170dfd7ce985584ff16edab3e76/torchvision-0.24.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:7fb7590c737ebe3e1c077ad60c0e5e2e56bb26e7bccc3b9d04dbfc34fd09f050", size = 2386737, upload-time = "2025-11-12T15:25:08.288Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b1/db2941526ecddd84884132e2742a55c9311296a6a38627f9e2627f5ac889/torchvision-0.24.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:66a98471fc18cad9064123106d810a75f57f0838eee20edc56233fd8484b0cc7", size = 8049868, upload-time = "2025-11-12T15:25:13.058Z" },
+    { url = "https://files.pythonhosted.org/packages/69/98/16e583f59f86cd59949f59d52bfa8fc286f86341a229a9d15cbe7a694f0c/torchvision-0.24.1-cp312-cp312-win_amd64.whl", hash = "sha256:4aa6cb806eb8541e92c9b313e96192c6b826e9eb0042720e2fa250d021079952", size = 4302006, upload-time = "2025-11-12T15:25:16.184Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/97/ab40550f482577f2788304c27220e8ba02c63313bd74cf2f8920526aac20/torchvision-0.24.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8a6696db7fb71eadb2c6a48602106e136c785642e598eb1533e0b27744f2cce6", size = 1891435, upload-time = "2025-11-12T15:25:28.642Z" },
+    { url = "https://files.pythonhosted.org/packages/30/65/ac0a3f9be6abdbe4e1d82c915d7e20de97e7fd0e9a277970508b015309f3/torchvision-0.24.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:db2125c46f9cb25dc740be831ce3ce99303cfe60439249a41b04fd9f373be671", size = 2338718, upload-time = "2025-11-12T15:25:26.19Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b5/5bba24ff9d325181508501ed7f0c3de8ed3dd2edca0784d48b144b6c5252/torchvision-0.24.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:f035f0cacd1f44a8ff6cb7ca3627d84c54d685055961d73a1a9fb9827a5414c8", size = 8049661, upload-time = "2025-11-12T15:25:22.558Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ec/54a96ae9ab6a0dd66d4bba27771f892e36478a9c3489fa56e51c70abcc4d/torchvision-0.24.1-cp313-cp313-win_amd64.whl", hash = "sha256:16274823b93048e0a29d83415166a2e9e0bf4e1b432668357b657612a4802864", size = 4319808, upload-time = "2025-11-12T15:25:17.318Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f3/a90a389a7e547f3eb8821b13f96ea7c0563cdefbbbb60a10e08dda9720ff/torchvision-0.24.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e3f96208b4bef54cd60e415545f5200346a65024e04f29a26cd0006dbf9e8e66", size = 2005342, upload-time = "2025-11-12T15:25:11.871Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/fe/ff27d2ed1b524078164bea1062f23d2618a5fc3208e247d6153c18c91a76/torchvision-0.24.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:f231f6a4f2aa6522713326d0d2563538fa72d613741ae364f9913027fa52ea35", size = 2341708, upload-time = "2025-11-12T15:25:25.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b9/d6c903495cbdfd2533b3ef6f7b5643ff589ea062f8feb5c206ee79b9d9e5/torchvision-0.24.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:1540a9e7f8cf55fe17554482f5a125a7e426347b71de07327d5de6bfd8d17caa", size = 8177239, upload-time = "2025-11-12T15:25:18.554Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2b/ba02e4261369c3798310483028495cf507e6cb3f394f42e4796981ecf3a7/torchvision-0.24.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d83e16d70ea85d2f196d678bfb702c36be7a655b003abed84e465988b6128938", size = 4251604, upload-time = "2025-11-12T15:25:34.069Z" },
+    { url = "https://files.pythonhosted.org/packages/42/84/577b2cef8f32094add5f52887867da4c2a3e6b4261538447e9b48eb25812/torchvision-0.24.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cccf4b4fec7fdfcd3431b9ea75d1588c0a8596d0333245dafebee0462abe3388", size = 2005319, upload-time = "2025-11-12T15:25:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/34/ecb786bffe0159a3b49941a61caaae089853132f3cd1e8f555e3621f7e6f/torchvision-0.24.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1b495edd3a8f9911292424117544f0b4ab780452e998649425d1f4b2bed6695f", size = 2338844, upload-time = "2025-11-12T15:25:32.625Z" },
+    { url = "https://files.pythonhosted.org/packages/51/99/a84623786a6969504c87f2dc3892200f586ee13503f519d282faab0bb4f0/torchvision-0.24.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ab211e1807dc3e53acf8f6638df9a7444c80c0ad050466e8d652b3e83776987b", size = 8175144, upload-time = "2025-11-12T15:25:31.355Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ba/8fae3525b233e109317ce6a9c1de922ab2881737b029a7e88021f81e068f/torchvision-0.24.1-cp314-cp314-win_amd64.whl", hash = "sha256:18f9cb60e64b37b551cd605a3d62c15730c086362b40682d23e24b616a697d41", size = 4234459, upload-time = "2025-11-12T15:25:19.859Z" },
+    { url = "https://files.pythonhosted.org/packages/50/33/481602c1c72d0485d4b3a6b48c9534b71c2957c9d83bf860eb837bf5a620/torchvision-0.24.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec9d7379c519428395e4ffda4dbb99ec56be64b0a75b95989e00f9ec7ae0b2d7", size = 2005336, upload-time = "2025-11-12T15:25:27.225Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7f/372de60bf3dd8f5593bd0d03f4aecf0d1fd58f5bc6943618d9d913f5e6d5/torchvision-0.24.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:af9201184c2712d808bd4eb656899011afdfce1e83721c7cb08000034df353fe", size = 2341704, upload-time = "2025-11-12T15:25:29.857Z" },
+    { url = "https://files.pythonhosted.org/packages/36/9b/0f3b9ff3d0225ee2324ec663de0e7fb3eb855615ca958ac1875f22f1f8e5/torchvision-0.24.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9ef95d819fd6df81bc7cc97b8f21a15d2c0d3ac5dbfaab5cbc2d2ce57114b19e", size = 8177422, upload-time = "2025-11-12T15:25:37.357Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ab/e2bcc7c2f13d882a58f8b30ff86f794210b075736587ea50f8c545834f8a/torchvision-0.24.1-cp314-cp314t-win_amd64.whl", hash = "sha256:480b271d6edff83ac2e8d69bbb4cf2073f93366516a50d48f140ccfceedb002e", size = 4335190, upload-time = "2025-11-12T15:25:35.745Z" },
 ]
 
 [[package]]
@@ -4344,14 +4442,14 @@ wheels = [
 
 [[package]]
 name = "triton"
-version = "3.6.0"
+version = "3.5.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
-    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
-    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/50/9a8358d3ef58162c0a415d173cfb45b67de60176e1024f71fbc4d24c0b6d/triton-3.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2c6b915a03888ab931a9fd3e55ba36785e1fe70cbea0b40c6ef93b20fc85232", size = 170470207, upload-time = "2025-11-11T17:41:00.253Z" },
+    { url = "https://files.pythonhosted.org/packages/27/46/8c3bbb5b0a19313f50edcaa363b599e5a1a5ac9683ead82b9b80fe497c8d/triton-3.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3f4346b6ebbd4fad18773f5ba839114f4826037c9f2f34e0148894cd5dd3dba", size = 170470410, upload-time = "2025-11-11T17:41:06.319Z" },
+    { url = "https://files.pythonhosted.org/packages/37/92/e97fcc6b2c27cdb87ce5ee063d77f8f26f19f06916aa680464c8104ef0f6/triton-3.5.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0b4d2c70127fca6a23e247f9348b8adde979d2e7a20391bfbabaac6aebc7e6a8", size = 170579924, upload-time = "2025-11-11T17:41:12.455Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e6/c595c35e5c50c4bc56a7bac96493dad321e9e29b953b526bbbe20f9911d0/triton-3.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0637b1efb1db599a8e9dc960d53ab6e4637db7d4ab6630a0974705d77b14b60", size = 170480488, upload-time = "2025-11-11T17:41:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/16/b5/b0d3d8b901b6a04ca38df5e24c27e53afb15b93624d7fd7d658c7cd9352a/triton-3.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bac7f7d959ad0f48c0e97d6643a1cc0fd5786fe61cb1f83b537c6b2d54776478", size = 170582192, upload-time = "2025-11-11T17:41:23.963Z" },
 ]
 
 [[package]]
@@ -4400,6 +4498,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
 ]
 
 [[package]]
@@ -4454,6 +4565,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
+]
+
+[[package]]
+name = "wadler-lindig"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/67/cbae4bf7683a64755c2c1778c418fea96d00e34395bb91743f08bd951571/wadler_lindig-0.1.7.tar.gz", hash = "sha256:81d14d3fe77d441acf3ebd7f4aefac20c74128bf460e84b512806dccf7b2cd55", size = 15842, upload-time = "2025-06-18T07:00:42.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl", hash = "sha256:e3ec83835570fd0a9509f969162aeb9c65618f998b1f42918cfc8d45122fe953", size = 20516, upload-time = "2025-06-18T07:00:41.684Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3762,14 +3762,14 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "botorch", marker = "extra == 'shapleig'", specifier = "==0.14.0" },
+    { name = "botorch", marker = "extra == 'shapleig'", specifier = ">=0.14.0" },
     { name = "catboost", marker = "extra == 'proxy'" },
     { name = "colour" },
     { name = "galois", marker = "extra == 'sparse'" },
-    { name = "gpytorch", marker = "extra == 'shapleig'", specifier = "==1.14" },
+    { name = "gpytorch", marker = "extra == 'shapleig'", specifier = ">=1.14" },
     { name = "joblib" },
     { name = "lightgbm", marker = "extra == 'proxy'" },
-    { name = "linear-operator", marker = "extra == 'shapleig'", specifier = "==0.6" },
+    { name = "linear-operator", marker = "extra == 'shapleig'", specifier = ">=0.6" },
     { name = "matplotlib" },
     { name = "networkx" },
     { name = "numpy" },
@@ -3780,7 +3780,7 @@ requires-dist = [
     { name = "scipy" },
     { name = "smac", marker = "extra == 'proxy'" },
     { name = "sparse-transform", marker = "extra == 'sparse'" },
-    { name = "torch", marker = "extra == 'shapleig'", specifier = "==2.9.1" },
+    { name = "torch", marker = "extra == 'shapleig'", specifier = ">=2.9.1" },
     { name = "tqdm" },
     { name = "xgboost", marker = "extra == 'proxy'" },
 ]


### PR DESCRIPTION
ShaplEIG fits a Gaussian process surrogate with a weighted Hamming product kernel on queried coalition values and sequentially selects coalitions by maximizing the closed-form expected information gain about the Shapley values. The Shapley structure is handled via elementary-symmetric-polynomial identities of the kernel's generating polynomials, so the 2^n coalition space is never enumerated.

- new optional extra 'shapleig' (torch/gpytorch/botorch/linear_operator) with lazy import and an informative placeholder when not installed
- shapiq/approximator/shapleig/: approximator + flat Hamming GP surrogate + self-contained ESP math core (controlled copy of the validated reference implementation, kept in sync)
- order-1 SV InteractionValues output (min_order=0, baseline = empty coalition value); SV-variance return left as a commented scaffold until InteractionValues supports uncertainty information
- tqdm progress bar over the BED iterations
- registered in SV_APPROXIMATORS and the public API; unit tests covering output format, determinism, and convergence to ExactComputer ground truth

## Motivation and Context

This PR adds **ShaplEIG**, an approximator for Shapley values based on Bayesian experimental design (BED), accompanying the paper *"ShaplEIG: Bayesian Experimental Design for Shapley Value Estimation"* (Rundel et al., 2026).

The scope was pre-agreed with @mmschlk and @Advueu963: a black-box, end-to-end approximator in `shapiq/approximator/shapleig/` behind a new optional dependency group `shapleig`.

  **Open questions for the maintainers:**

  - The `shapleig` extra is pinned to the exact versions used for the published experiments
  (`torch==2.9.1`, `gpytorch==1.14`, `botorch==0.14.0`, `linear_operator==0.6`). Is this ok?
  - The surrogate posterior also provides the marginal SV *variances*; the code contains a commented
  scaffold to expose them via an `approximate_with_variance` once `InteractionValues` supports
  uncertainty information (future work, as discussed).

---

## Public API Changes

-   [ ] No Public API changes
-   [x] Yes, Public API changes (Details below)

  - New public class `shapiq.ShaplEIG` (= `shapiq.approximator.shapleig.ShaplEIG`), registered in
  `SV_APPROXIMATORS`.
  - New optional dependency group `shapleig` in `pyproject.toml`.
  - No changes to any existing API. `import shapiq` works without the extra installed (the optional
  dependencies are imported in `ShaplEIG.__init__`, which raises an `ImportError` pointing to `pip
  install 'shapiq[shapleig]'` when they are missing).

---

## How Has This Been Tested?

  - New unit tests in `tests/shapiq/tests_unit/tests_approximators/test_approximator_shapleig.py`:
  output format (`InteractionValues`, order 1, `min_order=0`, baseline = empty-coalition value),
  determinism under `random_state`, convergence to `ExactComputer` ground truth with growing budget,
  budget/candidate-set validation, sampled-candidate-subset and warmstart configurations.
  - Verified **bit-identical** against the validated reference implementation of the paper on the
  same game/seed/protocol (default and warmstart configurations).
  - Full local unit suite passes (852 passed; the only failures are pre-existing `[spex]` tests
  caused by the `sparse` extra not being installed locally, identical on `main`).

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes). (Not actively. Does the API reference pick 
  `ShaplEIG` up via the `shapiq.approximator` autosummary?)
-   [x] An entry has been added to `CHANGELOG.md` (if relevant for users).
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
