### PR TITLE
Oddshap improvements

### DIFF
--- a/src/shapiq/approximator/regression/oddshap.py
+++ b/src/shapiq/approximator/regression/oddshap.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+from scipy import linalg as scipy_linalg
 from scipy.special import binom
 from sklearn.tree import DecisionTreeRegressor
 
@@ -111,10 +112,18 @@ class OddSHAP(Approximator):
 
     Note:
         Where Algorithm 1 of the paper falls back to TreeSHAP for budgets below
-        ``n * interaction_factor``, this implementation raises ``ValueError`` instead
+        ``interaction_factor``, this implementation raises ``ValueError`` instead
         (no silent downgrade to another estimator), unless the budget already covers
         the full coalition space (``budget >= 2**n``). It therefore does not reproduce
         the low-budget, high-dimension regime of the paper's Figure 2.
+
+        The active support's candidate budget (``ceil(budget / interaction_factor)``)
+        is shared between individuals and higher-order odd interactions: the most
+        relevant individuals (ranked by |Fourier coefficient|, all ``n`` of them
+        always considered) are screened first, and only the remaining candidate
+        budget is spent on higher-order odd interactions. Unlike the paper, low
+        budgets can therefore leave some individuals out of the active support
+        entirely (their Shapley value is then estimated as exactly 0).
     """
 
     valid_indices: tuple[str, ...] = ("SV",)
@@ -193,6 +202,7 @@ class OddSHAP(Approximator):
 
         self.odd_interaction_lookup: dict[tuple[int, ...], int] = {}
         self.odd_interaction_matrix_binary = np.zeros((0, self.n), dtype=bool)
+        self.odd_interaction_matrix_float = np.zeros((0, self.n), dtype=np.float64)
         self.n_active_interactions: int = 0
 
     def approximate(
@@ -213,7 +223,7 @@ class OddSHAP(Approximator):
             Estimated first-order Shapley values.
 
         Raises:
-            ValueError: If ``budget < min(n * interaction_factor, 2**n)``, i.e. the
+            ValueError: If ``budget < min(interaction_factor, 2**n)``, i.e. the
                 budget is below the eta-based minimum and does not cover the full
                 coalition space either. Algorithm 1 of the paper falls back to TreeSHAP
                 in this regime; this implementation deliberately raises instead, so an
@@ -226,7 +236,7 @@ class OddSHAP(Approximator):
         # Fail fast before any (possibly expensive) game evaluation. A budget that
         # covers the full coalition space is always sufficient, even when 2**n is
         # smaller than the eta-based minimum (small n).
-        minimum_budget = min(self.n * self.interaction_factor, 2**self.n)
+        minimum_budget = min(self.interaction_factor, 2**self.n)
         if budget < minimum_budget:
             msg = (
                 "The budget is too small for OddSHAP. "
@@ -254,15 +264,15 @@ class OddSHAP(Approximator):
 
         full_set_value = float(game_values[np.where(full_mask)[0][0]])
 
-        # Higher-order odd support size |T_odd| = ceil(m / eta) - d (paper Alg. 1,
-        # p. 6): the total regression variable count is ceil(m/eta), of which d are
-        # singletons (always included), so only the remainder are screened from the
-        # surrogate's Fourier spectrum.  At full budget all coalitions are enumerated,
-        # so the candidate support is not truncated.
+        # Total active-support candidate budget = ceil(m / eta) (paper Alg. 1, p. 6).
+        # Individuals and higher-order odd interactions draw from this shared budget:
+        # individuals are screened first (see `_select_active_terms`), so only the
+        # remainder goes to higher-order odd interactions. At full budget all
+        # coalitions are enumerated, so the candidate support is not truncated.
         if budget >= 2**self.n:
-            n_candidate_interactions = 2**self.n
+            n_candidate_terms = 2**self.n
         else:
-            n_candidate_interactions = max(0, math.ceil(budget / self.interaction_factor) - self.n)
+            n_candidate_terms = max(0, math.ceil(budget / self.interaction_factor))
 
         return self._approximate_via_odd_regression(
             budget=budget,
@@ -270,7 +280,7 @@ class OddSHAP(Approximator):
             game_values=game_values,
             empty_set_value=empty_set_value,
             full_set_value=full_set_value,
-            n_candidate_interactions=n_candidate_interactions,
+            n_candidate_terms=n_candidate_terms,
         )
 
     def _approximate_via_odd_regression(
@@ -281,24 +291,25 @@ class OddSHAP(Approximator):
         game_values: np.ndarray,
         empty_set_value: float,
         full_set_value: float,
-        n_candidate_interactions: int,
+        n_candidate_terms: int,
     ) -> InteractionValues:
         """Run the OddSHAP odd-regression approximation.
 
         This branch:
         1. fits the tree surrogate
-        2. detects higher-order odd interactions
+        2. selects the active odd support (individuals first, then higher-order
+           odd interactions)
         3. builds the active odd support
         4. constructs the weighted Fourier regression problem
         5. solves the constrained odd regression
         6. transforms the fitted coefficients into Shapley values
         """
         surrogate_model = self._fit_surrogate_model(coalitions=coalitions, game_values=game_values)
-        detected_interactions = self._select_odd_interactions(
-            n_candidate_interactions=n_candidate_interactions,
+        selected_individuals, selected_interactions = self._select_active_terms(
+            n_candidate_terms=n_candidate_terms,
             surrogate_model=surrogate_model,
         )
-        self._build_support(detected_interactions)
+        self._build_support(selected_individuals + selected_interactions)
 
         X_tilde, y_tilde = self._build_weighted_system(
             coalitions=coalitions,
@@ -344,39 +355,23 @@ class OddSHAP(Approximator):
 
     def _build_support(
         self,
-        selected_interactions: list[tuple[int, ...]] | None,
+        selected_terms: list[tuple[int, ...]] | None,
     ) -> None:
-        """Build the active OddSHAP support.
+        """Build the active OddSHAP support from a list of selected terms.
 
-        The support always contains:
-        - the empty interaction ()
-        - all singleton interactions (i,)
-        - selected higher-order odd interactions
-
-        The ordering is deterministic:
-        1. ()
-        2. (0,), (1,), ..., (n-1,)
-        3. sorted selected higher-order odd interactions
+        The support always contains the empty interaction ``()`` plus the given
+        terms (deduplicated and sorted by size then value). Unlike in Fumagalli et al. (20026),
+        singletons are *not* auto-injected here: relevance-based
+        individual selection now happens upstream in ``_select_active_terms``, so
+        only individuals that were actually selected end up in the support.
         """
-        if selected_interactions is None:
+        if selected_terms is None:
             normalized_selected: list[tuple[int, ...]] = []
         else:
-            normalized_set: set[tuple[int, ...]] = set()
+            normalized_set = {tuple(sorted(term)) for term in selected_terms if len(term) >= 1}
+            normalized_selected = sorted(normalized_set, key=lambda term: (len(term), term))
 
