### PR TITLE
Prepare v1.6.0 changelog (2026-07-06)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,27 @@ jobs:
             -   name: Test import of shapiq_games
                 run: uv run --no-sync python -c "import shapiq_games; print('shapiq_games imported successfully')"
     # ----------------------------------------------------------------------------------------------
+    # Install, Import, and Test `shapiq_benchmark`
+    # ----------------------------------------------------------------------------------------------
+    test_shapiq_benchmark:
+        name: Install and test shapiq-benchmark
+        runs-on: ubuntu-latest
+        needs:
+            - install_and_import_shapiq
+        steps:
+            -   uses: actions/checkout@v7
+            -   name: Set up Python and uv
+                uses: astral-sh/setup-uv@v7
+                with:
+                    python-version: "3.12"
+                    enable-cache: true
+            -   name: Install shapiq package and dependencies for shapiq-benchmark
+                run: uv sync --all-extras
+            -   name: Test import of shapiq_benchmark
+                run: uv run --no-sync python -c "import shapiq_benchmark; print('shapiq_benchmark imported successfully')"
+            -   name: Run shapiq_benchmark unit tests
+                run: uv run --no-sync pytest "tests/shapiq_benchmark"
+    # ----------------------------------------------------------------------------------------------
     # Unit Tests for shapiq (Stable Python and Matrix)
     # ----------------------------------------------------------------------------------------------
     test_shapiq_stable:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,35 @@
 # Changelog
 
-## Unreleased
+## v1.6.0 (2026-07-06)
 
-### Added
+### Highlights of new Features
 
