### PR TITLE
Include KNN explainers in the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,6 +197,7 @@ src/shapiq/_version.py
 docs/source/auto_examples/
 docs/source/sg_execution_times.rst
 docs/source/generated/
+docs/source/gen_modules/
 
 # Local debug / scratch scripts (not public)
 scripts/

--- a/src/shapiq/explainer/__init__.py
+++ b/src/shapiq/explainer/__init__.py
@@ -17,7 +17,19 @@ from shapiq.tree.explainer import TreeExplainer
 
 from .agnostic import AgnosticExplainer
 from .base import Explainer
+from .nn.knn import KNNExplainer
+from .nn.threshold_nn import ThresholdNNExplainer
+from .nn.weighted_knn import WeightedKNNExplainer
 from .tabpfn import TabPFNExplainer
 from .tabular import TabularExplainer
 
-__all__ = ["Explainer", "TabularExplainer", "TabPFNExplainer", "AgnosticExplainer", "TreeExplainer"]
+__all__ = [
+    "Explainer",
+    "TabularExplainer",
+    "TabPFNExplainer",
+    "AgnosticExplainer",
+    "TreeExplainer",
+    "KNNExplainer",
+    "WeightedKNNExplainer",
+    "ThresholdNNExplainer",
+]

--- a/src/shapiq/explainer/nn/base.py
+++ b/src/shapiq/explainer/nn/base.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 from sklearn.utils.validation import check_is_fitted
 
-from shapiq import Explainer
+from shapiq.explainer import Explainer
 
 if TYPE_CHECKING:
     import numpy.typing as npt

--- a/src/shapiq/explainer/nn/knn.py
+++ b/src/shapiq/explainer/nn/knn.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, override
 
 import numpy as np
 
-from shapiq import InteractionValues
 from shapiq.explainer.nn.base import NNExplainerBase
+from shapiq.interaction_values import InteractionValues
 
 from ._util import (
     assert_valid_index_and_order,

--- a/src/shapiq/explainer/nn/threshold_nn.py
+++ b/src/shapiq/explainer/nn/threshold_nn.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from sklearn.neighbors import RadiusNeighborsClassifier
 
     from shapiq.explainer.custom_types import ValidNNExplainerIndices
-from shapiq import InteractionValues
+from shapiq.interaction_values import InteractionValues
 
 from ._util import (
     assert_valid_index_and_order,


### PR DESCRIPTION
## Motivation and Context

The KNN explainer classes were missing from the `__all__` list in `shapiq.explainer`; this PR fixes this.

I also added `docs/source/gen_modules`, which is auto-generated, to `.gitignore`

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

By building the docs locally

---

## Checklist

-   [x] The changes have been tested locally.
-   [x] Documentation has been updated (if the public API or usage changes).
-   [ ] ~An entry has been added to `CHANGELOG.md` (if relevant for users).~
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