-            for interaction in selected_interactions:
-                normalized = tuple(sorted(interaction))
-
-                # skip empty or singleton terms because OddSHAP always includes them
-                if len(normalized) <= 1:
-                    continue
-
-                normalized_set.add(normalized)
-
-            normalized_selected = sorted(normalized_set)
-
-        active_interactions: list[tuple[int, ...]] = [()]
-        active_interactions.extend((player,) for player in range(self.n))
-        active_interactions.extend(normalized_selected)
+        active_interactions: list[tuple[int, ...]] = [(), *normalized_selected]
 
         self.odd_interaction_lookup = {
             interaction: position for position, interaction in enumerate(active_interactions)
@@ -389,7 +384,75 @@ class OddSHAP(Approximator):
                 interaction_matrix_binary[position, list(interaction)] = True
 
         self.odd_interaction_matrix_binary = interaction_matrix_binary
+        self.odd_interaction_matrix_float = interaction_matrix_binary.astype(np.float64)
         self.n_active_interactions = len(active_interactions)
+
+    @staticmethod
+    def _surrogate_to_fourier(surrogate_model: object) -> _FourierDict:
+        """Convert the fitted surrogate to its exact Fourier (Walsh) spectrum."""
+        tree_models = convert_tree_model(surrogate_model)
+        if not isinstance(tree_models, list):
+            tree_models = [tree_models]
+        return _ensemble_to_fourier(tree_models)
+
+    def _select_active_terms(
+        self,
+        *,
+        n_candidate_terms: int,
+        surrogate_model: object | None,
+    ) -> tuple[list[tuple[int, ...]], list[tuple[int, ...]]]:
+        """Split the shared candidate budget between individuals and interactions.
+
+        Implements the paper's "Controlling Higher-Order Terms" priority
+        (Fumagalli et al. 2026, Algorithm 1): the most relevant individuals are
+        screened first from the surrogate's Fourier spectrum (all ``n`` of them
+        are always ranked, whether or not the surrogate happened to split on
+        them), and only the remaining candidate budget is spent screening
+        higher-order odd interactions via ``_select_odd_interactions``.
+        """
+        if surrogate_model is None or n_candidate_terms <= 0:
+            return [], []
+
+        n_individual_terms = min(self.n, n_candidate_terms)
+        selected_individuals = self._select_individual_terms(
+            n_individual_terms=n_individual_terms,
+            surrogate_model=surrogate_model,
+        )
+
+        remaining_budget = n_candidate_terms - len(selected_individuals)
+        selected_interactions = self._select_odd_interactions(
+            n_candidate_interactions=remaining_budget,
+            surrogate_model=surrogate_model,
+        )
+
+        return selected_individuals, selected_interactions
+
+    def _select_individual_terms(
+        self,
+        *,
+        n_individual_terms: int,
+        surrogate_model: object | None = None,
+    ) -> list[tuple[int, ...]]:
+        """Rank all individuals by |Fourier coefficient| and keep the top ones.
+
+        Every player is ranked, including players the surrogate never split on
+        (their coefficient defaults to 0.0 and they rank last), so a scarce
+        budget always prefers players the surrogate found relevant over
+        arbitrary index order.
+        """
+        if surrogate_model is None or n_individual_terms <= 0:
+            return []
+
+        fourier_coefficients = self._surrogate_to_fourier(surrogate_model)
+        singleton_coefficients = {
+            player: float(fourier_coefficients.get((player,), 0.0)) for player in range(self.n)
+        }
+        ranked_players = sorted(
+            singleton_coefficients,
+            key=lambda player: (-abs(singleton_coefficients[player]), player),
+        )
+
+        return [(player,) for player in ranked_players[:n_individual_terms]]
 
     def _select_odd_interactions(
         self,
@@ -407,10 +470,7 @@ class OddSHAP(Approximator):
         if surrogate_model is None or n_candidate_interactions <= 0:
             return []
 
-        tree_models = convert_tree_model(surrogate_model)
-        if not isinstance(tree_models, list):
-            tree_models = [tree_models]
-        fourier_coefficients = _ensemble_to_fourier(tree_models)
+        fourier_coefficients = self._surrogate_to_fourier(surrogate_model)
 
         higher_order_odd: dict[tuple[int, ...], float] = {}
         for interaction, coefficient in fourier_coefficients.items():
@@ -427,19 +487,21 @@ class OddSHAP(Approximator):
         return [interaction for interaction, _ in selected]
 
     def _get_regression_row_weights(self) -> np.ndarray:
-        """Return square-root row weights for the OddSHAP regression problem.
+        """Return raw (non-square-root) row weights for the OddSHAP regression problem.
 
         The weights combine:
         - OddSHAP coalition-size kernel weights
         - sampling adjustment weights from the CoalitionSampler
 
+        Kept un-square-rooted because ``_pair_interior_rows`` combines pairs of
+        rows by doubling their raw weight; the square root is taken once, after
+        pairing, in ``_build_weighted_system``.
         """
         kernel_weights = self._kernel_weights
         coalition_sizes = self._sampler.coalitions_size
         sampling_adjustment_weights = self._sampler.sampling_adjustment_weights
 
-        regression_weights = kernel_weights[coalition_sizes] * sampling_adjustment_weights
-        return np.sqrt(regression_weights)
+        return kernel_weights[coalition_sizes] * sampling_adjustment_weights
 
     def _build_weighted_system(
         self,
@@ -458,6 +520,12 @@ class OddSHAP(Approximator):
             beta_empty = (f(full) + f(empty)) / 2
 
         following Appendix C of the OddSHAP paper.
+
+        When ``drop_boundary_rows`` is set (the only path used by
+        ``approximate``), complementary coalition pairs (S, S^c) sampled by the
+        pairing trick are collapsed into a single combined row each (see
+        ``_pair_interior_rows``), halving the number of regression rows without
+        changing the least-squares solution.
         """
         if self.n_active_interactions == 0:
             msg = "OddSHAP support has not been built yet. Call _build_support(...) first."
@@ -468,46 +536,130 @@ class OddSHAP(Approximator):
 
         if drop_boundary_rows:
             coalition_sizes = np.sum(coalitions, axis=1)
-            inner_row_mask = (coalition_sizes > 0) & (coalition_sizes < self.n)
-
-            coalitions_used = coalitions[inner_row_mask]
-            row_weights_used = row_weights[inner_row_mask]
-            centered_values = (game_values - beta_empty)[inner_row_mask]
+            interior_mask = (coalition_sizes > 0) & (coalition_sizes < self.n)
+            coalitions_used, weights_used, targets_used = self._pair_interior_rows(
+                coalitions=coalitions,
+                game_values=game_values,
+                row_weights=row_weights,
+                interior_mask=interior_mask,
+                beta_empty=beta_empty,
+            )
         else:
             coalitions_used = coalitions
-            row_weights_used = row_weights
-            centered_values = game_values - beta_empty
+            weights_used = row_weights
+            targets_used = game_values - beta_empty
 
         # Drop the empty interaction column because beta_empty is fixed exactly
-        interaction_masks = self.odd_interaction_matrix_binary[1:, :]
-
-        coalitions_int = coalitions_used.astype(np.uint8)
-        interaction_masks_int = interaction_masks.astype(np.uint8)
-
-        parity_matrix = (coalitions_int @ interaction_masks_int.T) % 2
-        # Cast before the Fourier sign transform: uint8 would underflow
-        # 1 - 2 * 1 to 255 instead of -1.
-        design_matrix = 1.0 - 2.0 * parity_matrix.astype(float)
-        X_tilde = design_matrix * row_weights_used[:, np.newaxis]
-        y_tilde = centered_values * row_weights_used
+        interaction_masks = self.odd_interaction_matrix_float[1:, :]
+        parity_matrix = np.remainder(coalitions_used.astype(np.float64) @ interaction_masks.T, 2.0)
+        design_matrix = 1.0 - 2.0 * parity_matrix
+        row_weights_sqrt = np.sqrt(weights_used)
+        X_tilde = design_matrix * row_weights_sqrt[:, np.newaxis]
+        y_tilde = targets_used * row_weights_sqrt
 
         return X_tilde, y_tilde
+
+    def _pair_interior_rows(
+        self,
+        *,
+        coalitions: np.ndarray,
+        game_values: np.ndarray,
+        row_weights: np.ndarray,
+        interior_mask: np.ndarray,
+        beta_empty: float,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Collapse complementary coalition pairs into single combined rows.
+
+        For every active support column T, |T| is odd (singletons and
+        higher-order odd interactions only), so chi_T(S^c) = -chi_T(S). Paired
+        coalitions also share identical kernel*sampling weight (the pairing
+        trick guarantees the complement is sampled, and OddSHAP's symmetric
+        kernel/sampling weights make w(S) == w(S^c)). Under weighted least
+        squares, replacing the two rows
+
+            sqrt(w) * chi(S)  ~  sqrt(w) * (f(S)  - beta_empty)
+            sqrt(w) * chi(S^c) ~ sqrt(w) * (f(S^c) - beta_empty)
+
+        by the single row
+
+            sqrt(2w) * chi(S)  ~  sqrt(2w) * (f(S) - f(S^c)) / 2
+
+        changes the weighted sum-of-squares objective only by a
+        beta-independent constant, so the least-squares solution is identical
+        while using half the rows. Coalitions without a sampled complement (a
+        rare edge case when the sampling budget is exhausted mid-pair) keep
+        their original, beta_empty-centered single-row equation.
+        """
+        interior_idx = np.where(interior_mask)[0]
+        if interior_idx.size == 0:
+            return (
+                np.zeros((0, self.n), dtype=bool),
+                np.zeros(0, dtype=float),
+                np.zeros(0, dtype=float),
+            )
+
+        interior_coalitions = coalitions[interior_idx]
+        packed = np.packbits(interior_coalitions, axis=1)
+        packed_complement = np.packbits(~interior_coalitions, axis=1)
+        local_index_by_key = {row.tobytes(): local for local, row in enumerate(packed)}
+
+        n_interior = interior_idx.size
+        processed = np.zeros(n_interior, dtype=bool)
+        pair_a: list[int] = []
+        pair_b: list[int] = []
+        unpaired: list[int] = []
+        for local in range(n_interior):
+            if processed[local]:
+                continue
+            partner = local_index_by_key.get(packed_complement[local].tobytes())
+            if partner is None:
+                unpaired.append(local)
+            else:
+                pair_a.append(local)
+                pair_b.append(partner)
+                processed[partner] = True
+            processed[local] = True
+
+        idx_a = interior_idx[pair_a]
+        idx_b = interior_idx[pair_b]
+        idx_unpaired = interior_idx[unpaired]
+
+        paired_coalitions = coalitions[idx_a]
+        paired_weights = 2.0 * row_weights[idx_a]
+        paired_targets = 0.5 * (game_values[idx_a] - game_values[idx_b])
+
+        unpaired_coalitions = coalitions[idx_unpaired]
+        unpaired_weights = row_weights[idx_unpaired]
+        unpaired_targets = game_values[idx_unpaired] - beta_empty
+
+        coalitions_used = np.concatenate([paired_coalitions, unpaired_coalitions], axis=0)
+        weights_used = np.concatenate([paired_weights, unpaired_weights])
+        targets_used = np.concatenate([paired_targets, unpaired_targets])
+
+        return coalitions_used, weights_used, targets_used
 
     def _build_constraint_system(
         self,
         *,
         full_set_value: float,
         empty_set_value: float,
-    ) -> tuple[float, np.ndarray, np.ndarray]:
-        """Build the exact OddSHAP Fourier constraint system.
+    ) -> tuple[float, float]:
+        """Build the exact OddSHAP Fourier constraint scalars.
 
         Returns:
             beta_empty = (f(full) + f(empty)) / 2
                 Exact Fourier coefficient for the empty interaction.
-            projection_matrix:
-                Projection onto the orthogonal complement of the all-ones vector.
-            beta_const:
-                A feasible point satisfying the odd-coefficient sum constraint.
+            b = -(f(full) - f(empty)) / 2
+                The exact sum constraint on the non-empty odd coefficients:
+                ``sum(beta_nonempty) == b``.
+
+        Note:
+            The non-empty coefficients live on the hyperplane
+            ``sum(beta) == b``, whose normal is the all-ones vector. Projecting
+            onto (and off) that hyperplane is therefore just row-mean / global-mean
+            subtraction — see ``_solve_constrained_regression`` — so no K x K
+            projection matrix (K = number of non-empty active terms) is ever
+            built or multiplied.
         """
         n_nonempty_terms = self.n_active_interactions - 1
         if n_nonempty_terms <= 0:
@@ -515,17 +667,9 @@ class OddSHAP(Approximator):
             raise RuntimeError(msg)
 
         beta_empty = 0.5 * (full_set_value + empty_set_value)
-
-        # non-empty odd coefficients
         b = -0.5 * (full_set_value - empty_set_value)
 
-        a = np.ones(n_nonempty_terms, dtype=float)
-        denominator = float(a @ a)
-
-        projection_matrix = np.eye(n_nonempty_terms, dtype=float) - np.outer(a, a) / denominator
-        beta_const = (b / denominator) * a
-
-        return beta_empty, projection_matrix, beta_const
+        return beta_empty, b
 
     def _solve_constrained_regression(
         self,
@@ -540,21 +684,33 @@ class OddSHAP(Approximator):
         This solves the non-empty odd coefficients under the exact sum constraint
         from the OddSHAP paper, then assembles the full coefficient vector
         including the empty interaction coefficient.
+
+        The textbook derivation projects onto the ``sum(beta) == b`` hyperplane
+        via a dense K x K projection matrix ``I - ones(K,K)/K``. Because that
+        matrix's only structure is "subtract the mean", the projection reduces
+        algebraically to O(m*K) row-mean subtraction (for ``X_tilde @ projection``)
+        and O(K) global-mean subtraction (for reconstructing beta_nonempty),
+        which is what is implemented below instead of materializing the matrix.
         """
-        beta_empty, projection_matrix, beta_const = self._build_constraint_system(
+        beta_empty, b = self._build_constraint_system(
             full_set_value=full_set_value,
             empty_set_value=empty_set_value,
         )
+        n_nonempty_terms = self.n_active_interactions - 1
 
-        # Project the constrained problem into an unconstrained least-squares problem
-        X_projected = X_tilde @ projection_matrix
-        y_projected = y_tilde - X_tilde @ beta_const
+        # Project the constrained problem into an unconstrained least-squares problem:
+        # X_tilde @ (I - ones(K,K)/K) == X_tilde - row_mean(X_tilde), and
+        # X_tilde @ (b/K * ones(K)) == b * row_mean(X_tilde).
+        row_mean = X_tilde.mean(axis=1)
+        X_projected = X_tilde - row_mean[:, np.newaxis]
+        y_projected = y_tilde - b * row_mean
 
         # Solve for the free projected coordinates
         z_solution = np.linalg.lstsq(X_projected, y_projected, rcond=None)[0]
 
-        # Reconstruct the constrained non-empty coefficient vector
-        beta_nonempty = beta_const + projection_matrix @ z_solution
+        # Reconstruct the constrained non-empty coefficient vector:
+        # beta_const + (I - ones(K,K)/K) @ z_solution == b/K + z_solution - mean(z_solution).
+        beta_nonempty = z_solution + (b / n_nonempty_terms - z_solution.mean())
 
         # Assemble the full coefficient vector including the empty interaction
         beta_full = np.zeros(self.n_active_interactions, dtype=float)
@@ -599,11 +755,13 @@ class OddSHAP(Approximator):
         # The active support contains only () and odd-cardinality interactions
         # (singletons + detected higher-order odds), so the membership matrix
         # already encodes the correct containment and sizes.
-        interaction_sizes = self.odd_interaction_matrix_binary.sum(axis=1).astype(float)  # (K,)
+        interaction_sizes = self.odd_interaction_matrix_float.sum(axis=1)  # (K,)
         # position 0 is () with size 0 — skip it; singletons have size 1
         coeffs = odd_fourier_coefficients[1:]
         sizes = interaction_sizes[1:]
-        masks = self.odd_interaction_matrix_binary[1:]  # (K-1, n) bool
+        # float64 (BLAS-backed) matmul: an order of magnitude faster than the
+        # equivalent bool matmul for this binary membership matrix.
+        masks = self.odd_interaction_matrix_float[1:]  # (K-1, n) float64
 
         # phi_i = -2 * sum_{T: i in T} beta_T / |T|
         shares = coeffs / sizes  # (K-1,)

--- a/src/shapiq/approximator/regression/oddshap.py
+++ b/src/shapiq/approximator/regression/oddshap.py
@@ -112,7 +112,8 @@ class OddSHAP(Approximator):
 
     Note:
         Where Algorithm 1 of the paper falls back to TreeSHAP for budgets below
-        ``interaction_factor``, this implementation raises ``ValueError`` instead
+        ``n * interaction_factor``, this implementation expands the selection of active terms also to individuals,
+          allowing a minimum budget of ``interaction_factor``. Below that, it returns ``ValueError``
         (no silent downgrade to another estimator), unless the budget already covers
         the full coalition space (``budget >= 2**n``). It therefore does not reproduce
         the low-budget, high-dimension regime of the paper's Figure 2.

--- a/src/shapiq/approximator/regression/oddshap.py
+++ b/src/shapiq/approximator/regression/oddshap.py
@@ -414,16 +414,23 @@ class OddSHAP(Approximator):
         if surrogate_model is None or n_candidate_terms <= 0:
             return [], []
 
+        # Convert the surrogate to its Fourier spectrum once and reuse it for both
+        # screening steps; individuals and higher-order odds previously each
+        # recomputed the full surrogate -> Fourier transform.
+        fourier_coefficients = self._surrogate_to_fourier(surrogate_model)
+
         n_individual_terms = min(self.n, n_candidate_terms)
         selected_individuals = self._select_individual_terms(
             n_individual_terms=n_individual_terms,
             surrogate_model=surrogate_model,
+            fourier_coefficients=fourier_coefficients,
         )
 
         remaining_budget = n_candidate_terms - len(selected_individuals)
         selected_interactions = self._select_odd_interactions(
             n_candidate_interactions=remaining_budget,
             surrogate_model=surrogate_model,
+            fourier_coefficients=fourier_coefficients,
         )
 
         return selected_individuals, selected_interactions
@@ -433,6 +440,7 @@ class OddSHAP(Approximator):
         *,
         n_individual_terms: int,
         surrogate_model: object | None = None,
+        fourier_coefficients: _FourierDict | None = None,
     ) -> list[tuple[int, ...]]:
         """Rank all individuals by absolute Fourier coefficient and keep the top ones.
 
@@ -440,11 +448,15 @@ class OddSHAP(Approximator):
         (their coefficient defaults to 0.0 and they rank last), so a scarce
         budget always prefers players the surrogate found relevant over
         arbitrary index order.
+
+        ``fourier_coefficients`` may be passed in to reuse an already-computed
+        spectrum; when omitted it is derived from ``surrogate_model``.
         """
         if surrogate_model is None or n_individual_terms <= 0:
             return []
 
-        fourier_coefficients = self._surrogate_to_fourier(surrogate_model)
+        if fourier_coefficients is None:
+            fourier_coefficients = self._surrogate_to_fourier(surrogate_model)
         singleton_coefficients = {
             player: float(fourier_coefficients.get((player,), 0.0)) for player in range(self.n)
         }
@@ -460,6 +472,7 @@ class OddSHAP(Approximator):
         *,
         n_candidate_interactions: int,
         surrogate_model: object | None = None,
+        fourier_coefficients: _FourierDict | None = None,
     ) -> list[tuple[int, ...]]:
         """Screen higher-order odd interactions from the surrogate's Fourier spectrum.
 
@@ -467,11 +480,15 @@ class OddSHAP(Approximator):
         Algorithm 1 / "Controlling Higher-Order Terms"): the fitted GBT is
         converted to its exact Fourier (Walsh) spectrum and the odd-cardinality
         frequencies with the largest coefficient magnitudes are kept.
+
+        ``fourier_coefficients`` may be passed in to reuse an already-computed
+        spectrum; when omitted it is derived from ``surrogate_model``.
         """
         if surrogate_model is None or n_candidate_interactions <= 0:
             return []
 
-        fourier_coefficients = self._surrogate_to_fourier(surrogate_model)
+        if fourier_coefficients is None:
+            fourier_coefficients = self._surrogate_to_fourier(surrogate_model)
 
         higher_order_odd: dict[tuple[int, ...], float] = {}
         for interaction, coefficient in fourier_coefficients.items():

--- a/src/shapiq/approximator/regression/oddshap.py
+++ b/src/shapiq/approximator/regression/oddshap.py
@@ -11,7 +11,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from scipy import linalg as scipy_linalg
 from scipy.special import binom
 from sklearn.tree import DecisionTreeRegressor
 
@@ -112,16 +111,17 @@ class OddSHAP(Approximator):
 
     Note:
         Where Algorithm 1 of the paper falls back to TreeSHAP for budgets below
-        ``n * interaction_factor``, this implementation expands the selection of active terms also to individuals,
-          allowing a minimum budget of ``interaction_factor``. Below that, it returns ``ValueError``
+        ``n * interaction_factor``, this implementation expands the selection of
+        active terms also to individuals, allowing a minimum budget of
+        ``interaction_factor``. Below that, it raises ``ValueError``
         (no silent downgrade to another estimator), unless the budget already covers
         the full coalition space (``budget >= 2**n``). It therefore does not reproduce
         the low-budget, high-dimension regime of the paper's Figure 2.
 
         The active support's candidate budget (``ceil(budget / interaction_factor)``)
         is shared between individuals and higher-order odd interactions: the most
-        relevant individuals (ranked by |Fourier coefficient|, all ``n`` of them
-        always considered) are screened first, and only the remaining candidate
+        relevant individuals (ranked by absolute Fourier coefficient, all ``n`` of
+        them always considered) are screened first, and only the remaining candidate
         budget is spent on higher-order odd interactions. Unlike the paper, low
         budgets can therefore leave some individuals out of the active support
         entirely (their Shapley value is then estimated as exactly 0).
@@ -361,7 +361,7 @@ class OddSHAP(Approximator):
         """Build the active OddSHAP support from a list of selected terms.
 
         The support always contains the empty interaction ``()`` plus the given
-        terms (deduplicated and sorted by size then value). Unlike in Fumagalli et al. (20026),
+        terms (deduplicated and sorted by size then value). Unlike in Fumagalli et al. (2026),
         singletons are *not* auto-injected here: relevance-based
         individual selection now happens upstream in ``_select_active_terms``, so
         only individuals that were actually selected end up in the support.
@@ -434,7 +434,7 @@ class OddSHAP(Approximator):
         n_individual_terms: int,
         surrogate_model: object | None = None,
     ) -> list[tuple[int, ...]]:
-        """Rank all individuals by |Fourier coefficient| and keep the top ones.
+        """Rank all individuals by absolute Fourier coefficient and keep the top ones.
 
         Every player is ranked, including players the surrogate never split on
         (their coefficient defaults to 0.0 and they rank last), so a scarce

--- a/tests/shapiq/tests_unit/tests_approximators/test_approximator_oddshap.py
+++ b/tests/shapiq/tests_unit/tests_approximators/test_approximator_oddshap.py
@@ -559,6 +559,35 @@ def test_select_active_terms_handles_missing_surrogate():
     assert approx._select_active_terms(n_candidate_terms=10, surrogate_model=None) == ([], [])
 
 
+def test_select_active_terms_computes_fourier_spectrum_once(monkeypatch):
+    """The surrogate -> Fourier transform is shared between the individual and
+    higher-order screening steps: `_select_active_terms` computes it exactly
+    once instead of each screening step recomputing the full spectrum."""
+    n = 8
+    game = SOUM(n=n, n_basis_games=15, max_interaction_size=3, random_state=42)
+    approx = OddSHAP(n=n, random_state=0)
+    *_, surrogate = _fit_surrogate(approx, game, 2**n)
+
+    original_to_fourier = OddSHAP._surrogate_to_fourier
+    call_count = 0
+
+    def counting_to_fourier(model):
+        nonlocal call_count
+        call_count += 1
+        return original_to_fourier(model)
+
+    monkeypatch.setattr(approx, "_surrogate_to_fourier", counting_to_fourier)
+
+    # budget large enough that both screening steps run (all n individuals, then
+    # a non-empty remaining budget for higher-order odd interactions).
+    individuals, interactions = approx._select_active_terms(
+        n_candidate_terms=n + 3,
+        surrogate_model=surrogate,
+    )
+    assert len(individuals) == n  # both screening steps actually executed
+    assert call_count == 1
+
+
 # -----------------------------------------------------------------------------
 # `_build_support` invariants
 # -----------------------------------------------------------------------------
@@ -796,6 +825,70 @@ def test_build_weighted_system_pairing_matches_unpaired_lstsq_solution():
     beta_ref = np.linalg.lstsq(X_ref, y_ref, rcond=None)[0]
 
     assert X_paired.shape[0] == X_ref.shape[0] // 2
+    np.testing.assert_allclose(beta_paired, beta_ref, atol=1e-8)
+
+
+@pytest.mark.parametrize(("n", "budget"), [(8, 120), (10, 300), (8, 90), (12, 500)])
+def test_build_weighted_system_pairing_matches_unpaired_lstsq_at_sub_budget(n, budget):
+    """Row-pairing must stay exact in the sub-budget *sampled* regime, not only
+    at full enumeration.
+
+    The full-budget test above exercises pairing where every complement is
+    trivially present with unit sampling weights. Here coalitions are genuinely
+    sampled (``budget < 2**n``) -- the regime ``approximate`` actually runs in.
+    Two invariants are checked:
+
+    1. every sampled interior pair (S, S^c) carries identical regression row
+       weight (the assumption ``_pair_interior_rows`` relies on), and
+    2. the paired (halved-row) system yields the same least-squares solution as
+       a naive one-row-per-interior-coalition reference.
+    """
+    assert budget < 2**n  # genuinely sub-budget: coalitions are sampled, not enumerated
+    game = SOUM(n=n, n_basis_games=15, max_interaction_size=3, random_state=42)
+    approx = OddSHAP(n=n, random_state=0)
+    approx._sampler.sample(budget)
+    coalitions = approx._sampler.coalitions_matrix
+    game_values = np.asarray(game(coalitions), dtype=float)
+    approx._build_support([(i,) for i in range(n)] + [(0, 1, 2)])
+
+    empty_set_value = float(game(np.zeros((1, n), dtype=bool))[0])
+    full_set_value = float(game(np.ones((1, n), dtype=bool))[0])
+
+    # (1) complementary interior pairs share the same regression row weight
+    row_weights = approx._get_regression_row_weights()
+    coalition_sizes = coalitions.sum(axis=1)
+    interior = np.where((coalition_sizes > 0) & (coalition_sizes < n))[0]
+    index_by_row = {coalitions[i].tobytes(): i for i in interior}
+    n_rows_with_partner = 0
+    for i in interior:
+        j = index_by_row.get((~coalitions[i]).tobytes())
+        if j is not None:
+            n_rows_with_partner += 1
+            assert row_weights[i] == pytest.approx(row_weights[j])
+    # the pairing trick samples every interior complement, so all interior rows
+    # are paired and the paired system holds exactly half of them
+    assert n_rows_with_partner == len(interior)
+
+    # (2) paired system matches the naive unpaired reference
+    X_paired, y_paired = approx._build_weighted_system(
+        coalitions=coalitions,
+        game_values=game_values,
+        empty_set_value=empty_set_value,
+        full_set_value=full_set_value,
+        drop_boundary_rows=True,
+    )
+    beta_paired = np.linalg.lstsq(X_paired, y_paired, rcond=None)[0]
+
+    beta_empty = 0.5 * (full_set_value + empty_set_value)
+    interaction_masks = approx.odd_interaction_matrix_float[1:, :]
+    parity = (coalitions[interior].astype(float) @ interaction_masks.T) % 2
+    design = 1.0 - 2.0 * parity
+    sqrtw = np.sqrt(row_weights[interior])
+    X_ref = design * sqrtw[:, None]
+    y_ref = (game_values[interior] - beta_empty) * sqrtw
+    beta_ref = np.linalg.lstsq(X_ref, y_ref, rcond=None)[0]
+
+    assert X_paired.shape[0] == len(interior) // 2
     np.testing.assert_allclose(beta_paired, beta_ref, atol=1e-8)
 
 

--- a/tests/shapiq/tests_unit/tests_approximators/test_approximator_oddshap.py
+++ b/tests/shapiq/tests_unit/tests_approximators/test_approximator_oddshap.py
@@ -482,17 +482,13 @@ def test_select_individual_terms_handles_zero_budget():
     game = SOUM(n=n, n_basis_games=15, max_interaction_size=3, random_state=42)
     approx = OddSHAP(n=n, random_state=0)
     *_, surrogate = _fit_surrogate(approx, game, 2**n)
-    assert (
-        approx._select_individual_terms(n_individual_terms=0, surrogate_model=surrogate) == []
-    )
+    assert approx._select_individual_terms(n_individual_terms=0, surrogate_model=surrogate) == []
 
 
 def test_select_individual_terms_handles_missing_surrogate():
     n = 8
     approx = OddSHAP(n=n, random_state=0)
-    assert (
-        approx._select_individual_terms(n_individual_terms=3, surrogate_model=None) == []
-    )
+    assert approx._select_individual_terms(n_individual_terms=3, surrogate_model=None) == []
 
 
 def test_select_individual_terms_respects_k_and_returns_singletons():

--- a/tests/shapiq/tests_unit/tests_approximators/test_approximator_oddshap.py
+++ b/tests/shapiq/tests_unit/tests_approximators/test_approximator_oddshap.py
@@ -3,12 +3,15 @@
 OddSHAP estimates first-order Shapley values via paired sampling + odd-only
 Fourier regression. A LightGBM surrogate is fitted to the sampled coalitions
 and its exact Fourier spectrum (extracted via ProxySPEX's tree-to-Fourier
-routine) screens the top ``ceil(budget / interaction_factor)`` odd
-higher-order interactions; the active support is then solved with a
-constrained weighted Fourier regression and the odd coefficients are
-transformed into Shapley values. Budgets below ``n * interaction_factor``
-are rejected with a ``ValueError`` (there is deliberately no fallback to
-another estimator).
+routine) screens the active support: the shared candidate budget
+``ceil(budget / interaction_factor)`` is spent on the most relevant
+individuals first (all ``n`` of them ranked, even those the surrogate never
+split on), and only the remainder is spent screening higher-order odd
+interactions. The active support is then solved with a constrained weighted
+Fourier regression (row-paired for efficiency, see below) and the odd
+coefficients are transformed into Shapley values. Budgets below
+``interaction_factor`` are rejected with a ``ValueError`` (there is
+deliberately no fallback to another estimator).
 
 The constraint system enforces the exact identities
     beta_empty = (f(N) + f(empty)) / 2,