-- Adds the `OddSHAP` approximator for first-order Shapley values (Fumagalli et al., 2026, arXiv:2602.01399): paired sampling, sparse odd-interaction screening via the ProxySPEX tree-to-Fourier extraction, and a constrained odd Fourier regression that enforces the efficiency axiom exactly. [#522](https://github.com/mmschlk/shapiq/pull/522)
-### New Features
+- adds the `OddSHAP` approximator in `shapiq.approximator.regression` for fast first-order Shapley value estimation via odd-only Fourier regression (Fumagalli et al., 2026) [#522](https://github.com/mmschlk/shapiq/pull/522)
+- adds the `ShaplEIG` approximator in `shapiq.approximator.shapleig` for Shapley value estimation via Bayesian experimental design (Rundel et al., 2026) [#548](https://github.com/mmschlk/shapiq/pull/548)
 
-- adds the `ShaplEIG` approximator in `shapiq.approximator.shapleig` for Shapley value estimation via Bayesian experimental design: a Gaussian process surrogate with a weighted Hamming kernel is fit on the queried coalition values, and the next coalition is selected by maximizing the closed-form expected information gain about the Shapley values. Requires the new optional `shapleig` dependency group (`pip install shapiq[shapleig]` — torch, gpytorch, botorch, linear-operator); the optional dependencies are imported lazily in the constructor.
+### Introducing OddSHAP [#522](https://github.com/mmschlk/shapiq/pull/522), [Preprint](https://arxiv.org/abs/2602.01399)
+
+Adds [`OddSHAP`](src/shapiq/approximator/regression/oddshap.py), a first-order Shapley value estimator that exploits the *odd* structure of the Shapley value (Fumagalli et al., 2026, "An Odd Estimator for Shapley Values"). It combines **paired sampling**, **sparse odd-interaction screening** via a surrogate tree model whose exact Fourier (Walsh) coefficients are extracted, and a **constrained odd Fourier regression** that enforces the efficiency axiom exactly. The surrogate defaults to LightGBM (the paper's configuration) and transparently falls back to a scikit-learn `DecisionTreeRegressor` when LightGBM is unavailable. It is exported as `shapiq.OddSHAP` and restricted to `index="SV"`, `max_order=1`.
+
+> Note: where Algorithm 1 of the paper falls back to TreeSHAP for budgets below `n * interaction_factor`, this implementation raises `ValueError` instead — so an under-budgeted call never silently returns a different estimator's values — unless the budget already covers the full coalition space (`budget >= 2**n`).
+
+### Introducing ShaplEIG [#548](https://github.com/mmschlk/shapiq/pull/548), [Preprint](https://arxiv.org/abs/2606.02247)
+
+Adds [`ShaplEIG`](src/shapiq/approximator/shapleig/shapleig.py), a **Bayesian experimental design** approximator for Shapley values (Rundel et al., 2026, "ShaplEIG: Bayesian Experimental Design for Shapley Value Estimation"). A Gaussian process surrogate with a weighted Hamming product kernel is fit on the queried coalition values, and the next coalition to evaluate is selected by maximizing the closed-form **expected information gain (EIG)** about the Shapley values. The Shapley structure is handled through elementary-symmetric-polynomial identities, so the full `2^n` coalition space is never enumerated and each iteration costs only polynomial time in `n`. The returned `InteractionValues` hold the posterior-mean Shapley value estimates; `approximate_with_variance` additionally returns their marginal posterior variances. It is exported as `shapiq.ShaplEIG`.
+
+ShaplEIG requires the new optional `shapleig` dependency group (`pip install shapiq[shapleig]` — `torch`, `gpytorch`, `botorch`, `linear_operator`); these optional dependencies are imported lazily in the constructor.
+
+### shapiq Benchmark [#521](https://github.com/mmschlk/shapiq/pull/521)
+
+Adds the `shapiq_benchmark` package, a framework to configure and run approximation benchmarks from either string tags or objects. It ships benchmark types for local XAI, image, TabPFN, path-dependent, and interventional games, a set of approximation-quality metrics, and Optuna-based hyperparameter optimization scripts with pre-computed best-parameter configs.
+
+### Documentation
+
+- includes the nearest-neighbor explainers (`KNNExplainer`, `WeightedKNNExplainer`, `ThresholdNNExplainer`) in the API documentation and the `shapiq.explainer` package exports [#558](https://github.com/mmschlk/shapiq/pull/558)
+
+### Maintenance
+
+- bumps `actions/checkout` from 6 to 7 [#555](https://github.com/mmschlk/shapiq/pull/555)
 
 ## v1.5.2 (2026-06-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ ShaplEIG requires the new optional `shapleig` dependency group (`pip install sha
 
 Adds the `shapiq_benchmark` package, a framework to configure and run approximation benchmarks from either string tags or objects. It ships benchmark types for local XAI, image, TabPFN, path-dependent, and interventional games, a set of approximation-quality metrics, and Optuna-based hyperparameter optimization scripts with pre-computed best-parameter configs.
 
+The package installs next to `shapiq` (like `shapiq_games`) and imports on a plain `pip install shapiq`. Its model backends are optional and imported lazily; install them with `pip install shapiq[benchmark]` (`optuna`, `tabpfn`, `lightgbm`, `xgboost`) to build the corresponding models or run the hyperparameter optimization.
+
 ### Documentation
 
 - includes the nearest-neighbor explainers (`KNNExplainer`, `WeightedKNNExplainer`, `ThresholdNNExplainer`) in the API documentation and the `shapiq.explainer` package exports [#558](https://github.com/mmschlk/shapiq/pull/558)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 Adds [`OddSHAP`](src/shapiq/approximator/regression/oddshap.py), a first-order Shapley value estimator that exploits the *odd* structure of the Shapley value (Fumagalli et al., 2026, "An Odd Estimator for Shapley Values"). It combines **paired sampling**, **sparse odd-interaction screening** via a surrogate tree model whose exact Fourier (Walsh) coefficients are extracted, and a **constrained odd Fourier regression** that enforces the efficiency axiom exactly. The surrogate defaults to LightGBM (the paper's configuration) and transparently falls back to a scikit-learn `DecisionTreeRegressor` when LightGBM is unavailable. It is exported as `shapiq.OddSHAP` and restricted to `index="SV"`, `max_order=1`.
 
-> Note: where Algorithm 1 of the paper falls back to TreeSHAP for budgets below `n * interaction_factor`, this implementation raises `ValueError` instead — so an under-budgeted call never silently returns a different estimator's values — unless the budget already covers the full coalition space (`budget >= 2**n`).
+> Note: unlike Algorithm 1 of the paper, which falls back to TreeSHAP at low budgets, this implementation never silently downgrades to another estimator — below the minimum budget of `min(interaction_factor, 2**n)` it raises `ValueError` instead.
 
 ### Introducing ShaplEIG [#548](https://github.com/mmschlk/shapiq/pull/548), [Preprint](https://arxiv.org/abs/2606.02247)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,17 @@ shapleig = [
     "botorch>=0.14.0",
     "linear_operator>=0.6",  # also a transitive gpytorch dependency, but imported directly
 ]
+benchmark = [
+    # optional model backends for the shapiq_benchmark package. These are
+    # imported lazily (see shapiq_benchmark._optional), so a plain
+    # `pip install shapiq` still ships and imports shapiq_benchmark; the
+    # extras are only needed to build the corresponding models / run the
+    # Optuna hyperparameter optimization.
+    "optuna",     # shapiq_benchmark.optimization
+    "tabpfn",     # TabPFN benchmark models
+    "lightgbm",   # LightGBM benchmark models
+    "xgboost",    # XGBoost benchmark models
+]
 
 [tool.coverage.report]
 exclude_also = [
@@ -107,7 +118,8 @@ changelog = "https://github.com/mmschlk/shapiq/blob/main/CHANGELOG.md"
 [tool.pytest.ini_options]
 testpaths = [
   "tests/shapiq",
-  "tests/shapiq_games"
+  "tests/shapiq_games",
+  "tests/shapiq_benchmark"
 ]
 pythonpath = ["src"]
 minversion = "8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,15 +83,11 @@ shapleig = [
     "linear_operator>=0.6",  # also a transitive gpytorch dependency, but imported directly
 ]
 benchmark = [
-    # optional model backends for the shapiq_benchmark package. These are
-    # imported lazily (see shapiq_benchmark._optional), so a plain
-    # `pip install shapiq` still ships and imports shapiq_benchmark; the
-    # extras are only needed to build the corresponding models / run the
-    # Optuna hyperparameter optimization.
-    "optuna",     # shapiq_benchmark.optimization
-    "tabpfn",     # TabPFN benchmark models
-    "lightgbm",   # LightGBM benchmark models
-    "xgboost",    # XGBoost benchmark models
+    # optional model backends for shapiq_benchmark, imported lazily
+    "optuna",
+    "tabpfn",
+    "lightgbm",
+    "xgboost",
 ]
 
 [tool.coverage.report]

--- a/src/shapiq_benchmark/__init__.py
+++ b/src/shapiq_benchmark/__init__.py
@@ -1,1 +1,25 @@
-"""Benchmark helpers for shapiq."""
+"""Benchmark helpers for shapiq.
+
+The benchmark model backends (``optuna``, ``tabpfn``, ``lightgbm``, ``xgboost``)
+are optional and imported lazily. Install them with
+``pip install 'shapiq[benchmark]'``. The package still imports without them; the
+extras are only needed to build the corresponding models or to run the Optuna
+hyperparameter optimization.
+"""
+
+import importlib.util
+import warnings
+
+_missing = [
+    module
+    for module in ["optuna", "tabpfn", "lightgbm", "xgboost"]
+    if importlib.util.find_spec(module) is None
+]
+
+if _missing:
+    msg = (
+        "The 'shapiq_benchmark' package uses optional model backends that are not part of the"
+        f" core shapiq install and are currently missing: {', '.join(_missing)}. Install them"
+        " via,\n\n    pip install 'shapiq[benchmark]'\n"
+    )
+    warnings.warn(msg, ImportWarning, stacklevel=2)

--- a/src/shapiq_benchmark/__init__.py
+++ b/src/shapiq_benchmark/__init__.py
@@ -1,11 +1,4 @@
-"""Benchmark helpers for shapiq.
-
-The benchmark model backends (``optuna``, ``tabpfn``, ``lightgbm``, ``xgboost``)
-are optional and imported lazily. Install them with
-``pip install 'shapiq[benchmark]'``. The package still imports without them; the
-extras are only needed to build the corresponding models or to run the Optuna
-hyperparameter optimization.
-"""
+"""Benchmark helpers for shapiq."""
 
 import importlib.util
 import warnings

--- a/src/shapiq_benchmark/_optional.py
+++ b/src/shapiq_benchmark/_optional.py
@@ -1,11 +1,4 @@
-"""Optional-dependency handling for shapiq_benchmark.
-
-The benchmark model backends (``optuna``, ``tabpfn``, ``lightgbm``,
-``xgboost``) are optional. They are imported lazily through :func:`require`
-so that importing ``shapiq_benchmark`` (and its benchmark-type modules) does
-not require them; the extras are only needed when the corresponding model is
-actually built. Install them via ``pip install 'shapiq[benchmark]'``.
-"""
+"""Lazy imports for shapiq_benchmark's optional model backends."""
 
 from __future__ import annotations
 
@@ -19,18 +12,7 @@ _INSTALL_HINT = "Install the benchmark extras with: pip install 'shapiq[benchmar
 
 
 def require(package: str) -> ModuleType:
-    """Import an optional benchmark backend, raising a helpful error if missing.
-
-    Args:
-        package: Import name of the optional dependency (e.g. ``"xgboost"``).
-
-    Returns:
-        The imported module.
-
-    Raises:
-        ImportError: If the package is not installed. The message points to the
-            ``benchmark`` extra so users know how to get it.
-    """
+    """Import ``package``, raising a helpful error pointing at the extra if it is missing."""
     try:
         return importlib.import_module(package)
     except ImportError as err:

--- a/src/shapiq_benchmark/_optional.py
+++ b/src/shapiq_benchmark/_optional.py
@@ -1,0 +1,41 @@
+"""Optional-dependency handling for shapiq_benchmark.
+
+The benchmark model backends (``optuna``, ``tabpfn``, ``lightgbm``,
+``xgboost``) are optional. They are imported lazily through :func:`require`
+so that importing ``shapiq_benchmark`` (and its benchmark-type modules) does
+not require them; the extras are only needed when the corresponding model is
+actually built. Install them via ``pip install 'shapiq[benchmark]'``.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+_INSTALL_HINT = "Install the benchmark extras with: pip install 'shapiq[benchmark]'"
+
+
+def require(package: str) -> ModuleType:
+    """Import an optional benchmark backend, raising a helpful error if missing.
+
+    Args:
+        package: Import name of the optional dependency (e.g. ``"xgboost"``).
+
+    Returns:
+        The imported module.
+
+    Raises:
+        ImportError: If the package is not installed. The message points to the
+            ``benchmark`` extra so users know how to get it.
+    """
+    try:
+        return importlib.import_module(package)
+    except ImportError as err:
+        msg = (
+            f"'{package}' is required for this shapiq_benchmark feature but is not "
+            f"installed. {_INSTALL_HINT}"
+        )
+        raise ImportError(msg) from err

--- a/src/shapiq_benchmark/optimization/optuna_optimization.py
+++ b/src/shapiq_benchmark/optimization/optuna_optimization.py
@@ -9,19 +9,17 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import optuna
-
-# Model imports
-from lightgbm import LGBMClassifier, LGBMRegressor
 from numpy.typing import NDArray
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.metrics import accuracy_score, r2_score
 from sklearn.model_selection import KFold, StratifiedKFold
-from xgboost import XGBClassifier, XGBRegressor
 
+from shapiq_benchmark._optional import require
 from shapiq_benchmark.setup import load_data_from_str
 
 if TYPE_CHECKING:
+    import optuna
+
     from shapiq_benchmark.bench_types import BenchmarkDataset
 
 IndexArray = NDArray[np.integer]
@@ -115,7 +113,9 @@ def get_model_instance(model_name: str, task: str, params: dict[str, Any]) -> An
         params: Hyperparameters to initialize the model with.
     """
     if model_name == "lightgbm":
-        return LGBMClassifier(**params) if task == "classification" else LGBMRegressor(**params)
+        lightgbm = require("lightgbm")
+        builder = lightgbm.LGBMClassifier if task == "classification" else lightgbm.LGBMRegressor
+        return builder(**params)
     if model_name == "random_forest":
         return (
             RandomForestClassifier(**params)
@@ -123,7 +123,9 @@ def get_model_instance(model_name: str, task: str, params: dict[str, Any]) -> An
             else RandomForestRegressor(**params)
         )
     if model_name == "xgboost":
-        return XGBClassifier(**params) if task == "classification" else XGBRegressor(**params)
+        xgboost = require("xgboost")
+        builder = xgboost.XGBClassifier if task == "classification" else xgboost.XGBRegressor
+        return builder(**params)
     msg = f"Unsupported model: {model_name}"
     raise ValueError(msg)
 
@@ -215,6 +217,7 @@ def save_results(
 
 def main() -> None:
     """Run Optuna optimization dynamically based on arguments."""
+    optuna = require("optuna")
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description="Optimize ML models using Optuna.")
 

--- a/src/shapiq_benchmark/setup.py
+++ b/src/shapiq_benchmark/setup.py
@@ -7,15 +7,13 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal, Protocol, cast, get_args
 
-from lightgbm import LGBMClassifier, LGBMRegressor
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.neural_network import MLPClassifier, MLPRegressor
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
-from tabpfn import TabPFNClassifier, TabPFNRegressor
-from xgboost import XGBClassifier, XGBRegressor
 
 from shapiq_games.benchmark.setup import GameBenchmarkSetup
 
+from ._optional import require
 from .bench_types import BenchmarkDataset
 
 type AllSupportedDatasets = Literal[
@@ -109,20 +107,47 @@ def _get_literal_args(type_alias: object) -> tuple[str, ...]:
     return cast("tuple[str, ...]", get_args(value))
 
 
-_MODEL_BUILDERS: dict[tuple[str, str], ModelBuilder] = {
+# scikit-learn models are always available (core shapiq dependency).
+_SKLEARN_MODEL_BUILDERS: dict[tuple[str, str], ModelBuilder] = {
     ("decision_tree", "classification"): DecisionTreeClassifier,
     ("decision_tree", "regression"): DecisionTreeRegressor,
     ("random_forest", "classification"): RandomForestClassifier,
     ("random_forest", "regression"): RandomForestRegressor,
-    ("xgboost", "classification"): XGBClassifier,
-    ("xgboost", "regression"): XGBRegressor,
-    ("lightgbm", "classification"): LGBMClassifier,
-    ("lightgbm", "regression"): LGBMRegressor,
-    ("tabpfn", "classification"): TabPFNClassifier,
-    ("tabpfn", "regression"): TabPFNRegressor,
     ("mlp", "classification"): MLPClassifier,
     ("mlp", "regression"): MLPRegressor,
 }
+
+# Optional backends, resolved lazily via ``require`` so that importing this
+# module does not require the ``benchmark`` extras. Maps the model name to the
+# (import package, classifier attribute, regressor attribute) to look up.
+_OPTIONAL_MODEL_BACKENDS: dict[str, tuple[str, str, str]] = {
+    "xgboost": ("xgboost", "XGBClassifier", "XGBRegressor"),
+    "lightgbm": ("lightgbm", "LGBMClassifier", "LGBMRegressor"),
+    "tabpfn": ("tabpfn", "TabPFNClassifier", "TabPFNRegressor"),
+}
+
+# All supported (model, task) pairs, independent of whether the optional backend
+# is installed. Used for validation and error messages so the advertised set of
+# supported models does not silently shrink when an extra is missing.
+_SUPPORTED_MODEL_TASKS: frozenset[tuple[str, str]] = frozenset(_SKLEARN_MODEL_BUILDERS) | {
+    (name, task) for name in _OPTIONAL_MODEL_BACKENDS for task in ("classification", "regression")
+}
+
+
+def _resolve_model_builder(model_str: str, task: str) -> ModelBuilder:
+    """Return the model builder for a ``(model, task)`` pair.
+
+    scikit-learn models are returned directly. The optional backends
+    (``xgboost`` / ``lightgbm`` / ``tabpfn``) are imported lazily and raise a
+    helpful error pointing to the ``benchmark`` extra if they are not installed.
+    """
+    key = (model_str, task)
+    if key in _SKLEARN_MODEL_BUILDERS:
+        return _SKLEARN_MODEL_BUILDERS[key]
+    package, classifier_attr, regressor_attr = _OPTIONAL_MODEL_BACKENDS[model_str]
+    module = require(package)
+    attr = classifier_attr if task == "classification" else regressor_attr
+    return cast("ModelBuilder", getattr(module, attr))
 
 
 def load_data_from_str(
@@ -176,15 +201,16 @@ def load_and_fit_model_from_str(
             A fitted model instance.
     """
     key = (model_str.lower(), dataset.data_type.lower())
-    if key not in _MODEL_BUILDERS:
-        supported = sorted({name for name, _dtype in _MODEL_BUILDERS})
+    if key not in _SUPPORTED_MODEL_TASKS:
+        supported = sorted({name for name, _dtype in _SUPPORTED_MODEL_TASKS})
         msg = (
             f"Unsupported model '{model_str}' for data type '{dataset.data_type}'. "
             f"Supported models: {', '.join(supported)}"
         )
         raise ValueError(msg)
 
-    model = _MODEL_BUILDERS[key](**kwargs)
+    builder = _resolve_model_builder(*key)
+    model = builder(**kwargs)
     return model.fit(dataset.x_train, dataset.y_train)
 
 

--- a/src/shapiq_benchmark/setup.py
+++ b/src/shapiq_benchmark/setup.py
@@ -117,18 +117,14 @@ _SKLEARN_MODEL_BUILDERS: dict[tuple[str, str], ModelBuilder] = {
     ("mlp", "regression"): MLPRegressor,
 }
 
-# Optional backends, resolved lazily via ``require`` so that importing this
-# module does not require the ``benchmark`` extras. Maps the model name to the
-# (import package, classifier attribute, regressor attribute) to look up.
+# optional backends, imported lazily; model name -> (package, classifier, regressor)
 _OPTIONAL_MODEL_BACKENDS: dict[str, tuple[str, str, str]] = {
     "xgboost": ("xgboost", "XGBClassifier", "XGBRegressor"),
     "lightgbm": ("lightgbm", "LGBMClassifier", "LGBMRegressor"),
     "tabpfn": ("tabpfn", "TabPFNClassifier", "TabPFNRegressor"),
 }
 
-# All supported (model, task) pairs, independent of whether the optional backend
-# is installed. Used for validation and error messages so the advertised set of
-# supported models does not silently shrink when an extra is missing.
+# all supported (model, task) pairs, independent of which backends are installed
 _SUPPORTED_MODEL_TASKS: frozenset[tuple[str, str]] = frozenset(_SKLEARN_MODEL_BUILDERS) | {
     (name, task) for name in _OPTIONAL_MODEL_BACKENDS for task in ("classification", "regression")
 }

--- a/src/shapiq_benchmark/tabpfn_bench.py
+++ b/src/shapiq_benchmark/tabpfn_bench.py
@@ -5,18 +5,20 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
-from tabpfn import TabPFNClassifier, TabPFNRegressor
 
 from shapiq.explainer.utils import get_predict_function_and_model_type
 from shapiq.imputer.tabpfn_imputer import TabPFNImputer
 from shapiq.typing import IndexType, Model
 
+from ._optional import require
 from .base import Benchmark
 from .computers import BruteForceComputer, GroundTruthComputer
 from .setup import load_from_str
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from tabpfn import TabPFNClassifier, TabPFNRegressor
 
     from .bench_types import BenchmarkDataset
 
@@ -46,6 +48,9 @@ class TabPFNBench(Benchmark[IndexType]):
             random_state: Random state used for data split and model initialization.
             **kwargs: Additional keyword arguments for model building.
         """
+        tabpfn = require("tabpfn")
+        tabpfn_model_types = (tabpfn.TabPFNClassifier, tabpfn.TabPFNRegressor)
+
         self.dataset: BenchmarkDataset | None = None
         self.model: TabPFNClassifier | TabPFNRegressor
         if isinstance(data, str) and isinstance(model, str):
@@ -69,7 +74,7 @@ class TabPFNBench(Benchmark[IndexType]):
             if labels is None:
                 msg = "When data is a tuple, labels must be provided as (y_train, y_test)."
                 raise ValueError(msg)
-            if not isinstance(model, TabPFNClassifier | TabPFNRegressor):
+            if not isinstance(model, tabpfn_model_types):
                 msg = "Model must be a TabPFNClassifier or TabPFNRegressor."
                 raise TypeError(msg)
             self.model = model

--- a/tests/shapiq_benchmark/__init__.py
+++ b/tests/shapiq_benchmark/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the shapiq_benchmark package."""

--- a/tests/shapiq_benchmark/test_optional_dependencies.py
+++ b/tests/shapiq_benchmark/test_optional_dependencies.py
@@ -1,0 +1,91 @@
+"""Tests for shapiq_benchmark's optional-dependency wiring.
+
+The benchmark model backends (``optuna``, ``tabpfn``, ``lightgbm``, ``xgboost``)
+are optional and imported lazily so that a plain ``pip install shapiq`` still
+ships and imports ``shapiq_benchmark``. These tests pin that behavior down:
+the package imports without the backends, missing backends raise a helpful
+error pointing at the ``benchmark`` extra, and the always-available
+scikit-learn models keep working.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import numpy as np
+import pytest
+
+import shapiq_benchmark
+from shapiq_benchmark._optional import require
+from shapiq_benchmark.setup import (
+    _OPTIONAL_MODEL_BACKENDS,
+    _SUPPORTED_MODEL_TASKS,
+    _resolve_model_builder,
+)
+
+OPTIONAL_MODELS = ["xgboost", "lightgbm", "tabpfn"]
+
+
+def test_package_imports() -> None:
+    """The package itself imports even without the optional backends installed."""
+    assert shapiq_benchmark.__name__ == "shapiq_benchmark"
+
+
+def test_require_returns_module_when_present() -> None:
+    """``require`` returns the imported module for an installed package."""
+    assert require("numpy") is np
+
+
+def test_require_raises_helpful_error_when_missing() -> None:
+    """``require`` raises an ImportError that points at the benchmark extra."""
+    with pytest.raises(ImportError, match=r"shapiq\[benchmark\]"):
+        require("a_module_that_is_definitely_not_installed_xyz")
+
+
+def test_resolve_sklearn_builder_needs_no_optional_backend() -> None:
+    """scikit-learn models resolve directly, without importing an optional backend."""
+    from sklearn.tree import DecisionTreeClassifier
+
+    assert _resolve_model_builder("decision_tree", "classification") is DecisionTreeClassifier
+
+
+@pytest.mark.parametrize("model", OPTIONAL_MODELS)
+def test_missing_optional_backend_raises_helpful_error(monkeypatch, model) -> None:
+    """Resolving an optional model with its backend absent errors clearly.
+
+    Setting ``sys.modules[name] = None`` makes ``import name`` raise, faithfully
+    simulating a bare ``pip install shapiq`` even when the backend happens to be
+    installed in the test environment.
+    """
+    package = _OPTIONAL_MODEL_BACKENDS[model][0]
+    monkeypatch.setitem(sys.modules, package, None)
+    with pytest.raises(ImportError, match=r"shapiq\[benchmark\]"):
+        _resolve_model_builder(model, "classification")
+
+
+@pytest.mark.parametrize("model", OPTIONAL_MODELS)
+def test_optional_backend_resolves_when_present(model) -> None:
+    """When the backend is installed, resolving returns a usable (callable) builder."""
+    package = _OPTIONAL_MODEL_BACKENDS[model][0]
+    pytest.importorskip(package)
+    for task in ("classification", "regression"):
+        assert callable(_resolve_model_builder(model, task))
+
+
+def test_supported_model_set_is_backend_independent() -> None:
+    """All model names are advertised regardless of which backends are installed."""
+    names = {name for name, _task in _SUPPORTED_MODEL_TASKS}
+    assert {"decision_tree", "random_forest", "mlp", *OPTIONAL_MODELS} <= names
+
+
+def test_import_warns_when_a_backend_is_missing(monkeypatch) -> None:
+    """Importing the package emits an ImportWarning listing the missing backends."""
+    # Make an (otherwise possibly installed) backend appear absent, then re-run
+    # the package __init__ via reload and capture the warning.
+    monkeypatch.setitem(sys.modules, "xgboost", None)
+    with pytest.warns(ImportWarning, match=r"shapiq\[benchmark\]"):
+        importlib.reload(shapiq_benchmark)
+    # Restore a clean module state so ordering does not affect other tests.
+    monkeypatch.undo()
+    importlib.reload(shapiq_benchmark)

--- a/tests/shapiq_benchmark/test_optional_dependencies.py
+++ b/tests/shapiq_benchmark/test_optional_dependencies.py
@@ -81,11 +81,10 @@ def test_supported_model_set_is_backend_independent() -> None:
 
 def test_import_warns_when_a_backend_is_missing(monkeypatch) -> None:
     """Importing the package emits an ImportWarning listing the missing backends."""
-    # Make an (otherwise possibly installed) backend appear absent, then re-run
-    # the package __init__ via reload and capture the warning.
+    # make xgboost look absent, then re-run __init__ via reload to catch the warning
     monkeypatch.setitem(sys.modules, "xgboost", None)
     with pytest.warns(ImportWarning, match=r"shapiq\[benchmark\]"):
         importlib.reload(shapiq_benchmark)
-    # Restore a clean module state so ordering does not affect other tests.
+    # reload again with the backend restored so test ordering is unaffected
     monkeypatch.undo()
     importlib.reload(shapiq_benchmark)

--- a/tests/shapiq_benchmark/test_setup.py
+++ b/tests/shapiq_benchmark/test_setup.py
@@ -59,5 +59,4 @@ def test_check_for_known_combination_reads_shipped_configs() -> None:
     known = check_for_known_combination("california_housing", "xgboost")
     assert isinstance(known, dict)
     assert "n_estimators" in known
-    # An unknown (dataset, model) pair resolves to None.
     assert check_for_known_combination("not_a_dataset", "not_a_model") is None

--- a/tests/shapiq_benchmark/test_setup.py
+++ b/tests/shapiq_benchmark/test_setup.py
@@ -1,0 +1,63 @@
+"""Tests for shapiq_benchmark.setup (loading datasets and models from strings).
+
+These run fully in-memory: no dataset downloads and no optional model backends,
+so they exercise the always-available scikit-learn path and the shipped
+hyperparameter configs.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+
+from shapiq_benchmark.bench_types import BenchmarkDataset
+from shapiq_benchmark.setup import (
+    check_for_known_combination,
+    infer_data_type,
+    load_and_fit_model_from_str,
+)
+
+
+@pytest.fixture
+def tiny_dataset() -> BenchmarkDataset:
+    """A tiny in-memory classification dataset (no network / data download)."""
+    rng = np.random.default_rng(0)
+    x_train = rng.normal(size=(20, 4))
+    x_test = rng.normal(size=(5, 4))
+    return BenchmarkDataset(
+        x_train=x_train,
+        y_train=(x_train[:, 0] > 0).astype(int),
+        x_test=x_test,
+        y_test=(x_test[:, 0] > 0).astype(int),
+        data_type="classification",
+    )
+
+
+def test_load_and_fit_decision_tree(tiny_dataset) -> None:
+    """A scikit-learn model fits end-to-end from a string id, no optional deps."""
+    model = load_and_fit_model_from_str("decision_tree", tiny_dataset)
+    assert isinstance(model, DecisionTreeClassifier)
+    preds = model.predict(tiny_dataset.x_test)
+    assert preds.shape == (tiny_dataset.x_test.shape[0],)
+
+
+def test_load_and_fit_unsupported_model_raises(tiny_dataset) -> None:
+    """An unknown model id raises a ValueError that lists the supported models."""
+    with pytest.raises(ValueError, match="Unsupported model"):
+        load_and_fit_model_from_str("not_a_real_model", tiny_dataset)
+
+
+def test_infer_data_type() -> None:
+    """``infer_data_type`` distinguishes classifiers from regressors."""
+    assert infer_data_type(DecisionTreeClassifier()) == "classification"
+    assert infer_data_type(DecisionTreeRegressor()) == "regression"
+
+
+def test_check_for_known_combination_reads_shipped_configs() -> None:
+    """The shipped optimization JSONs are packaged, found, and parsed."""
+    known = check_for_known_combination("california_housing", "xgboost")
+    assert isinstance(known, dict)
+    assert "n_estimators" in known
+    # An unknown (dataset, model) pair resolves to None.
+    assert check_for_known_combination("not_a_dataset", "not_a_model") is None

--- a/uv.lock
+++ b/uv.lock
@@ -44,6 +44,20 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/cc/ac0bed8e562e7407fe55c3ba85a4dce86e6dbd8730887bd1e406a6c5c18a/alembic-1.18.5.tar.gz", hash = "sha256:1554982221dd17e9a749b53902407578eb305e453f71999e8c7f0a48389fff8e", size = 2060480, upload-time = "2026-06-25T15:20:54.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/78/5fe6dc3a3a5b2f5a2a4faef8bfe336d5fa049a38884ab3172e0098160c01/alembic-1.18.5-py3-none-any.whl", hash = "sha256:06d8ba9d04558022f5395e9317de03d270f3dced49cee01f89fe7a13c26f14bc", size = 264664, upload-time = "2026-06-25T15:20:56.673Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -436,6 +450,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
 ]
 
 [[package]]
@@ -966,6 +992,73 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/fb/d97dc261209c80744b7c8132693a30d70ec6e7315e632cb0a10b3fec94dd/greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23", size = 622351, upload-time = "2026-06-26T19:24:16.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/e5fee13cbbd0e8de312d9a146584b8a51891c68847330ef9dc8b5109d23f/greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c", size = 425395, upload-time = "2026-06-26T19:25:37.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
+    { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/6fea0e3d6600f785069481ee637e09378dd4118acdfd38ad88ae2db31c98/greenlet-3.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:c4e7b79d83805475f0102008843f6eb45fd3bb0b2e88c774adab5fbaab27117d", size = 238211, upload-time = "2026-06-26T18:22:37.671Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7e/220a7f5824a64a60443fc03b39dfac4ea63a7fb6d481efa27eafa928e7f4/greenlet-3.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:dc133a1569ee667b2a6ef56ce551084aeefd87a5acbc4736d336d1e2edc6cfc4", size = 238141, upload-time = "2026-06-26T18:22:48.507Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a9/73fa62893d5b84b4205544e6b673c654cc43aa5b9899bac00f04d64af73d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814", size = 670657, upload-time = "2026-06-26T19:24:19.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/2ffce64929fb3cab7b65d5a0b20aaf9764e227681d731b041077fc9a525a/greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260", size = 473497, upload-time = "2026-06-26T19:25:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
+    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/8faec206b851c22b1733545fda900829a1f3f5b1c78ae7e0fb3dba57d9f4/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d", size = 659582, upload-time = "2026-06-26T19:24:21.357Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/55/50c19e49f8045834ada71ef12f8ad048eba8517c6aa41161bed676328fae/greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0", size = 491037, upload-time = "2026-06-26T19:25:40.672Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/aa/952cf28c2ff949a8c971134fb43854dd7eaa737218723aaef758f8c9aead/greenlet-3.5.3-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cefa9cef4b371f9844c6053db71f1138bc6807bab1578b0dae5149c1f1141357", size = 674261, upload-time = "2026-06-26T19:24:22.79Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/b00d6f5e63e531a93562b2ec1a4c320fbee91f580fc42e6417af69d706e5/greenlet-3.5.3-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:6219b6d04dbf6ba6084d77dc609e8473060dc55f759cbf626d512122781fa128", size = 480322, upload-time = "2026-06-26T19:25:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/883785b44c5780ed71e83d3e4437e710470be17a2e181e8b601e2da0dc4a/greenlet-3.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:499fef2acede88c1864a57bb586b4bf533c81e1b82df7ab93451cdb47dfec227", size = 240085, upload-time = "2026-06-26T18:23:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
+    { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/39/0e0938a75115b939d42733a2a12e1d349653c9531fe6fe563e8a681f04e6/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d192579ed281051396dddd7f7754dac6259e6b1fb26378c87b66622f8e3f91", size = 663706, upload-time = "2026-06-26T19:24:24.312Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/41/35d1c678cdb3c3b9e6bee691728e563cfb294202b23c7a4c3c2ccc343589/greenlet-3.5.3-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:4399eb8d041f20b68d943918bc55502a93d6fdc0a37c14da7881c04139acee9d", size = 498803, upload-time = "2026-06-26T19:25:43.063Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
+    { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/ca7d15afbdc397e3401134c9e1800d51d12b829661786187a4ad08fe484f/greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31", size = 242586, upload-time = "2026-06-26T18:23:37.93Z" },
 ]
 
 [[package]]
@@ -1722,6 +1815,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2444,6 +2549,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/da/52e684c42dc29d3b4d52f2029545742ef43e151cea112d9093d2ad164f53/optree-0.19.0-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a39fdd614f46bcaf810b2bb1ed940e82b8a19e654bc325df0cc6554e25c3b7eb", size = 484506, upload-time = "2026-02-23T01:56:12.723Z" },
     { url = "https://files.pythonhosted.org/packages/2d/f7/0d41edf484e11ba5357f91dba8d85ce06ca9d840ac7d95e58b856a49b13b/optree-0.19.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfc1bcba22f182f39f1a80ae3ac511ebfa4daea62c3058edd021ce7a5cda3009", size = 468846, upload-time = "2026-02-23T01:56:13.826Z" },
     { url = "https://files.pythonhosted.org/packages/79/5e/a8f49cfd6c3ae0e59dcb1155cd49f1e5ba41889c9388360264c8369589c6/optree-0.19.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:afe595a052cc45d3addb6045f04a3ca7e1fb664de032ecbbb2bfd76dfe1fcb61", size = 433899, upload-time = "2026-02-23T01:56:14.889Z" },
+]
+
+[[package]]
+name = "optuna"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alembic" },
+    { name = "colorlog" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "sqlalchemy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/aa/05f5e3f662cc96a4c478fc3446b8ed6359825a2b504ecb614a9ac84e4a4d/optuna-4.9.0.tar.gz", hash = "sha256:b322e5cbdf1655fb84c37646c4a7a1f391de1b47806bbe222e015825d0a82b87", size = 485834, upload-time = "2026-06-01T06:23:30.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/f3/e5fcd5d9b15771ed6dc10e3a7eeddc672e418f4f4c4653d216cc1d857e2d/optuna-4.9.0-py3-none-any.whl", hash = "sha256:f52f3be6148654850c92a5860d398fd88ec6b2c84ab68d9c3d07dcff02e7afee", size = 425553, upload-time = "2026-06-01T06:23:28.804Z" },
 ]
 
 [[package]]
@@ -3676,6 +3799,12 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+benchmark = [
+    { name = "lightgbm" },
+    { name = "optuna" },
+    { name = "tabpfn" },
+    { name = "xgboost" },
+]
 proxy = [
     { name = "catboost" },
     { name = "lightgbm" },
@@ -3768,11 +3897,13 @@ requires-dist = [
     { name = "galois", marker = "extra == 'sparse'" },
     { name = "gpytorch", marker = "extra == 'shapleig'", specifier = ">=1.14" },
     { name = "joblib" },
+    { name = "lightgbm", marker = "extra == 'benchmark'" },
     { name = "lightgbm", marker = "extra == 'proxy'" },
     { name = "linear-operator", marker = "extra == 'shapleig'", specifier = ">=0.6" },
     { name = "matplotlib" },
     { name = "networkx" },
     { name = "numpy" },
+    { name = "optuna", marker = "extra == 'benchmark'" },
     { name = "pandas" },
     { name = "pillow" },
     { name = "requests" },
@@ -3780,11 +3911,13 @@ requires-dist = [
     { name = "scipy" },
     { name = "smac", marker = "extra == 'proxy'" },
     { name = "sparse-transform", marker = "extra == 'sparse'" },
+    { name = "tabpfn", marker = "extra == 'benchmark'" },
     { name = "torch", marker = "extra == 'shapleig'", specifier = ">=2.9.1" },
     { name = "tqdm" },
+    { name = "xgboost", marker = "extra == 'benchmark'" },
     { name = "xgboost", marker = "extra == 'proxy'" },
 ]
-provides-extras = ["sparse", "proxy", "shapleig"]
+provides-extras = ["sparse", "proxy", "shapleig", "benchmark"]
 
 [package.metadata.requires-dev]
 all-ml = [
@@ -4080,6 +4213,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/f1/a7a892f18d4d224e6b26f706531eafccc41e37594d37d304786969ee13cb/sqlalchemy-2.0.51.tar.gz", hash = "sha256:804dccd8a4a6242c4e30ad961e540e18a588f6527202f2d6791b01845d59fdc9", size = 9912201, upload-time = "2026-06-15T15:41:20.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/70/e868bc5412acd101a8280f25c95f10eeae0771c4eb806b02491142810ee8/sqlalchemy-2.0.51-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d78702b26ba1c18b2d0fb2ea940ba7f17a9581b42e8361ff93920ebbee1235a", size = 2160291, upload-time = "2026-06-15T16:08:48.918Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1c/71ee0f8a6b9d7316a1ccd30430b4c62b6c2e36adc96017a4e3a72dce49d6/sqlalchemy-2.0.51-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:581921d849d6e6f994d560389192955e80e2950e18fcdfe2ccea863e01158e6e", size = 3343835, upload-time = "2026-06-15T16:19:42.613Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/7c/7ab9f9aadc5944fdd06612484ed7918fe376ad871a5f50404dc1536e0194/sqlalchemy-2.0.51-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d21ce524ab86c23046e992a5b81cb54c21079c6df6e78b8fc77d77cac70a6b9", size = 3358470, upload-time = "2026-06-15T16:26:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7d/ff77169fee6186de145a7f2b87006c39638391130abbab2b1f63ac6ea583/sqlalchemy-2.0.51-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c5d98a2709840027f5a347c3af0a7c3d5f6c1ff93af2ca1c54494e23cba8f389", size = 3289874, upload-time = "2026-06-15T16:19:45.212Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/3b/6c505903710d781b55bc3141ee34a062bf9745a6b5bc7333305b9ed63b33/sqlalchemy-2.0.51-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1181256e0f16479691b5616d36375dc2620ad8332b25978763c3d206ad3f3f1d", size = 3321692, upload-time = "2026-06-15T16:26:39.747Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b7/c5ffe50aa2f4d947c9250e1519d939260329a07fe6272edfccd784b3d007/sqlalchemy-2.0.51-cp312-cp312-win32.whl", hash = "sha256:9f380393be5abeb6815f68fd39271b95127173511b6706b0a630a9995d53f8f5", size = 2119674, upload-time = "2026-06-15T16:23:09.543Z" },
+    { url = "https://files.pythonhosted.org/packages/25/dc/46a65916af68a06ef6b972c6050ba4c8f97070fe3fb33097d34229d9bef6/sqlalchemy-2.0.51-cp312-cp312-win_amd64.whl", hash = "sha256:2cf39aabdf48e87c1c2c2ed6d20d33ffa0733b3071ce9c5f66357947dd009080", size = 2146670, upload-time = "2026-06-15T16:23:11.048Z" },
+    { url = "https://files.pythonhosted.org/packages/54/fe/a210d52fd1a90ecfae8a78e9d8b27e18d733d60818a8bf250ff690b75120/sqlalchemy-2.0.51-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c2056838b6685b72fdb36c99996cf862753461a62f2e84f4196371d3b2d6a07", size = 2157184, upload-time = "2026-06-15T16:08:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6b/2dce8369b199cb855110e056032f94a9f66dacc2237d3d39c115a86eac56/sqlalchemy-2.0.51-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:483b11bd46bf35fc14c52faf338b04300c9e6ce554bce9b11be85bfec3bc3195", size = 3284735, upload-time = "2026-06-15T16:19:46.934Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ff/dbc495b8a14da840faffb353857a72d4190113cac33727906fb997047f0f/sqlalchemy-2.0.51-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1bed1ee8b01da6088210aa9412023326fb98a599ba502e6118308601dcbef77f", size = 3302756, upload-time = "2026-06-15T16:26:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/d5/fde8f4dddcf518ee15ab35a7c6a28acc32c8ba548d1d2aa451f96e6dbb0b/sqlalchemy-2.0.51-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:72ca54c952107ba5cd58854b67a5a6268631289d21651a1235396f3b98b47400", size = 3232055, upload-time = "2026-06-15T16:19:49.286Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d1/43d3a0ac955a58601c24fa23038b1c55ee3a1ec02c0f96ebb1eae2bcf614/sqlalchemy-2.0.51-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b3e693d15533a45cd5906f0589f9c35090bef6ef45bf1e8195c424aa0ae06a8d", size = 3269850, upload-time = "2026-06-15T16:26:43.017Z" },
+    { url = "https://files.pythonhosted.org/packages/94/df/de669c7054cd47c4439ac34b1b2ee8b804a794791fbb10720e997a2c87c7/sqlalchemy-2.0.51-cp313-cp313-win32.whl", hash = "sha256:b93ab07b5292dbe7e6b8da89475275e7042744283921344b56105f3eeb0f828b", size = 2117721, upload-time = "2026-06-15T16:23:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8a/403c51d064196bae20a0bc2476577f83a3f8dd299719a97417086b7f2ec5/sqlalchemy-2.0.51-cp313-cp313-win_amd64.whl", hash = "sha256:0f053118c30e53161857a953e4de667d90e274980dccbe5dd3829bbbeece72a5", size = 2143615, upload-time = "2026-06-15T16:23:13.906Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/49/a739be2e1d02a96a658eb71ab45d921c874249252358ad24a5bffdd02525/sqlalchemy-2.0.51-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6ea306caaae6bd5afd0a46050003c88f6bf33227377a49298c498c3cb88ff491", size = 2158999, upload-time = "2026-06-15T16:08:51.759Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6b/2e0e38cf75c8780eca78d9b2e78164f8bcfd70125e5caa588ff5cbb9c9f4/sqlalchemy-2.0.51-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c45a496d6bc05dec41dcd4c3a2b183723f47473255c159cd80b503c8f246424d", size = 3282539, upload-time = "2026-06-15T16:19:51.065Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a1/e77854cb5336fd37dc3c6ae3b71de242c98caac5725120be0b526b31cbd0/sqlalchemy-2.0.51-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4004ada0aafe8ae1991b2cd1d99c6d9146126e123bd6f883c260d974aa012e54", size = 3287545, upload-time = "2026-06-15T16:26:44.735Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ab/9e17272fd4dac8df3b83c4fbe52b998a1c9d89a843c8c35ff29b74ff7364/sqlalchemy-2.0.51-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f6bcad487aee1c638d707235682fc96f741de00663619881ab235400d03289e", size = 3230929, upload-time = "2026-06-15T16:19:52.625Z" },
+    { url = "https://files.pythonhosted.org/packages/02/3c/52f408ea701781caee975606beccc48845f2aee8711ac29843d612c0306c/sqlalchemy-2.0.51-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:39a76529db6305693d8d4affa58ad5b5e2e18edd62daea628b29b97930b3513d", size = 3252888, upload-time = "2026-06-15T16:26:46.454Z" },
+    { url = "https://files.pythonhosted.org/packages/24/16/3efd2ee6bc4ca4693a30a1dd17a91b606cae15d517d2a4746611d9b73ce8/sqlalchemy-2.0.51-cp314-cp314-win32.whl", hash = "sha256:08a204d8b5638717c26a24df18fcf40af45a6b22e35b70b1d62f0113c2e278e8", size = 2120551, upload-time = "2026-06-15T16:23:15.629Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/78/55b12e70f45bccc40d9e483925c065027b3b98ea4cbbdf6f8c2546feaf6c/sqlalchemy-2.0.51-cp314-cp314-win_amd64.whl", hash = "sha256:96747bfbadb055466e5b46d572618170046b45ce5a4879167f50d70a5319a499", size = 2146318, upload-time = "2026-06-15T16:23:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/21/db/a9574ed40fed418924b1b1a3e54f47ee3963053b3d3d325a0d36b41f2c08/sqlalchemy-2.0.51-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e5ea1a213be1fcd5e49d9904c3b9939211ded90bc2a64e93f4c01963474285de", size = 2178920, upload-time = "2026-06-15T15:59:56.285Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/90/a1bb5c7cbba76b7bc1fbd586d0a5479a7bc9c27b4a8298f22ec9423b2bb3/sqlalchemy-2.0.51-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c6b36ed71f41942bdcd2ad2522be46bfce09d5705be5640ecf19bbc7660e4b7", size = 3566534, upload-time = "2026-06-15T15:58:35.024Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4b/481f1fed30e0e9e8dd24aecbb49f29eb57fe7657ece5cf06ee9b84bb97d8/sqlalchemy-2.0.51-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c2c62877097e1a0db401fba5cb4debee33265e5b2a55c4ccb489c02c53b4f72", size = 3535844, upload-time = "2026-06-15T16:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/02/71/0aa64aeda645510af0a43f7d9ee70932f0d1dc4263aed34c50ee891d9df3/sqlalchemy-2.0.51-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0378d055e9e8cd6ce4d8dff683bdd3d7d413533c4ee51d67a2b1e0f9eacc0f23", size = 3475355, upload-time = "2026-06-15T15:58:36.592Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/6061db32316446135a3abae5f308d144ab988a34234726042da3e58b1c63/sqlalchemy-2.0.51-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6e46fc36029eff666391e0531e5387b62ce6c4f1d8e50b3fb3099eaca1b42522", size = 3486591, upload-time = "2026-06-15T16:02:45.346Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c9/f14fdf71bb8957e0c7e39db69bbdf12b5c80f4ef775fdfa127bf4e0d6760/sqlalchemy-2.0.51-cp314-cp314t-win32.whl", hash = "sha256:9161cfc9efce70d1715f47d6ff40f79c6778c00d53be4fbc09d70301e4b83ba7", size = 2151313, upload-time = "2026-06-15T16:03:39.127Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c6/673e618e6f4f297e126d9b56ea2f6478708f6c1af4e3223835c22e2c3697/sqlalchemy-2.0.51-cp314-cp314t-win_amd64.whl", hash = "sha256:159bb6ba32059f57ad7375a8f50d844dd2f19d14954ecf820cd33e20debd46b2", size = 2186280, upload-time = "2026-06-15T16:03:40.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/22/dbf013a12ec759e54a34a119e9e217435b3f71b2dd5c61a7ade0a25dae87/sqlalchemy-2.0.51-py3-none-any.whl", hash = "sha256:bb024d8b621d0be75f4f44ecc7c950450026e76d66dc8f791bb5331d7fed59d5", size = 1944334, upload-time = "2026-06-15T16:09:22.418Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Turn the Unreleased section into the dated v1.6.0 release entry. The two
headline features are the OddSHAP (#522) and ShaplEIG (#548) approximators,
each with a dedicated "Introducing" subsection and preprint link. Also
documents the new shapiq_benchmark package (#521), the inclusion of the
nearest-neighbor explainers in the docs/exports (#558), and the
actions/checkout bump (#555). Normalizes the previously inconsistent
headings and corrects the OddSHAP description to reference its own
standalone tree-to-Fourier extraction.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>