@@ -270,18 +273,18 @@ def test_different_seed_differs():
 
 
 def test_low_budget_raises_value_error():
-    """budget < n * interaction_factor must raise ValueError, not silently fall back."""
+    """budget < interaction_factor must raise ValueError, not silently fall back."""
     n = 8
     game = SOUM(n=n, n_basis_games=15, max_interaction_size=3, random_state=42)
     approx = OddSHAP(n=n, random_state=0)
-    budget = n * approx.interaction_factor - 1
+    budget = approx.interaction_factor - 1
     with pytest.raises(ValueError, match="too small"):
         approx.approximate(budget, game)
 
 
 def test_full_enumeration_bypasses_minimum_budget():
-    """budget >= 2**n is accepted even when 2**n < n * interaction_factor (small n)."""
-    n = 4  # 2**4 = 16 < 40 = n * eta
+    """budget >= 2**n is accepted even when 2**n < interaction_factor (small n)."""
+    n = 3  # 2**3 = 8 < 10 = interaction_factor (default)
     game = DummyGame(n=n, interaction=(1, 2))
     iv = OddSHAP(n=n, random_state=0).approximate(2**n, game)
     assert isinstance(iv, InteractionValues)
@@ -292,21 +295,20 @@ def test_full_enumeration_bypasses_minimum_budget():
 
 def test_small_budget_below_full_enumeration_still_raises():
     """Below both the eta-based minimum and 2**n the ValueError is kept, and the
-    message reports the effective minimum (16 = 2**4, not n * eta = 40)."""
+    message reports the effective minimum (10 = interaction_factor, not 2**4 = 16)."""
     n = 4
     game = DummyGame(n=n, interaction=(1, 2))
-    with pytest.raises(ValueError, match="at least 16 evaluations"):
-        OddSHAP(n=n, random_state=0).approximate(2**n - 1, game)
+    with pytest.raises(ValueError, match="at least 10 evaluations"):
+        OddSHAP(n=n, random_state=0).approximate(9, game)
 
 
 def test_boundary_budget_uses_paper_candidate_count(monkeypatch):
-    """At budget = n * interaction_factor (the minimum permitted),
-    `_select_odd_interactions` should be called with the paper's
-    candidate count `ceil(budget / interaction_factor)`.
+    """At budget = interaction_factor (the minimum permitted), `_select_active_terms`
+    should be called with the paper's candidate count `ceil(budget / interaction_factor)`.
     """
     n = 8
     approx = OddSHAP(n=n, random_state=0)
-    budget = n * approx.interaction_factor
+    budget = approx.interaction_factor
     captured = {}
 
     def additive_game(coalitions):
@@ -315,18 +317,16 @@ def test_boundary_budget_uses_paper_candidate_count(monkeypatch):
     def fake_fit_surrogate_model(*, coalitions, game_values):
         return object()
 
-    def fake_select_odd_interactions(**kwargs):
-        captured["n_candidate_interactions"] = kwargs["n_candidate_interactions"]
-        return []
+    def fake_select_active_terms(**kwargs):
+        captured["n_candidate_terms"] = kwargs["n_candidate_terms"]
+        return [(0,)], []
 
     monkeypatch.setattr(approx, "_fit_surrogate_model", fake_fit_surrogate_model)
-    monkeypatch.setattr(approx, "_select_odd_interactions", fake_select_odd_interactions)
+    monkeypatch.setattr(approx, "_select_active_terms", fake_select_active_terms)
 
     approx.approximate(budget, additive_game)
 
-    assert captured["n_candidate_interactions"] == max(
-        0, math.ceil(budget / approx.interaction_factor) - n
-    )
+    assert captured["n_candidate_terms"] == math.ceil(budget / approx.interaction_factor)
 
 
 def test_candidate_interaction_count_matches_paper(monkeypatch):
@@ -341,18 +341,16 @@ def test_candidate_interaction_count_matches_paper(monkeypatch):
     def fake_fit_surrogate_model(*, coalitions, game_values):
         return object()
 
-    def fake_select_odd_interactions(**kwargs):
-        captured["n_candidate_interactions"] = kwargs["n_candidate_interactions"]
-        return []
+    def fake_select_active_terms(**kwargs):
+        captured["n_candidate_terms"] = kwargs["n_candidate_terms"]
+        return [(0,)], []
 
     monkeypatch.setattr(approx, "_fit_surrogate_model", fake_fit_surrogate_model)
-    monkeypatch.setattr(approx, "_select_odd_interactions", fake_select_odd_interactions)
+    monkeypatch.setattr(approx, "_select_active_terms", fake_select_active_terms)
 
     approx.approximate(budget, additive_game)
 
-    assert captured["n_candidate_interactions"] == max(
-        0, math.ceil(budget / approx.interaction_factor) - n
-    )
+    assert captured["n_candidate_terms"] == math.ceil(budget / approx.interaction_factor)
 
 
 # -----------------------------------------------------------------------------
@@ -439,17 +437,17 @@ def test_full_budget_bypasses_candidate_truncation(monkeypatch):
     def additive_game(coalitions):
         return coalitions.astype(float).sum(axis=1)
 
-    def fake_select_odd_interactions(**kwargs):
-        captured["n_candidate_interactions"] = kwargs["n_candidate_interactions"]
-        return []
+    def fake_select_active_terms(**kwargs):
+        captured["n_candidate_terms"] = kwargs["n_candidate_terms"]
+        return [(0,)], []
 
     monkeypatch.setattr(approx, "_fit_surrogate_model", lambda **kw: object())
-    monkeypatch.setattr(approx, "_select_odd_interactions", fake_select_odd_interactions)
+    monkeypatch.setattr(approx, "_select_active_terms", fake_select_active_terms)
 
     approx.approximate(2**n, additive_game)
 
-    assert captured["n_candidate_interactions"] == 2**n
-    assert captured["n_candidate_interactions"] > math.ceil(2**n / approx.interaction_factor)
+    assert captured["n_candidate_terms"] == 2**n
+    assert captured["n_candidate_terms"] > math.ceil(2**n / approx.interaction_factor)
 
 
 def test_select_odd_interactions_returns_full_support_for_large_k():
@@ -473,27 +471,125 @@ def test_select_odd_interactions_returns_full_support_for_large_k():
 
 
 # -----------------------------------------------------------------------------
+# Individual screening (_select_individual_terms) and budget orchestration
+# (_select_active_terms): individuals are ranked by relevance and take
+# priority over higher-order odd interactions for the shared candidate budget.
+# -----------------------------------------------------------------------------
+
+
+def test_select_individual_terms_handles_zero_budget():
+    n = 8
+    game = SOUM(n=n, n_basis_games=15, max_interaction_size=3, random_state=42)
+    approx = OddSHAP(n=n, random_state=0)
+    *_, surrogate = _fit_surrogate(approx, game, 2**n)
+    assert (
+        approx._select_individual_terms(n_individual_terms=0, surrogate_model=surrogate) == []
+    )
+
+
+def test_select_individual_terms_handles_missing_surrogate():
+    n = 8
+    approx = OddSHAP(n=n, random_state=0)
+    assert (
+        approx._select_individual_terms(n_individual_terms=3, surrogate_model=None) == []
+    )
+
+
+def test_select_individual_terms_respects_k_and_returns_singletons():
+    n = 10
+    game = SOUM(n=n, n_basis_games=15, max_interaction_size=3, random_state=42)
+    approx = OddSHAP(n=n, random_state=0)
+    *_, surrogate = _fit_surrogate(approx, game, 2**n)
+    k = 4
+    selected = approx._select_individual_terms(n_individual_terms=k, surrogate_model=surrogate)
+    assert len(selected) == k
+    assert all(isinstance(t, tuple) and len(t) == 1 for t in selected)
+    assert len(set(selected)) == k  # no duplicates
+
+
+def test_select_individual_terms_caps_at_n():
+    n = 5
+    game = SOUM(n=n, n_basis_games=15, max_interaction_size=3, random_state=42)
+    approx = OddSHAP(n=n, random_state=0)
+    *_, surrogate = _fit_surrogate(approx, game, 2**n)
+    selected = approx._select_individual_terms(n_individual_terms=100, surrogate_model=surrogate)
+    assert len(selected) == n
+    assert set(selected) == {(i,) for i in range(n)}
+
+
+def test_select_active_terms_prioritizes_individuals_over_interactions():
+    """With a budget smaller than n, all of it goes to individuals; nothing is
+    left for higher-order odd interactions."""
+    n = 10
+    game = SOUM(n=n, n_basis_games=15, max_interaction_size=3, random_state=42)
+    approx = OddSHAP(n=n, random_state=0)
+    *_, surrogate = _fit_surrogate(approx, game, 2**n)
+    individuals, interactions = approx._select_active_terms(
+        n_candidate_terms=4,
+        surrogate_model=surrogate,
+    )
+    assert len(individuals) == 4
+    assert interactions == []
+
+
+def test_select_active_terms_splits_budget_after_all_individuals():
+    """With a budget larger than n, all n individuals are selected and the
+    remainder is spent on higher-order odd interactions."""
+    n = 6
+    game = SOUM(n=n, n_basis_games=15, max_interaction_size=3, random_state=42)
+    approx = OddSHAP(n=n, random_state=0)
+    *_, surrogate = _fit_surrogate(approx, game, 2**n)
+    budget = n + 3
+    individuals, interactions = approx._select_active_terms(
+        n_candidate_terms=budget,
+        surrogate_model=surrogate,
+    )
+    assert len(individuals) == n
+    assert set(individuals) == {(i,) for i in range(n)}
+    assert len(interactions) <= 3
+
+
+def test_select_active_terms_handles_zero_budget():
+    n = 6
+    game = SOUM(n=n, n_basis_games=15, max_interaction_size=3, random_state=42)
+    approx = OddSHAP(n=n, random_state=0)
+    *_, surrogate = _fit_surrogate(approx, game, 2**n)
+    assert approx._select_active_terms(n_candidate_terms=0, surrogate_model=surrogate) == ([], [])
+
+
+def test_select_active_terms_handles_missing_surrogate():
+    n = 6
+    approx = OddSHAP(n=n, random_state=0)
+    assert approx._select_active_terms(n_candidate_terms=10, surrogate_model=None) == ([], [])
+
+
+# -----------------------------------------------------------------------------
 # `_build_support` invariants
 # -----------------------------------------------------------------------------
 
 
-def test_build_support_always_includes_empty_and_singletons():
+def test_build_support_includes_only_given_terms():
+    """_build_support no longer force-injects singletons: only () plus the
+    given terms end up in the support (individual relevance-selection now
+    happens upstream, in `_select_active_terms`)."""
     n = 6
     approx = OddSHAP(n=n, random_state=0)
-    approx._build_support([(0, 1, 2)])
+    approx._build_support([(0, 1, 2), (0,), (3,)])
     assert () in approx.odd_interaction_lookup
-    for i in range(n):
-        assert (i,) in approx.odd_interaction_lookup
+    assert (0,) in approx.odd_interaction_lookup
+    assert (3,) in approx.odd_interaction_lookup
+    assert (1,) not in approx.odd_interaction_lookup
     assert (0, 1, 2) in approx.odd_interaction_lookup
+    assert approx.n_active_interactions == 4  # (), (0,), (3,), (0,1,2)
 
 
-def test_build_support_drops_singleton_inputs():
-    """_build_support skips singleton inputs because singletons are always included."""
+def test_build_support_keeps_singleton_inputs():
+    """Singleton terms passed to _build_support are respected (they are no
+    longer special-cased / dropped)."""
     n = 6
     approx = OddSHAP(n=n, random_state=0)
     approx._build_support([(0,), (0, 1, 2, 3, 4)])
-    higher_order = {t for t in approx.odd_interaction_lookup if len(t) >= 2}
-    assert higher_order == {(0, 1, 2, 3, 4)}
+    assert set(approx.odd_interaction_lookup) == {(), (0,), (0, 1, 2, 3, 4)}
 
 
 def test_build_support_normalizes_unsorted_tuples():
@@ -508,9 +604,13 @@ def test_build_support_n_active_interactions_consistent():
     n = 6
     approx = OddSHAP(n=n, random_state=0)
     approx._build_support([(0, 1, 2), (1, 3, 5)])
-    expected = 1 + n + 2  # empty + n singletons + 2 higher-order odd
+    expected = 1 + 2  # empty + 2 higher-order odd (no singletons auto-added anymore)
     assert approx.n_active_interactions == expected
     assert approx.odd_interaction_matrix_binary.shape == (expected, n)
+    assert approx.odd_interaction_matrix_float.shape == (expected, n)
+    np.testing.assert_array_equal(
+        approx.odd_interaction_matrix_float, approx.odd_interaction_matrix_binary.astype(float)
+    )
 
 
 # -----------------------------------------------------------------------------
@@ -621,16 +721,18 @@ def test_tree_params_without_depth_keeps_paper_default():
 
 
 def test_build_support_with_none_yields_baseline_support():
-    """`_build_support(None)` produces the minimal support: () plus singletons."""
+    """`_build_support(None)` produces the minimal support: only ()."""
     n = 5
     approx = OddSHAP(n=n, random_state=0)
     approx._build_support(None)
-    assert approx.n_active_interactions == n + 1
-    assert list(approx.odd_interaction_lookup) == [()] + [(i,) for i in range(n)]
+    assert approx.n_active_interactions == 1
+    assert list(approx.odd_interaction_lookup) == [()]
 
 
 def test_build_weighted_system_keeps_boundary_rows_when_requested():
-    """`drop_boundary_rows=False` keeps the empty and grand coalition rows."""
+    """`drop_boundary_rows=False` keeps the empty and grand coalition rows;
+    `drop_boundary_rows=True` additionally halves the interior rows by
+    collapsing complementary coalition pairs (see `_pair_interior_rows`)."""
     n = 5
     game = DummyGame(n=n, interaction=(1, 2))
     approx = OddSHAP(n=n, random_state=0)
@@ -653,8 +755,52 @@ def test_build_weighted_system_keeps_boundary_rows_when_requested():
         drop_boundary_rows=False,
     )
     assert x_keep.shape[0] == coalitions.shape[0]
-    assert x_keep.shape[0] == x_drop.shape[0] + 2
+    assert x_keep.shape[0] == 2**n
+    # full enumeration: every interior coalition's complement is also present,
+    # so pairing exactly halves the (2**n - 2) interior rows.
+    assert x_drop.shape[0] == (2**n - 2) // 2
     assert y_keep.shape[0] == x_keep.shape[0]
+
+
+def test_build_weighted_system_pairing_matches_unpaired_lstsq_solution():
+    """The paired (halved-row) system must yield an algebraically identical
+    least-squares solution to a naive one-row-per-coalition reference system,
+    confirming the row-pairing optimization changes performance, not results."""
+    n = 6
+    game = SOUM(n=n, n_basis_games=15, max_interaction_size=3, random_state=1)
+    approx = OddSHAP(n=n, random_state=0)
+    approx._sampler.sample(2**n)
+    coalitions = approx._sampler.coalitions_matrix
+    game_values = np.asarray(game(coalitions), dtype=float)
+    approx._build_support([(i,) for i in range(n)] + [(0, 1, 2), (1, 2, 3, 4, 5)])
+
+    empty_set_value = float(game(np.zeros((1, n), dtype=bool))[0])
+    full_set_value = float(game(np.ones((1, n), dtype=bool))[0])
+
+    X_paired, y_paired = approx._build_weighted_system(
+        coalitions=coalitions,
+        game_values=game_values,
+        empty_set_value=empty_set_value,
+        full_set_value=full_set_value,
+        drop_boundary_rows=True,
+    )
+    beta_paired = np.linalg.lstsq(X_paired, y_paired, rcond=None)[0]
+
+    # naive reference: one row per interior coalition, no pairing
+    beta_empty = 0.5 * (full_set_value + empty_set_value)
+    coalition_sizes = coalitions.sum(axis=1)
+    interior_mask = (coalition_sizes > 0) & (coalition_sizes < n)
+    row_weights = approx._get_regression_row_weights()[interior_mask]
+    interaction_masks = approx.odd_interaction_matrix_float[1:, :]
+    parity = (coalitions[interior_mask].astype(float) @ interaction_masks.T) % 2
+    design = 1.0 - 2.0 * parity
+    sqrtw = np.sqrt(row_weights)
+    X_ref = design * sqrtw[:, None]
+    y_ref = (game_values[interior_mask] - beta_empty) * sqrtw
+    beta_ref = np.linalg.lstsq(X_ref, y_ref, rcond=None)[0]
+
+    assert X_paired.shape[0] == X_ref.shape[0] // 2
+    np.testing.assert_allclose(beta_paired, beta_ref, atol=1e-8)
 
 
 # -----------------------------------------------------------------------------
@@ -721,7 +867,7 @@ def test_transform_to_shapley_vectorized_matches_formula():
     """The vectorized Shapley transform matches the expected closed-form values."""
     n = 6
     approx = OddSHAP(n=n, random_state=0)
-    approx._build_support([(0, 1, 2)])
+    approx._build_support([(i,) for i in range(n)] + [(0, 1, 2)])
     coeffs = np.ones(approx.n_active_interactions)
     sv = approx._transform_to_shapley(coeffs, baseline_value=0.0)
     # singletons contribute -2 * 1/1 = -2; the triple contributes -2 * 1/3
@@ -729,4 +875,17 @@ def test_transform_to_shapley_vectorized_matches_formula():
         expected = -2.0 * 1.0  # singleton (i,)
         if i in (0, 1, 2):
             expected += -2.0 * (1.0 / 3.0)  # triple (0,1,2)
+        np.testing.assert_allclose(sv[i + 1], expected, atol=1e-12)
+
+
+def test_transform_to_shapley_zero_for_unselected_players():
+    """A player with no selected term in the active support gets a Shapley
+    value of exactly 0 (only relevant, selected terms are ever screened)."""
+    n = 6
+    approx = OddSHAP(n=n, random_state=0)
+    approx._build_support([(0, 1, 2)])  # no singletons selected at all
+    coeffs = np.ones(approx.n_active_interactions)
+    sv = approx._transform_to_shapley(coeffs, baseline_value=0.0)
+    for i in range(n):
+        expected = -2.0 * (1.0 / 3.0) if i in (0, 1, 2) else 0.0
         np.testing.assert_allclose(sv[i + 1], expected, atol=1e-12)


### PR DESCRIPTION
## Motivation and Context

Improvements in OddSHAP:
(1) Minimum budget changed from `interaction_factor * n` to `interaction_factor` by relaxing the condition that all individuals have to be in the Fourier regression support. Instead, the surrogate tree will now also detect the most important individuals in the low-budget regime. After `interaction_factor *n`, the interaction detection begins, which is similarl to the one described in the paper.
(2) Paired subsets are merged into a single row, which halves the number of rows in the Fourier regression without changing the solution to the least squares problem, as described in the paper.

## Public API Changes

-   [x ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

Expanded the unit test, and tested some tabular benchmarks.

## Checklist

-   [x] The changes have been tested locally.
-   [x] Documentation has been updated (if the public API or usage changes).
-   [ ] An entry has been added to `CHANGELOG.md` (if relevant for users).
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
