### PR TITLE
Performance and Array API pass over samplers, approximators, and lookups

### DIFF
--- a/src/shapiq/_shape.py
+++ b/src/shapiq/_shape.py
@@ -2,9 +2,60 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from math import prod
+from typing import Any, cast
+
+import numpy as np
 
 type Shape = tuple[int, ...]
 type ShapeLike = int | Iterable[int]
+
+
+def broadcast_shapes(*shapes: Shape) -> Shape:
+    """Return the broadcast of logical shapes as a plain tuple.
+
+    Shape arithmetic is host metadata, so it lives here rather than in a
+    compute backend.
+    """
+    return tuple(int(dim) for dim in np.broadcast_shapes(*shapes))
+
+
+def indexed_shape(shape: Shape, key: object) -> Shape:
+    """Return the logical shape produced by indexing ``shape`` with ``key``.
+
+    The key semantics are resolved by indexing a stride-zero host dummy, so
+    no allocation or kernel is spent on shape metadata; out-of-range indices
+    raise ``IndexError``.
+    """
+    dummy = cast("Any", np.broadcast_to(np.empty((), dtype=bool), shape))
+    return tuple(int(dim) for dim in dummy[key].shape)
+
+
+def expand_ellipsis(key: tuple[object, ...], ndim: int) -> tuple[object, ...]:
+    """Replace an ``Ellipsis`` key entry with explicit full slices.
+
+    Container ``__getitem__`` implementations append their own trailing
+    axes to the key, which an unexpanded user ``Ellipsis`` would clash
+    with. Entries other than ``None`` count as consuming one axis, so a
+    multi-axis boolean mask combined with an ellipsis is not supported.
+    """
+    positions = [index for index, entry in enumerate(key) if entry is Ellipsis]
+    if len(positions) != 1:
+        return key
+    consumed = sum(1 for entry in key if entry is not Ellipsis and entry is not None)
+    fill = (slice(None),) * max(ndim - consumed, 0)
+    return (*key[: positions[0]], *fill, *key[positions[0] + 1 :])
+
+
+def shape_of(value: object) -> Shape:
+    """Return a value's logical shape as a plain tuple, host-side.
+
+    Prefers the value's own ``shape`` attribute; values without one
+    (nested sequences, scalars) are probed through NumPy.
+    """
+    shape = getattr(value, "shape", None)
+    if shape is not None:
+        return tuple(int(dim) for dim in shape)
+    return tuple(int(dim) for dim in np.shape(cast("Any", value)))
 
 
 def normalize_shape(shape: ShapeLike = ()) -> Shape:

--- a/src/shapiq/explainers/_evidence.py
+++ b/src/shapiq/explainers/_evidence.py
@@ -127,16 +127,17 @@ class EvidenceApproximator(
             coalitions, sampler = sampler.sample(self.state, remaining)
             dense = jnp.asarray(coalitions.to_dense())
             chunks.append(dense)
-            found = _classify_chunk(
-                _packed_rows(dense),
-                position,
-                known=known,
-                batch_ranks=batch_ranks,
-                novel_positions=novel_positions,
-                state_duplicates=state_duplicates,
-                batch_duplicates=batch_duplicates,
-            )
-            position += int(dense.shape[-2])
+            found = 0
+            for key in _coalition_keys(dense):
+                if key in batch_ranks:
+                    batch_duplicates.append((position, batch_ranks[key]))
+                elif key in known:
+                    state_duplicates.append((position, known[key]))
+                else:
+                    batch_ranks[key] = len(novel_positions)
+                    novel_positions.append(position)
+                    found += 1
+                position += 1
             remaining -= found
             raw_since_novel = 0 if found else raw_since_novel + int(dense.shape[-2])
             if remaining > 0 and raw_since_novel >= stall_limit:
@@ -181,12 +182,11 @@ class EvidenceApproximator(
                 if cached_length == len(cached):
                     return cached
                 return {key: index for key, index in cached.items() if index < n_samples}
-        packed = _packed_rows(jnp.asarray(self.state.coalitions.to_dense()))
-        unique_rows, first_indices = np.unique(packed, axis=0, return_index=True)
-        return {
-            row.tobytes(): int(index)
-            for row, index in zip(unique_rows, first_indices, strict=True)
-        }
+        dense = jnp.asarray(self.state.coalitions.to_dense())
+        known: dict[bytes, int] = {}
+        for index, key in enumerate(_coalition_keys(dense)):
+            known.setdefault(key, index)
+        return known
 
     def _stitch_values(
         self,
@@ -268,67 +268,10 @@ class EvidenceApproximator(
         raise InsufficientSamplesError(msg)
 
 
-def _packed_rows(dense: Array) -> np.ndarray:
-    """Return one packed identity row per sample-axis coalition (shared targets only)."""
+def _coalition_keys(dense: Array) -> list[bytes]:
+    """Return a hashable identity per sample-axis coalition (shared targets only)."""
     rows = np.asarray(dense).reshape(-1, dense.shape[-2], dense.shape[-1])[0]
-    return np.packbits(rows, axis=-1)
-
-
-def _classify_chunk(
-    packed: np.ndarray,
-    position: int,
-    *,
-    known: dict[bytes, int],
-    batch_ranks: dict[bytes, int],
-    novel_positions: list[int],
-    state_duplicates: list[tuple[int, int]],
-    batch_duplicates: list[tuple[int, int]],
-) -> int:
-    """Classify one sampled chunk into novel rows and duplicates.
-
-    The classification runs once per distinct coalition of the chunk instead
-    of once per row: duplicates within the chunk resolve through
-    ``np.unique``, and only the unique rows touch the carried dictionaries.
-    Novel ranks are assigned in first-occurrence order, matching sequential
-    row-by-row classification exactly.
-
-    Returns:
-        The number of novel coalitions found in the chunk.
-    """
-    unique_rows, first_indices, inverse = np.unique(
-        packed,
-        axis=0,
-        return_index=True,
-        return_inverse=True,
-    )
-    codes = np.empty(unique_rows.shape[0], dtype=np.int64)
-    is_state_dup = np.zeros(unique_rows.shape[0], dtype=bool)
-    found = 0
-    for unique_index in np.argsort(first_indices, kind="stable"):
-        key = unique_rows[unique_index].tobytes()
-        rank = batch_ranks.get(key)
-        if rank is not None:
-            codes[unique_index] = rank
-        elif (source := known.get(key)) is not None:
-            is_state_dup[unique_index] = True
-            codes[unique_index] = source
-        else:
-            batch_ranks[key] = len(novel_positions)
-            codes[unique_index] = len(novel_positions)
-            novel_positions.append(position + int(first_indices[unique_index]))
-            found += 1
-    row_positions = position + np.arange(packed.shape[0])
-    row_codes = codes[inverse]
-    row_is_state = is_state_dup[inverse]
-    novel_first = np.zeros(packed.shape[0], dtype=bool)
-    if found:
-        novel_first[np.asarray(novel_positions[-found:]) - position] = True
-    state_mask = row_is_state
-    batch_mask = ~row_is_state & ~novel_first
-    state_duplicates.extend(
-        zip(row_positions[state_mask].tolist(), row_codes[state_mask].tolist(), strict=True),
-    )
-    batch_duplicates.extend(
-        zip(row_positions[batch_mask].tolist(), row_codes[batch_mask].tolist(), strict=True),
-    )
-    return found
+    packed = np.packbits(rows, axis=-1)
+    width = packed.shape[-1]
+    blob = packed.tobytes()
+    return [blob[start : start + width] for start in range(0, len(blob), width)]

--- a/src/shapiq/explainers/_evidence.py
+++ b/src/shapiq/explainers/_evidence.py
@@ -207,7 +207,10 @@ class EvidenceApproximator(
                 n_value_axes,
             )
         state_values = None
-        if isinstance(self.state, SamplingState):
+        # reading stored values materializes the state's lazy chunks, so only
+        # touch them when duplicates need filling or no novel values exist to
+        # serve as the dtype reference
+        if isinstance(self.state, SamplingState) and (state_duplicates or not novel_positions):
             state_values = to_leading(
                 jnp.asarray(cast("SamplingState[Array]", self.state).values),
                 n_value_axes,

--- a/src/shapiq/explainers/_evidence.py
+++ b/src/shapiq/explainers/_evidence.py
@@ -127,17 +127,16 @@ class EvidenceApproximator(
             coalitions, sampler = sampler.sample(self.state, remaining)
             dense = jnp.asarray(coalitions.to_dense())
             chunks.append(dense)
-            found = 0
-            for key in _coalition_keys(dense):
-                if key in batch_ranks:
-                    batch_duplicates.append((position, batch_ranks[key]))
-                elif key in known:
-                    state_duplicates.append((position, known[key]))
-                else:
-                    batch_ranks[key] = len(novel_positions)
-                    novel_positions.append(position)
-                    found += 1
-                position += 1
+            found = _classify_chunk(
+                _packed_rows(dense),
+                position,
+                known=known,
+                batch_ranks=batch_ranks,
+                novel_positions=novel_positions,
+                state_duplicates=state_duplicates,
+                batch_duplicates=batch_duplicates,
+            )
+            position += int(dense.shape[-2])
             remaining -= found
             raw_since_novel = 0 if found else raw_since_novel + int(dense.shape[-2])
             if remaining > 0 and raw_since_novel >= stall_limit:
@@ -182,11 +181,12 @@ class EvidenceApproximator(
                 if cached_length == len(cached):
                     return cached
                 return {key: index for key, index in cached.items() if index < n_samples}
-        dense = jnp.asarray(self.state.coalitions.to_dense())
-        known: dict[bytes, int] = {}
-        for index, key in enumerate(_coalition_keys(dense)):
-            known.setdefault(key, index)
-        return known
+        packed = _packed_rows(jnp.asarray(self.state.coalitions.to_dense()))
+        unique_rows, first_indices = np.unique(packed, axis=0, return_index=True)
+        return {
+            row.tobytes(): int(index)
+            for row, index in zip(unique_rows, first_indices, strict=True)
+        }
 
     def _stitch_values(
         self,
@@ -268,10 +268,67 @@ class EvidenceApproximator(
         raise InsufficientSamplesError(msg)
 
 
-def _coalition_keys(dense: Array) -> list[bytes]:
-    """Return a hashable identity per sample-axis coalition (shared targets only)."""
+def _packed_rows(dense: Array) -> np.ndarray:
+    """Return one packed identity row per sample-axis coalition (shared targets only)."""
     rows = np.asarray(dense).reshape(-1, dense.shape[-2], dense.shape[-1])[0]
-    packed = np.packbits(rows, axis=-1)
-    width = packed.shape[-1]
-    blob = packed.tobytes()
-    return [blob[start : start + width] for start in range(0, len(blob), width)]
+    return np.packbits(rows, axis=-1)
+
+
+def _classify_chunk(
+    packed: np.ndarray,
+    position: int,
+    *,
+    known: dict[bytes, int],
+    batch_ranks: dict[bytes, int],
+    novel_positions: list[int],
+    state_duplicates: list[tuple[int, int]],
+    batch_duplicates: list[tuple[int, int]],
+) -> int:
+    """Classify one sampled chunk into novel rows and duplicates.
+
+    The classification runs once per distinct coalition of the chunk instead
+    of once per row: duplicates within the chunk resolve through
+    ``np.unique``, and only the unique rows touch the carried dictionaries.
+    Novel ranks are assigned in first-occurrence order, matching sequential
+    row-by-row classification exactly.
+
+    Returns:
+        The number of novel coalitions found in the chunk.
+    """
+    unique_rows, first_indices, inverse = np.unique(
+        packed,
+        axis=0,
+        return_index=True,
+        return_inverse=True,
+    )
+    codes = np.empty(unique_rows.shape[0], dtype=np.int64)
+    is_state_dup = np.zeros(unique_rows.shape[0], dtype=bool)
+    found = 0
+    for unique_index in np.argsort(first_indices, kind="stable"):
+        key = unique_rows[unique_index].tobytes()
+        rank = batch_ranks.get(key)
+        if rank is not None:
+            codes[unique_index] = rank
+        elif (source := known.get(key)) is not None:
+            is_state_dup[unique_index] = True
+            codes[unique_index] = source
+        else:
+            batch_ranks[key] = len(novel_positions)
+            codes[unique_index] = len(novel_positions)
+            novel_positions.append(position + int(first_indices[unique_index]))
+            found += 1
+    row_positions = position + np.arange(packed.shape[0])
+    row_codes = codes[inverse]
+    row_is_state = is_state_dup[inverse]
+    novel_first = np.zeros(packed.shape[0], dtype=bool)
+    if found:
+        novel_first[np.asarray(novel_positions[-found:]) - position] = True
+    state_mask = row_is_state
+    batch_mask = ~row_is_state & ~novel_first
+    state_duplicates.extend(
+        zip(row_positions[state_mask].tolist(), row_codes[state_mask].tolist(), strict=True),
+    )
+    batch_duplicates.extend(
+        zip(row_positions[batch_mask].tolist(), row_codes[batch_mask].tolist(), strict=True),
+    )
+    return found

--- a/src/shapiq/explainers/_exact.py
+++ b/src/shapiq/explainers/_exact.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from functools import cache
-from itertools import combinations
 from math import comb
 from typing import cast
 
@@ -214,12 +213,9 @@ def _require_weight_length(source: str, weights: Array, n_players: int, size: in
 @cache
 def _powerset_masks(n_players: int) -> Array:
     """Return all coalitions as dense masks, ordered by size then lexicographically."""
-    return jnp.asarray(
-        [
-            [player in members for player in range(n_players)]
-            for size in range(n_players + 1)
-            for members in combinations(range(n_players), size)
-        ],
+    return jnp.concatenate(
+        [interaction_masks(n_players, size) for size in range(n_players + 1)],
+        axis=0,
     )
 
 

--- a/src/shapiq/explainers/_faithful.py
+++ b/src/shapiq/explainers/_faithful.py
@@ -8,6 +8,7 @@ from itertools import combinations
 from math import comb
 
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 
 from shapiq.errors import InsufficientSamplesError
@@ -16,12 +17,16 @@ from shapiq.errors import InsufficientSamplesError
 @cache
 def interaction_masks(n_players: int, size: int) -> Array:
     """Return dense member masks of all size-``size`` interactions, lexicographic."""
-    return jnp.asarray(
-        [
-            [player in members for player in range(n_players)]
-            for members in combinations(range(n_players), size)
-        ],
+    if size == 0:
+        return jnp.zeros((1, n_players), dtype=bool)
+    members = np.fromiter(
+        combinations(range(n_players), size),
+        dtype=np.dtype((np.int64, (size,))),
+        count=comb(n_players, size),
     )
+    masks = np.zeros((members.shape[0], n_players), dtype=bool)
+    masks[np.arange(members.shape[0])[:, None], members] = True
+    return jnp.asarray(masks)
 
 
 def interaction_design(masks: Array, order: int) -> Array:
@@ -51,10 +56,10 @@ def eliminate_constraint(design: Array) -> tuple[Array, Array]:
 
     Returns:
         The reduced design ``(rows, columns - 1)`` and the pivot column
-        ``(rows, 1)``.
+        ``(rows, 1)``; leading batch axes pass through.
     """
-    pivot = design[:, -1:]
-    return design[:, :-1] - pivot, pivot
+    pivot = design[..., -1:]
+    return design[..., :-1] - pivot, pivot
 
 
 def solve_faithful(
@@ -64,6 +69,8 @@ def solve_faithful(
     delta: Array,
     *,
     sqrt_weights: Array | None = None,
+    identify: bool = False,
+    deduplicating: bool = False,
 ) -> Array:
     """Solve the eliminated least squares problem for all interaction columns.
 
@@ -74,17 +81,48 @@ def solve_faithful(
         delta: Grand-minus-empty value per target, shape ``(targets,)``.
         sqrt_weights: Optional square roots of row weights, shape ``(rows,)``;
             rows with zero weight drop out of the fit.
+        identify: Whether to require the design to identify all columns,
+            raising ``InsufficientSamplesError`` otherwise.
+        deduplicating: Whether the caller deduplicates coalitions, selecting
+            the identification hint.
 
     Returns:
         Attributions for every interaction column, shape ``(columns, targets)``.
     """
-    shifted = response - pivot * delta[None, :]
+    shifted = response - pivot * delta[..., None, :]
     if sqrt_weights is not None:
         reduced = reduced * sqrt_weights[:, None]
         shifted = shifted * sqrt_weights[:, None]
-    partial, *_ = jnp.linalg.lstsq(reduced, shifted)
-    last = delta[None, :] - jnp.sum(partial, axis=0, keepdims=True)
-    return jnp.concatenate([partial, last], axis=0)
+    if identify:
+        partial = lstsq_identified(reduced, shifted, deduplicating=deduplicating)
+    else:
+        partial, *_ = jnp.linalg.lstsq(reduced, shifted)
+    last = delta[..., None, :] - jnp.sum(partial, axis=-2, keepdims=True)
+    return jnp.concatenate([partial, last], axis=-2)
+
+
+def lstsq_identified(design: Array, response: Array, *, deduplicating: bool = False) -> Array:
+    """Solve a least squares fit, requiring the design to identify all columns.
+
+    The identifying rank comes from the solve itself, so no second
+    decomposition is paid on top of the fit.
+
+    Args:
+        design: Design matrix of shape ``(rows, columns)``.
+        response: Responses of shape ``(rows, targets)``.
+        deduplicating: Whether the caller deduplicates coalitions, selecting
+            the identification hint.
+
+    Returns:
+        The least squares solution of shape ``(columns, targets)``.
+
+    Raises:
+        InsufficientSamplesError: If the design does not identify every
+            column.
+    """
+    solution, _, rank, _ = jnp.linalg.lstsq(design, response)
+    _require_rank(int(rank), int(design.shape[-1]), deduplicating=deduplicating)
+    return solution
 
 
 def bernoulli_numbers(order: int) -> list[float]:
@@ -111,7 +149,7 @@ def bernoulli_design(masks: Array, order: int) -> Array:
         member_masks = interaction_masks(n_players, size)
         intersections = masks.astype(jnp.int32) @ member_masks.T.astype(jnp.int32)
         columns.append(table[size][intersections])
-    return jnp.concatenate(columns, axis=1)
+    return jnp.concatenate(columns, axis=-1)
 
 
 def _bernoulli_weight_table(order: int) -> Array:
@@ -129,18 +167,26 @@ def _bernoulli_weight_table(order: int) -> Array:
 
 def require_identification(reduced: Array, *, deduplicating: bool = False) -> None:
     """Raise when the sampled coalitions do not yet identify all attributions."""
-    needed = int(reduced.shape[-1])
-    rank = int(jnp.linalg.matrix_rank(reduced))
-    if rank < needed:
-        hint = (
-            "sample more evaluations and retry"
-            if deduplicating
-            else "sample more evaluations (deduplicate=True reaches distinct "
-            "coalitions with the fewest evaluations)"
-        )
-        msg = (
-            "the faithful regression is not yet identified: the sampled coalitions "
-            f"give rank {rank} of the {needed} required, so at least "
-            f"{needed - rank} more distinct informative coalitions are needed; {hint}"
-        )
-        raise InsufficientSamplesError(msg)
+    _require_rank(
+        int(jnp.linalg.matrix_rank(reduced)),
+        int(reduced.shape[-1]),
+        deduplicating=deduplicating,
+    )
+
+
+def _require_rank(rank: int, needed: int, *, deduplicating: bool) -> None:
+    """Raise the identification error when a solved rank falls short."""
+    if rank >= needed:
+        return
+    hint = (
+        "sample more evaluations and retry"
+        if deduplicating
+        else "sample more evaluations (deduplicate=True reaches distinct "
+        "coalitions with the fewest evaluations)"
+    )
+    msg = (
+        "the faithful regression is not yet identified: the sampled coalitions "
+        f"give rank {rank} of the {needed} required, so at least "
+        f"{needed - rank} more distinct informative coalitions are needed; {hint}"
+    )
+    raise InsufficientSamplesError(msg)

--- a/src/shapiq/explainers/_permutation.py
+++ b/src/shapiq/explainers/_permutation.py
@@ -14,6 +14,7 @@ from shapiq.explainers._evidence import EvidenceApproximator
 from shapiq.explainers._valueaxes import to_leading, to_trailing
 from shapiq.explanations import DenseExplanationArray
 from shapiq.interactions import SII, STII, SV
+from shapiq.interactions._ranks import interaction_ranks
 from shapiq.sampling import (
     EmptyState,
     PairedSampler,
@@ -362,10 +363,21 @@ def _explain_interactions(
                 [permutations[..., start : start + n_windows] for start in range(size)],
                 axis=-1,
             )
-            ranks = _interaction_ranks(window_members, n_players)
-            onehots = ranks[..., None] == jnp.arange(comb(n_players, size))
-            sums = jnp.sum(onehots * derivatives[..., None], axis=(-3, -2))
-            counts = jnp.sum(onehots, axis=(-3, -2))
+            ranks = interaction_ranks(window_members, n_players)
+            n_interactions = comb(n_players, size)
+            sums = _scatter_by_rank(
+                jnp.broadcast_to(
+                    derivatives,
+                    jnp.broadcast_shapes(ranks.shape, derivatives.shape),
+                ),
+                ranks,
+                n_interactions,
+            )
+            counts = _scatter_by_rank(
+                jnp.ones(ranks.shape, dtype=jnp.int32),
+                ranks,
+                n_interactions,
+            )
             if bool(jnp.any(counts == 0)):
                 missing = int(jnp.sum(counts == 0))
                 walks_needed = -(-missing // n_windows)
@@ -444,7 +456,7 @@ def _taylor_exact_empty_derivatives(
     for pattern in nonempty_patterns(size):
         subset_members = members[:, jnp.asarray(pattern)]
         block_offset = 2 + sum(comb(n_players, s) for s in range(1, len(pattern)))
-        indices = block_offset + _interaction_ranks(subset_members, n_players)
+        indices = block_offset + interaction_ranks(subset_members, n_players)
         sign = (-1) ** (size - len(pattern))
         derivatives = derivatives + sign * seed_values[..., indices]
     return derivatives
@@ -523,6 +535,26 @@ def _chain_marginal_sums(
     return sums + jnp.sum(~chain_masks[..., -1, :] * last_marginals[..., None], axis=-2)
 
 
+def _scatter_by_rank(values: Array, ranks: Array, n_interactions: int) -> Array:
+    """Sum per-window values into per-interaction bins by lexicographic rank.
+
+    The scatter-add avoids materializing a one-hot
+    ``(walks, windows, interactions)`` tensor, whose size grows with the
+    full interaction count times the sample count.
+    """
+    lead = values.shape[:-2]
+    n_samples = values.shape[-2] * values.shape[-1]
+    flat_values = values.reshape(-1, n_samples)
+    flat_ranks = jnp.broadcast_to(ranks, values.shape).reshape(-1, n_samples)
+    rows = jnp.arange(flat_values.shape[0])[:, None]
+    binned = (
+        jnp.zeros((flat_values.shape[0], n_interactions), dtype=values.dtype)
+        .at[rows, flat_ranks]
+        .add(flat_values)
+    )
+    return binned.reshape(*lead, n_interactions)
+
+
 def _recover_permutations(chain_masks: Array) -> Array:
     """Recover player orderings from stored prefix chains."""
     previous_masks = jnp.concatenate(
@@ -534,12 +566,3 @@ def _recover_permutations(chain_masks: Array) -> Array:
     return jnp.argmax(jnp.concatenate([added_players, last_players], axis=-2), axis=-1)
 
 
-def _interaction_ranks(members: Array, n_players: int) -> Array:
-    """Return lexicographic ranks of fixed-size interactions among all combinations."""
-    size = members.shape[-1]
-    ordered = jnp.sort(members, axis=-1)
-    binomials = jnp.asarray(
-        [[comb(row, column) for column in range(size + 1)] for row in range(n_players)],
-    )
-    terms = binomials[n_players - 1 - ordered, size - jnp.arange(size)]
-    return comb(n_players, size) - 1 - jnp.sum(terms, axis=-1)

--- a/src/shapiq/explainers/_permutation.py
+++ b/src/shapiq/explainers/_permutation.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, NamedTuple, cast
 import jax.numpy as jnp
 from jax import Array
 
-from shapiq._shape import ensure_bool
+from shapiq._shape import broadcast_shapes, ensure_bool
 from shapiq.errors import InsufficientSamplesError
 from shapiq.explainers._base import reject_common_index_mistakes
 from shapiq.explainers._evidence import EvidenceApproximator
@@ -368,7 +368,7 @@ def _explain_interactions(
             sums = _scatter_by_rank(
                 jnp.broadcast_to(
                     derivatives,
-                    jnp.broadcast_shapes(ranks.shape, derivatives.shape),
+                    broadcast_shapes(ranks.shape, derivatives.shape),
                 ),
                 ranks,
                 n_interactions,

--- a/src/shapiq/explainers/_regression.py
+++ b/src/shapiq/explainers/_regression.py
@@ -15,7 +15,7 @@ from shapiq.explainers._faithful import (
     bernoulli_design,
     eliminate_constraint,
     interaction_design,
-    require_identification,
+    lstsq_identified,
     solve_faithful,
 )
 from shapiq.explainers._valueaxes import to_leading, to_trailing
@@ -234,6 +234,8 @@ class Regression(EvidenceApproximator):
         if flat_masks.shape[0] == 1:
             solutions = self._solve(flat_masks[0], response, delta)
         else:
+            # per-target solves stay sequential: LAPACK multithreads inside
+            # each least squares solve, which beats one batched SVD on CPU
             broadcast_masks = jnp.broadcast_to(
                 sample_masks,
                 (*target_shape, n_rows, n_players),
@@ -423,8 +425,14 @@ def _constrained_solve(
 ) -> Array:
     """Fit the constrained Shapley-kernel regression (empty and grand exact)."""
     reduced, pivot = eliminate_constraint(interaction_design(masks, order))
-    require_identification(reduced, deduplicating=deduplicating)
-    return solve_faithful(reduced, pivot, response, delta)
+    return solve_faithful(
+        reduced,
+        pivot,
+        response,
+        delta,
+        identify=True,
+        deduplicating=deduplicating,
+    )
 
 
 def _free_intercept_solve(
@@ -438,10 +446,8 @@ def _free_intercept_solve(
     """Fit the unconstrained kernel regression with a free intercept row."""
     del delta
     design = interaction_design(masks, order)
-    design = jnp.concatenate([jnp.ones((design.shape[0], 1)), design], axis=-1)
-    require_identification(design, deduplicating=deduplicating)
-    solution, *_ = jnp.linalg.lstsq(design, response)
-    return solution
+    design = jnp.concatenate([jnp.ones((*design.shape[:-1], 1)), design], axis=-1)
+    return lstsq_identified(design, response, deduplicating=deduplicating)
 
 
 def _kadd_solve(
@@ -466,11 +472,14 @@ def _kadd_solve(
     constraint = bernoulli_design(jnp.ones((1, n_players)), order)[0]
     pivot_column = int(jnp.argmax(jnp.abs(constraint)))
     anchor = constraint[pivot_column]
-    pivot = design[:, pivot_column : pivot_column + 1]
-    reduced = jnp.delete(design - pivot * (constraint / anchor)[None, :], pivot_column, axis=1)
-    require_identification(reduced, deduplicating=deduplicating)
-    shifted = response - (pivot / anchor) * delta[None, :]
-    partial, *_ = jnp.linalg.lstsq(reduced, shifted)
+    pivot = design[..., pivot_column : pivot_column + 1]
+    reduced = jnp.delete(
+        design - pivot * (constraint / anchor)[None, :],
+        pivot_column,
+        axis=-1,
+    )
+    shifted = response - (pivot / anchor) * delta[..., None, :]
+    partial = lstsq_identified(reduced, shifted, deduplicating=deduplicating)
     others = jnp.delete(constraint, pivot_column)
-    back_substituted = (delta[None, :] - others[:, None].T @ partial) / anchor
-    return jnp.insert(partial, pivot_column, back_substituted[0], axis=0)
+    back_substituted = (delta[..., None, :] - others[None, :] @ partial) / anchor
+    return jnp.insert(partial, pivot_column, back_substituted[..., 0, :], axis=-2)

--- a/src/shapiq/explanations/_base.py
+++ b/src/shapiq/explanations/_base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Self
 
-import jax.numpy as jnp
+import numpy as np
 
 from shapiq._shape import Shape, logical_size
 from shapiq.interactions import (
@@ -15,8 +15,6 @@ from shapiq.interactions import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
-
-    from jax import Array
 
 
 class ExplanationArray[ValueT](ABC):
@@ -121,24 +119,28 @@ def check_represented_window(index: InteractionIndex, size: int, order: int) -> 
     raise KeyError(msg)
 
 
-def as_interaction_array(value: object) -> Array:
-    """Coerce an array-of-interactions lookup argument, teaching on misuse."""
-    array = jnp.asarray(value)
+def as_interaction_array(value: object) -> np.ndarray:
+    """Coerce an array-of-interactions lookup argument, teaching on misuse.
+
+    Interactions are host-side index metadata, so lookups coerce to NumPy;
+    device-backed lookup arrays come home once here.
+    """
+    array = np.asarray(value)
     if array.ndim < 1:
         msg = (
             "interactions must be tuples of player indices, e.g. explanation((0,)) "
             "for player 0; array lookups need a final interaction-members axis"
         )
         raise TypeError(msg)
-    if array.dtype == jnp.bool_ or not jnp.issubdtype(array.dtype, jnp.integer):
+    if array.dtype == np.bool_ or not np.issubdtype(array.dtype, np.integer):
         msg = "interaction arrays must have integer dtype"
         raise TypeError(msg)
     return array
 
 
-def interaction_rows(array: Array) -> list[list[int]]:
+def interaction_rows(array: np.ndarray) -> list[list[int]]:
     """Return the interactions of a lookup array as flat host rows."""
-    return jnp.reshape(array, (-1, array.shape[-1])).tolist()
+    return array.reshape(-1, array.shape[-1]).tolist()
 
 
 def validate_explained_index(index: object, *, order: int) -> InteractionIndex:

--- a/src/shapiq/explanations/_dense.py
+++ b/src/shapiq/explanations/_dense.py
@@ -6,6 +6,7 @@ from math import comb
 from typing import TYPE_CHECKING, Protocol, cast
 
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 
 from shapiq._shape import Shape, normalize_shape, validate_n_players
@@ -13,18 +14,16 @@ from shapiq.explanations._base import (
     ExplanationArray,
     as_interaction_array,
     check_represented_window,
-    interaction_rows,
     validate_explained_index,
 )
 from shapiq.interactions import (
     Interaction,
     InteractionIndex,
     InteractionOrientation,
-    iter_interactions,
     normalize_interaction,
     validate_interaction_metadata,
 )
-from shapiq.interactions._ranks import interaction_rank, interaction_ranks
+from shapiq.interactions._ranks import host_interaction_ranks, interaction_rank
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -153,21 +152,13 @@ class DenseExplanationArray[ValueT](ExplanationArray[ValueT]):
                 return jnp.zeros(self.shape, dtype=bool)
             return jnp.ones(self.shape, dtype=bool)
         interactions = as_interaction_array(interaction)
-        if self.orientation == "undirected":
-            size = int(interactions.shape[-1])
-            mask = (
-                self._valid_players(interactions)
-                if self._represents_size(size)
-                else jnp.zeros(interactions.shape[:-1], dtype=bool)
-            )
-        else:
-            mask = jnp.reshape(
-                jnp.asarray(
-                    [self._is_represented(tuple(row)) for row in interaction_rows(interactions)],
-                    dtype=bool,
-                ),
-                interactions.shape[:-1],
-            )
+        rows = np.asarray(interactions).reshape(-1, int(interactions.shape[-1]))
+        available = (
+            self._valid_players(rows)
+            if self._represents_size(int(interactions.shape[-1]))
+            else np.zeros(rows.shape[0], dtype=bool)
+        )
+        mask = jnp.asarray(available.reshape(interactions.shape[:-1]))
         return jnp.broadcast_to(mask, jnp.broadcast_shapes(self.shape, interactions.shape[:-1]))
 
     def _represents_size(self, size: int) -> bool:
@@ -190,57 +181,45 @@ class DenseExplanationArray[ValueT](ExplanationArray[ValueT]):
             raise KeyError(msg)
         return normalized
 
-    def _is_represented(self, interaction: Sequence[int]) -> bool:
-        try:
-            self._normalize_represented(interaction)
-        except (TypeError, ValueError, KeyError):
-            return False
-        return True
-
-    def _valid_players(self, interactions: Array) -> Array:
+    def _valid_players(self, rows: np.ndarray) -> np.ndarray:
         """Return per-interaction validity: players in range, no repeats."""
-        in_bounds = jnp.all(
-            (interactions >= 0) & (interactions < self.n_players),
-            axis=-1,
-        )
-        if interactions.shape[-1] < 2:
+        in_bounds = np.all((rows >= 0) & (rows < self.n_players), axis=-1)
+        if rows.shape[-1] < 2:
             return in_bounds
-        ordered = jnp.sort(interactions, axis=-1)
-        distinct = jnp.all(ordered[..., 1:] > ordered[..., :-1], axis=-1)
-        return in_bounds & distinct
+        ordered = np.sort(rows, axis=-1)
+        return in_bounds & np.all(ordered[..., 1:] > ordered[..., :-1], axis=-1)
 
     def _position(self, interaction: Interaction) -> int:
-        if self.orientation == "undirected":
-            return interaction_rank(interaction, self.n_players)
-        return list(
-            iter_interactions(
-                self.n_players,
-                len(interaction),
-                min_order=len(interaction),
-                orientation=self.orientation,
-            )
-        ).index(interaction)
+        # every constructible explanation is undirected; a directed rank
+        # would need its own closed form next to interaction_rank
+        return interaction_rank(interaction, self.n_players)
 
     def _positions(self, interactions: Array) -> Array:
-        if self.orientation != "undirected" or not bool(
-            jnp.all(self._valid_players(interactions)),
-        ):
-            # the loop re-raises the per-interaction teaching error
-            return jnp.reshape(
-                jnp.asarray(
-                    [
-                        self._position(self._normalize_represented(tuple(row)))
-                        for row in interaction_rows(interactions)
-                    ]
-                ),
-                interactions.shape[:-1],
+        """Resolve block positions of a lookup array, teaching on bad rows.
+
+        Positions are host-side index math and resolve in plain NumPy, so
+        bulk lookups run at full speed on the first call with no kernel
+        compilation.
+        """
+        rows = np.asarray(interactions).reshape(-1, int(interactions.shape[-1]))
+        invalid = ~self._valid_players(rows)
+        if bool(invalid.any()):
+            offender = tuple(int(player) for player in rows[int(np.argmax(invalid))])
+            normalize_interaction(
+                offender,
+                orientation=self.orientation,
+                n_players=self.n_players,
             )
+            msg = "invalid interaction row"  # unreachable: the checks above mirror it
+            raise ValueError(msg)
         size = int(interactions.shape[-1])
         check_represented_window(self.index, size, self.order)
         if size not in self.attributions_by_order:
             msg = f"no order-{size} attributions are stored on this explanation"
             raise KeyError(msg)
-        return interaction_ranks(interactions, self.n_players)
+        return jnp.asarray(
+            host_interaction_ranks(rows, self.n_players).reshape(interactions.shape[:-1]),
+        )
 
 
 def _slice_attributions(value: object, key: tuple[object, ...]) -> object:

--- a/src/shapiq/explanations/_dense.py
+++ b/src/shapiq/explanations/_dense.py
@@ -24,6 +24,7 @@ from shapiq.interactions import (
     normalize_interaction,
     validate_interaction_metadata,
 )
+from shapiq.interactions._ranks import interaction_rank, interaction_ranks
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -152,12 +153,30 @@ class DenseExplanationArray[ValueT](ExplanationArray[ValueT]):
                 return jnp.zeros(self.shape, dtype=bool)
             return jnp.ones(self.shape, dtype=bool)
         interactions = as_interaction_array(interaction)
-        mask = jnp.asarray(
-            [self._is_represented(tuple(row)) for row in interaction_rows(interactions)],
-            dtype=bool,
-        )
-        mask = jnp.reshape(mask, interactions.shape[:-1])
+        if self.orientation == "undirected":
+            size = int(interactions.shape[-1])
+            mask = (
+                self._valid_players(interactions)
+                if self._represents_size(size)
+                else jnp.zeros(interactions.shape[:-1], dtype=bool)
+            )
+        else:
+            mask = jnp.reshape(
+                jnp.asarray(
+                    [self._is_represented(tuple(row)) for row in interaction_rows(interactions)],
+                    dtype=bool,
+                ),
+                interactions.shape[:-1],
+            )
         return jnp.broadcast_to(mask, jnp.broadcast_shapes(self.shape, interactions.shape[:-1]))
+
+    def _represents_size(self, size: int) -> bool:
+        """Return whether lookups of one interaction size can succeed."""
+        try:
+            check_represented_window(self.index, size, self.order)
+        except KeyError:
+            return False
+        return size in self.attributions_by_order
 
     def _normalize_represented(self, interaction: Sequence[int]) -> Interaction:
         normalized = normalize_interaction(
@@ -178,7 +197,21 @@ class DenseExplanationArray[ValueT](ExplanationArray[ValueT]):
             return False
         return True
 
+    def _valid_players(self, interactions: Array) -> Array:
+        """Return per-interaction validity: players in range, no repeats."""
+        in_bounds = jnp.all(
+            (interactions >= 0) & (interactions < self.n_players),
+            axis=-1,
+        )
+        if interactions.shape[-1] < 2:
+            return in_bounds
+        ordered = jnp.sort(interactions, axis=-1)
+        distinct = jnp.all(ordered[..., 1:] > ordered[..., :-1], axis=-1)
+        return in_bounds & distinct
+
     def _position(self, interaction: Interaction) -> int:
+        if self.orientation == "undirected":
+            return interaction_rank(interaction, self.n_players)
         return list(
             iter_interactions(
                 self.n_players,
@@ -189,15 +222,25 @@ class DenseExplanationArray[ValueT](ExplanationArray[ValueT]):
         ).index(interaction)
 
     def _positions(self, interactions: Array) -> Array:
-        return jnp.reshape(
-            jnp.asarray(
-                [
-                    self._position(self._normalize_represented(tuple(row)))
-                    for row in interaction_rows(interactions)
-                ]
-            ),
-            interactions.shape[:-1],
-        )
+        if self.orientation != "undirected" or not bool(
+            jnp.all(self._valid_players(interactions)),
+        ):
+            # the loop re-raises the per-interaction teaching error
+            return jnp.reshape(
+                jnp.asarray(
+                    [
+                        self._position(self._normalize_represented(tuple(row)))
+                        for row in interaction_rows(interactions)
+                    ]
+                ),
+                interactions.shape[:-1],
+            )
+        size = int(interactions.shape[-1])
+        check_represented_window(self.index, size, self.order)
+        if size not in self.attributions_by_order:
+            msg = f"no order-{size} attributions are stored on this explanation"
+            raise KeyError(msg)
+        return interaction_ranks(interactions, self.n_players)
 
 
 def _slice_attributions(value: object, key: tuple[object, ...]) -> object:

--- a/src/shapiq/explanations/_dense.py
+++ b/src/shapiq/explanations/_dense.py
@@ -7,9 +7,16 @@ from typing import TYPE_CHECKING, Protocol, cast
 
 import jax.numpy as jnp
 import numpy as np
-from jax import Array
 
-from shapiq._shape import Shape, normalize_shape, validate_n_players
+from shapiq._shape import (
+    Shape,
+    broadcast_shapes,
+    expand_ellipsis,
+    indexed_shape,
+    normalize_shape,
+    shape_of,
+    validate_n_players,
+)
 from shapiq.explanations._base import (
     ExplanationArray,
     as_interaction_array,
@@ -59,10 +66,7 @@ class DenseExplanationArray[ValueT](ExplanationArray[ValueT]):
         )
         for size, block in self.attributions_by_order.items():
             expected = (*shape, comb(n_players, size), *value_shape)
-            block_shape = getattr(block, "shape", None)
-            actual = (
-                tuple(block_shape) if block_shape is not None else jnp.shape(cast("Array", block))
-            )
+            actual = shape_of(block)
             if actual != expected:
                 msg = (
                     f"order-{size} attributions have shape {actual}, expected "
@@ -71,12 +75,7 @@ class DenseExplanationArray[ValueT](ExplanationArray[ValueT]):
                 raise ValueError(msg)
         if self.baseline is not None:
             expected = (*shape, *value_shape)
-            baseline_shape = getattr(self.baseline, "shape", None)
-            actual = (
-                tuple(baseline_shape)
-                if baseline_shape is not None
-                else jnp.shape(cast("Array", self.baseline))
-            )
+            actual = shape_of(self.baseline)
             if actual != expected:
                 msg = f"the baseline has shape {actual}, expected {expected}"
                 raise ValueError(msg)
@@ -86,8 +85,8 @@ class DenseExplanationArray[ValueT](ExplanationArray[ValueT]):
         if self.shape == ():
             msg = "cannot index a scalar explanation"
             raise IndexError(msg)
-        key_tuple = key if isinstance(key, tuple) else (key,)
-        new_shape = tuple(int(dim) for dim in jnp.empty(self.shape)[key].shape)
+        new_shape = indexed_shape(self.shape, key)
+        key_tuple = expand_ellipsis(key if isinstance(key, tuple) else (key,), self.ndim)
         new_values = {
             order: _slice_attributions(values, key_tuple)
             for order, values in self.attributions_by_order.items()
@@ -152,14 +151,14 @@ class DenseExplanationArray[ValueT](ExplanationArray[ValueT]):
                 return jnp.zeros(self.shape, dtype=bool)
             return jnp.ones(self.shape, dtype=bool)
         interactions = as_interaction_array(interaction)
-        rows = np.asarray(interactions).reshape(-1, int(interactions.shape[-1]))
+        rows = interactions.reshape(-1, interactions.shape[-1])
         available = (
             self._valid_players(rows)
             if self._represents_size(int(interactions.shape[-1]))
             else np.zeros(rows.shape[0], dtype=bool)
         )
         mask = jnp.asarray(available.reshape(interactions.shape[:-1]))
-        return jnp.broadcast_to(mask, jnp.broadcast_shapes(self.shape, interactions.shape[:-1]))
+        return jnp.broadcast_to(mask, broadcast_shapes(self.shape, interactions.shape[:-1]))
 
     def _represents_size(self, size: int) -> bool:
         """Return whether lookups of one interaction size can succeed."""
@@ -194,14 +193,14 @@ class DenseExplanationArray[ValueT](ExplanationArray[ValueT]):
         # would need its own closed form next to interaction_rank
         return interaction_rank(interaction, self.n_players)
 
-    def _positions(self, interactions: Array) -> Array:
+    def _positions(self, interactions: np.ndarray) -> np.ndarray:
         """Resolve block positions of a lookup array, teaching on bad rows.
 
         Positions are host-side index math and resolve in plain NumPy, so
         bulk lookups run at full speed on the first call with no kernel
         compilation.
         """
-        rows = np.asarray(interactions).reshape(-1, int(interactions.shape[-1]))
+        rows = interactions.reshape(-1, interactions.shape[-1])
         invalid = ~self._valid_players(rows)
         if bool(invalid.any()):
             offender = tuple(int(player) for player in rows[int(np.argmax(invalid))])
@@ -217,9 +216,7 @@ class DenseExplanationArray[ValueT](ExplanationArray[ValueT]):
         if size not in self.attributions_by_order:
             msg = f"no order-{size} attributions are stored on this explanation"
             raise KeyError(msg)
-        return jnp.asarray(
-            host_interaction_ranks(rows, self.n_players).reshape(interactions.shape[:-1]),
-        )
+        return host_interaction_ranks(rows, self.n_players).reshape(interactions.shape[:-1])
 
 
 def _slice_attributions(value: object, key: tuple[object, ...]) -> object:

--- a/src/shapiq/explanations/_sparse.py
+++ b/src/shapiq/explanations/_sparse.py
@@ -5,7 +5,15 @@ from typing import TYPE_CHECKING, Protocol, cast
 
 import jax.numpy as jnp
 
-from shapiq._shape import Shape, normalize_shape, validate_n_players
+from shapiq._shape import (
+    Shape,
+    broadcast_shapes,
+    expand_ellipsis,
+    indexed_shape,
+    normalize_shape,
+    shape_of,
+    validate_n_players,
+)
 from shapiq.explanations._base import (
     ExplanationArray,
     as_interaction_array,
@@ -61,7 +69,7 @@ class SparseExplanationArray[ValueT](ExplanationArray[ValueT]):
         object.__setattr__(self, "attributions", normalized)
         expected = (*shape, *value_shape)
         for interaction, value in normalized.items():
-            actual = jnp.shape(cast("jnp.ndarray", value))
+            actual = shape_of(value)
             if actual != expected:
                 msg = (
                     f"attributions for {interaction} have shape {actual}, expected "
@@ -69,7 +77,7 @@ class SparseExplanationArray[ValueT](ExplanationArray[ValueT]):
                 )
                 raise ValueError(msg)
         if self.baseline is not None:
-            actual = jnp.shape(cast("jnp.ndarray", self.baseline))
+            actual = shape_of(self.baseline)
             if actual != expected:
                 msg = f"the baseline has shape {actual}, expected {expected}"
                 raise ValueError(msg)
@@ -79,8 +87,8 @@ class SparseExplanationArray[ValueT](ExplanationArray[ValueT]):
         if self.shape == ():
             msg = "cannot index a scalar explanation"
             raise IndexError(msg)
-        key_tuple = key if isinstance(key, tuple) else (key,)
-        new_shape = tuple(int(dim) for dim in jnp.empty(self.shape)[key].shape)
+        new_shape = indexed_shape(self.shape, key)
+        key_tuple = expand_ellipsis(key if isinstance(key, tuple) else (key,), self.ndim)
         new_values = {
             interaction: cast("ValueT", cast("_Indexable", value)[(*key_tuple, Ellipsis)])
             for interaction, value in self.attributions.items()
@@ -152,7 +160,7 @@ class SparseExplanationArray[ValueT](ExplanationArray[ValueT]):
             dtype=bool,
         )
         mask = jnp.reshape(mask, interactions.shape[:-1])
-        return jnp.broadcast_to(mask, jnp.broadcast_shapes(self.shape, interactions.shape[:-1]))
+        return jnp.broadcast_to(mask, broadcast_shapes(self.shape, interactions.shape[:-1]))
 
     def _single_attribution(self, interaction: Sequence[int]) -> ValueT:
         normalized = self._normalize_valid(interaction)

--- a/src/shapiq/games/_base.py
+++ b/src/shapiq/games/_base.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Protocol
 
-import jax.numpy as jnp
+from shapiq._shape import broadcast_shapes, shape_of
 
 if TYPE_CHECKING:
-    from jax import Array
-
     from shapiq._shape import Shape
     from shapiq.coalitions import CoalitionArray
 
@@ -43,12 +41,11 @@ class Game[ValueT](ABC):
         if coalitions.shape == ():
             return
         expected = (
-            *jnp.broadcast_shapes(self.target_shape, coalitions.shape[:-1]),
+            *broadcast_shapes(self.target_shape, coalitions.shape[:-1]),
             coalitions.shape[-1],
             *self.value_shape,
         )
-        shape = getattr(values, "shape", None)
-        actual = tuple(shape) if shape is not None else jnp.shape(cast("Array", values))
+        actual = shape_of(values)
         if actual != expected:
             msg = (
                 f"game values have shape {actual}, expected {expected} "

--- a/src/shapiq/games/_superpixel.py
+++ b/src/shapiq/games/_superpixel.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 from array_api_compat import array_namespace, device
 
-from shapiq._shape import validate_int
+from shapiq._shape import broadcast_shapes, validate_int
 from shapiq.games._masker import (
     BackendArray,
     Masker,
@@ -108,7 +108,7 @@ class SuperpixelMasker[InputT: BackendArray](Masker[InputT]):
             require_shared_backend(self.inputs, baseline=self.baseline)
             baseline_array = cast("InputT", self.baseline)
         try:
-            np.broadcast_shapes(tuple(baseline_array.shape), image_shape)
+            broadcast_shapes(tuple(baseline_array.shape), image_shape)
         except ValueError as error:
             msg = (
                 f"baseline with shape {tuple(baseline_array.shape)} does not "

--- a/src/shapiq/games/torch/_callable.py
+++ b/src/shapiq/games/torch/_callable.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
+import numpy as np
 import torch
 
 from shapiq.games import CallableGame
@@ -87,8 +88,14 @@ class TorchCallableGame[ValueT](CallableGame[ValueT]):
 
 
 def _coalitions_to_torch(coalitions: CoalitionArray) -> torch.Tensor:
-    """Convert coalitions to torch bool tensors, using DLPack when possible."""
+    """Convert coalitions to torch bool tensors, keeping the DLPack device.
+
+    DLPack import preserves the coalitions' device, so a GPU JAX backend
+    hands the wrapped callable GPU-resident masks with no copy; inputs
+    torch cannot import come through host memory instead.
+    """
     dense = coalitions.to_dense()
-    if hasattr(dense, "__dlpack__"):
+    try:
         return torch.from_dlpack(dense).to(dtype=torch.bool)
-    return torch.as_tensor(dense, dtype=torch.bool)
+    except (AttributeError, BufferError, RuntimeError, TypeError, ValueError):
+        return torch.as_tensor(np.asarray(dense).copy(), dtype=torch.bool)

--- a/src/shapiq/games/torch/_chunked.py
+++ b/src/shapiq/games/torch/_chunked.py
@@ -6,10 +6,9 @@ from dataclasses import dataclass
 from math import prod
 from typing import TYPE_CHECKING
 
-import jax.numpy as jnp
 import torch
 
-from shapiq._shape import validate_int
+from shapiq._shape import broadcast_shapes, validate_int
 from shapiq.games._masked_predictor import MaskedPredictor
 
 if TYPE_CHECKING:
@@ -93,7 +92,7 @@ class ChunkedMaskedPredictor(MaskedPredictor[torch.Tensor]):
         n_samples = coalitions.shape[-1]
         leading = (slice(None),) * (len(coalitions.shape) - 1)
         instances_per_sample = prod(
-            jnp.broadcast_shapes(self.target_shape, coalitions.shape[:-1]),
+            broadcast_shapes(self.target_shape, coalitions.shape[:-1]),
         )
         samples_per_chunk = max(1, self.batch_size // max(instances_per_sample, 1))
         chunks: list[torch.Tensor] = []

--- a/src/shapiq/interactions/_ranks.py
+++ b/src/shapiq/interactions/_ranks.py
@@ -1,0 +1,67 @@
+"""Combinatorial ranking of fixed-size interactions.
+
+The lexicographic rank of a size-``k`` interaction among all ``comb(n, k)``
+combinations is a closed-form sum of binomial coefficients, so positions in
+dense per-order attribution blocks resolve in ``O(k)`` per interaction
+instead of materializing the full combination list.
+"""
+
+from __future__ import annotations
+
+from functools import cache
+from math import comb
+from typing import TYPE_CHECKING
+
+import jax.numpy as jnp
+
+if TYPE_CHECKING:
+    from jax import Array
+
+    from shapiq.interactions._types import Interaction
+
+
+def interaction_rank(interaction: Interaction, n_players: int) -> int:
+    """Return the lexicographic rank of one sorted interaction.
+
+    Args:
+        interaction: Sorted tuple of distinct player indices.
+        n_players: Number of players.
+
+    Returns:
+        The position of the interaction among all ``comb(n_players, size)``
+        combinations in lexicographic order, matching ``iter_interactions``.
+    """
+    size = len(interaction)
+    terms = sum(
+        comb(n_players - 1 - player, size - position)
+        for position, player in enumerate(interaction)
+    )
+    return comb(n_players, size) - 1 - terms
+
+
+def interaction_ranks(members: Array, n_players: int) -> Array:
+    """Return lexicographic ranks of fixed-size interactions among all combinations.
+
+    Args:
+        members: Integer array whose final axis holds the players of one
+            interaction each; player order within an interaction is free.
+        n_players: Number of players.
+
+    Returns:
+        An integer array of ``members.shape[:-1]`` whose entries are the
+        interactions' positions in lexicographic order, matching
+        ``iter_interactions``.
+    """
+    size = members.shape[-1]
+    ordered = jnp.sort(members, axis=-1)
+    binomials = _binomial_table(n_players, size)
+    terms = binomials[n_players - 1 - ordered, size - jnp.arange(size)]
+    return comb(n_players, size) - 1 - jnp.sum(terms, axis=-1)
+
+
+@cache
+def _binomial_table(n_players: int, size: int) -> Array:
+    """Return ``comb(row, column)`` for rows ``0..n-1`` and columns ``0..size``."""
+    return jnp.asarray(
+        [[comb(row, column) for column in range(size + 1)] for row in range(n_players)],
+    )

--- a/src/shapiq/interactions/_ranks.py
+++ b/src/shapiq/interactions/_ranks.py
@@ -13,6 +13,7 @@ from math import comb
 from typing import TYPE_CHECKING
 
 import jax.numpy as jnp
+import numpy as np
 
 if TYPE_CHECKING:
     from jax import Array
@@ -42,6 +43,9 @@ def interaction_rank(interaction: Interaction, n_players: int) -> int:
 def interaction_ranks(members: Array, n_players: int) -> Array:
     """Return lexicographic ranks of fixed-size interactions among all combinations.
 
+    The device twin of ``host_interaction_ranks`` for member arrays that
+    live inside estimator pipelines.
+
     Args:
         members: Integer array whose final axis holds the players of one
             interaction each; player order within an interaction is free.
@@ -54,14 +58,39 @@ def interaction_ranks(members: Array, n_players: int) -> Array:
     """
     size = members.shape[-1]
     ordered = jnp.sort(members, axis=-1)
-    binomials = _binomial_table(n_players, size)
+    binomials = jnp.asarray(_binomial_table(n_players, size))
     terms = binomials[n_players - 1 - ordered, size - jnp.arange(size)]
     return comb(n_players, size) - 1 - jnp.sum(terms, axis=-1)
 
 
+def host_interaction_ranks(members: np.ndarray, n_players: int) -> np.ndarray:
+    """Return lexicographic ranks as plain NumPy, compilation-free.
+
+    The host twin of ``interaction_ranks`` for lookup paths, where the
+    members arrive from the caller and positions index host-side storage:
+    plain NumPy resolves them at full speed on the first call, with no
+    kernel compilation.
+
+    Args:
+        members: Integer array whose final axis holds the players of one
+            interaction each; player order within an interaction is free.
+        n_players: Number of players.
+
+    Returns:
+        An integer array of ``members.shape[:-1]`` whose entries are the
+        interactions' positions in lexicographic order, matching
+        ``iter_interactions``.
+    """
+    size = members.shape[-1]
+    ordered = np.sort(members, axis=-1)
+    binomials = _binomial_table(n_players, size)
+    terms = binomials[n_players - 1 - ordered, size - np.arange(size)]
+    return comb(n_players, size) - 1 - np.sum(terms, axis=-1)
+
+
 @cache
-def _binomial_table(n_players: int, size: int) -> Array:
+def _binomial_table(n_players: int, size: int) -> np.ndarray:
     """Return ``comb(row, column)`` for rows ``0..n-1`` and columns ``0..size``."""
-    return jnp.asarray(
+    return np.asarray(
         [[comb(row, column) for column in range(size + 1)] for row in range(n_players)],
     )

--- a/src/shapiq/sampling/_permutation.py
+++ b/src/shapiq/sampling/_permutation.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from functools import lru_cache
 from itertools import combinations
 from math import comb
 from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 
 from shapiq._shape import validate_int
@@ -285,6 +287,11 @@ def nonempty_patterns(size: int) -> tuple[tuple[int, ...], ...]:
 def interaction_members(n_players: int, order: int) -> Array:
     """Return the member table of all order-sized interactions.
 
+    The host table is cached with a small bound: building the combination
+    list on every walk render or explain call is waste, while caching
+    device arrays would pin accelerator memory and the first call's dtype
+    regime for the process lifetime.
+
     Args:
         n_players: Number of players.
         order: Interaction order of the listed interactions.
@@ -294,4 +301,10 @@ def interaction_members(n_players: int, order: int) -> Array:
         rows are the interactions in lexicographic order, matching the order
         used by explanations.
     """
-    return jnp.asarray(list(combinations(range(n_players), order)))
+    return jnp.asarray(_member_table(n_players, order))
+
+
+@lru_cache(maxsize=16)
+def _member_table(n_players: int, order: int) -> np.ndarray:
+    """Return the host member table of all order-sized interactions."""
+    return np.asarray(list(combinations(range(n_players), order)))

--- a/src/shapiq/sampling/_schedule.py
+++ b/src/shapiq/sampling/_schedule.py
@@ -112,7 +112,13 @@ class UnitScheduleSampler(Sampler["ApproximationState"]):
         quantum = self.sampling_quantum
         full_units = remaining // quantum
         if full_units > 0:
-            batch = self._sampled_unit_batch(jnp.arange(units - 1, units - 1 + full_units))
+            # render in power-of-two unit buckets: budgets vary call to call,
+            # and a handful of stable batch shapes keeps XLA from recompiling
+            # the render pipeline per budget; padded units are sliced away
+            # before use and never reach the game
+            bucket = 1 << (full_units - 1).bit_length()
+            indices = jnp.arange(units - 1, units - 1 + bucket)
+            batch = self._sampled_unit_batch(indices)[:full_units]
             if batch.shape[-2] != quantum:
                 msg = (
                     f"sampled units hold {batch.shape[-2]} coalitions but sampling_quantum "

--- a/src/shapiq/sampling/_state.py
+++ b/src/shapiq/sampling/_state.py
@@ -1,27 +1,26 @@
 from __future__ import annotations
 
+from copy import copy
 from dataclasses import dataclass
 from typing import Protocol, Self, cast
 
 import jax.numpy as jnp
 
-from shapiq._shape import Shape, ensure_bool, normalize_shape
+from shapiq._shape import Shape, ShapeLike, ensure_bool, normalize_shape
 from shapiq.coalitions import CoalitionArray, DenseCoalitionArray
 from shapiq.errors import HistoryError
 
 
 class ApproximationState:
-    """Base abstraction for approximator evidence."""
+    """Base abstraction for approximator evidence.
 
-    @property
-    def mutable(self) -> bool:
-        """Return whether this state mutates in place."""
-        return False
+    ``mutable`` declares value-visible in-place mutation; value-equivalent
+    internal caching does not count. Both flags are plain class attributes
+    so subclasses may shadow them with fields or instance assignments.
+    """
 
-    @property
-    def track_history(self) -> bool:
-        """Return whether history tracking is enabled."""
-        return False
+    mutable: bool = False
+    track_history: bool = False
 
     def rollback(self, steps: int = 1) -> Self:
         """Return a value-equivalent previous state."""
@@ -114,64 +113,139 @@ class EmptyState(ApproximationState):
         return [self] if include_self else []
 
 
-@dataclass(eq=False, frozen=True)
 class SamplingState[ValueT](ApproximationState):  # noqa: PLW1641
-    """Approximation state storing sampled coalitions and evaluated values."""
+    """Approximation state storing sampled coalitions and evaluated values.
 
-    coalitions: CoalitionArray
-    values: ValueT
-    target_shape: Shape = ()
-    track_history: bool = False
-    _history_n_samples: tuple[int, ...] | None = None
+    Evidence accumulates as chunks: ``append`` shares the stored chunks and
+    adds the new one without copying, and the ``coalitions`` and ``values``
+    views concatenate all chunks once, on first access, caching the result.
+    Sampling many times between explanations therefore costs one
+    concatenation per explanation instead of one per sample call.
+    """
 
-    def __post_init__(self) -> None:
-        """Normalize metadata and initialize compact history."""
-        ensure_bool("track_history", self.track_history)
-        target_shape = normalize_shape(self.target_shape)
-        object.__setattr__(self, "target_shape", target_shape)
-        if self.track_history and self.mutable:
+    target_shape: Shape
+    track_history: bool
+
+    def __init__(
+        self,
+        coalitions: CoalitionArray,
+        values: ValueT,
+        target_shape: ShapeLike = (),
+        *,
+        track_history: bool = False,
+        _history_n_samples: tuple[int, ...] | None = None,
+    ) -> None:
+        """Initialize the evidence state from one sampled block.
+
+        Args:
+            coalitions: The sampled coalitions, as a dense coalition array.
+            values: The evaluated values aligned with the coalitions.
+            target_shape: The game's explanation-target shape.
+            track_history: Whether to record value-equivalent history.
+            _history_n_samples: Internal compact history carried by
+                ``append`` and ``rollback``.
+
+        Raises:
+            TypeError: If the coalitions are not dense.
+            ValueError: If the values' sample axis does not pair with the
+                coalitions.
+        """
+        ensure_bool("track_history", track_history)
+        _require_dense(coalitions)
+        self.target_shape = normalize_shape(target_shape)
+        self.track_history = track_history
+        _validate_values_alignment(coalitions, values, axis=len(self.target_shape))
+        self._chunks: tuple[tuple[CoalitionArray, ValueT], ...] = ((coalitions, values),)
+        self._history_n_samples = _history_n_samples
+        if track_history and self.mutable:
             msg = "mutable states cannot track history"
             raise HistoryError(msg)
-        if self.track_history and self._history_n_samples is None:
-            object.__setattr__(self, "_history_n_samples", (self.n_samples,))
+        if track_history and _history_n_samples is None:
+            self._history_n_samples = (self.n_samples,)
+
+    def __repr__(self) -> str:
+        """Return a concise representation."""
+        return (
+            f"{type(self).__name__}(n_samples={self.n_samples!r}, "
+            f"target_shape={self.target_shape!r}, track_history={self.track_history!r})"
+        )
+
+    @property
+    def coalitions(self) -> CoalitionArray:
+        """Return all sampled coalitions as one array."""
+        return self._materialized()[0]
+
+    @property
+    def values(self) -> ValueT:
+        """Return all evaluated values, aligned with the coalitions."""
+        return self._materialized()[1]
 
     @property
     def n_samples(self) -> int:
         """Return the number of sampled coalitions."""
-        if self.coalitions.shape == ():
-            return 0
-        return self.coalitions.shape[-1]
+        return sum(
+            0 if coalitions.shape == () else coalitions.shape[-1]
+            for coalitions, _ in self._chunks
+        )
 
     @property
     def shared_target_shape(self) -> Shape:
         """Return the sampler-produced shared target shape."""
-        if self.coalitions.shape == ():
+        first_coalitions, _ = self._chunks[0]
+        if first_coalitions.shape == ():
             return ()
-        return self.coalitions.shape[:-1]
+        return first_coalitions.shape[:-1]
 
     def append(self, coalitions: CoalitionArray, values: ValueT) -> SamplingState[ValueT]:
-        """Append sampled coalitions and evaluated values."""
+        """Append sampled coalitions and evaluated values without copying.
+
+        The appended state shares the stored chunks, so a sampling chain
+        costs no concatenations until its evidence is read.
+        """
         if coalitions.shape == () or coalitions.shape[-1] == 0:
             return self
-        if coalitions.n_players != self.coalitions.n_players:
+        if coalitions.n_players != self._chunks[0][0].n_players:
             msg = "coalitions use a different number of players"
             raise ValueError(msg)
         if coalitions.shape[:-1] != self.shared_target_shape:
             msg = "coalitions use a different shared target shape"
             raise ValueError(msg)
-        next_coalitions = _append_coalitions(self.coalitions, coalitions)
-        next_values = _append_values(self.values, values, axis=len(self.target_shape))
-        history = None
+        _require_dense(coalitions)
+        _validate_values_alignment(
+            coalitions,
+            values,
+            axis=len(self.target_shape),
+            like=self._chunks[0][1],
+        )
+        appended = copy(self)
+        appended._chunks = (*self._chunks, (coalitions, values))  # noqa: SLF001 - evolving a copy of self
         if self.track_history:
             previous = self._history_n_samples or (self.n_samples,)
-            history = (*previous, self.n_samples + coalitions.shape[-1])
-        return type(self)(
-            coalitions=next_coalitions,
-            values=next_values,
-            target_shape=self.target_shape,
-            track_history=self.track_history,
-            _history_n_samples=history,
-        )
+            appended._history_n_samples = (*previous, appended.n_samples)  # noqa: SLF001
+        return appended
+
+    def _materialized(self) -> tuple[CoalitionArray, ValueT]:
+        """Concatenate the stored chunks once and cache the result.
+
+        The cache swap is value-equivalent, so the state stays immutable in
+        the sense ``mutable`` declares.
+        """
+        if len(self._chunks) > 1:
+            merged_coalitions = DenseCoalitionArray(
+                jnp.concatenate(
+                    [jnp.asarray(chunk.to_dense()) for chunk, _ in self._chunks],
+                    axis=-2,
+                ),
+            )
+            merged_values = cast(
+                "ValueT",
+                jnp.concatenate(
+                    [jnp.asarray(values) for _, values in self._chunks],
+                    axis=len(self.target_shape),
+                ),
+            )
+            self._chunks = ((merged_coalitions, merged_values),)
+        return self._chunks[0]
 
     def rollback(self, steps: int = 1) -> SamplingState[ValueT]:
         """Return a previous sampling state."""
@@ -239,17 +313,51 @@ def _validate_history_steps(steps: int) -> None:
         raise HistoryError(msg)
 
 
-def _append_coalitions(left: CoalitionArray, right: CoalitionArray) -> CoalitionArray:
-    if isinstance(left, DenseCoalitionArray) and isinstance(right, DenseCoalitionArray):
-        return DenseCoalitionArray(
-            jnp.concatenate([jnp.asarray(left.to_dense()), jnp.asarray(right.to_dense())], axis=-2),
+def _require_dense(coalitions: CoalitionArray) -> None:
+    if not isinstance(coalitions, DenseCoalitionArray):
+        msg = "only dense coalition storage is supported by SamplingState"
+        raise TypeError(msg)
+
+
+def _validate_values_alignment(
+    coalitions: CoalitionArray,
+    values: object,
+    *,
+    axis: int,
+    like: object = None,
+) -> None:
+    """Reject values whose shape does not pair with the coalitions.
+
+    Deferring this to the lazy chunk concatenation would blame the read
+    instead of the append that stored the misaligned block. The sample axis
+    must match the coalitions; with a stored reference block ``like``, the
+    remaining axes must match it too. Values without a shape (nested
+    sequences) pass through and fail at materialization.
+    """
+    if coalitions.shape == ():
+        return
+    shape = getattr(values, "shape", None)
+    if shape is None:
+        return
+    n_samples = coalitions.shape[-1]
+    like_shape = getattr(like, "shape", None)
+    if like_shape is not None and len(like_shape) > axis:
+        expected = (*like_shape[:axis], n_samples, *like_shape[axis + 1 :])
+        if tuple(shape) != expected:
+            msg = (
+                f"values with shape {tuple(shape)} do not pair with the stored "
+                f"evidence: expected {tuple(expected)} (target axes, then "
+                f"{n_samples} samples, then value axes)"
+            )
+            raise ValueError(msg)
+        return
+    if len(shape) <= axis or shape[axis] != n_samples:
+        msg = (
+            f"values with shape {tuple(shape)} do not pair with {n_samples} "
+            f"sampled coalitions: the sample axis follows the target axes "
+            f"(axis {axis}), then any value axes trail"
         )
-    msg = "only dense coalition append is supported by SamplingState"
-    raise TypeError(msg)
-
-
-def _append_values(left: object, right: object, *, axis: int) -> object:
-    return jnp.concatenate([jnp.asarray(left), jnp.asarray(right)], axis=axis)
+        raise ValueError(msg)
 
 
 def _dense_equal(left: CoalitionArray, right: CoalitionArray) -> bool:


### PR DESCRIPTION
Three commits from the profiling-driven performance pass and the Array API audit, verified against the full suite (369 passed) and `prek` after each commit.

## 1. Vectorization where profiling confirmed hotspots (`7dfa6f8`)

- **Closed-form interaction ranking** (`interactions/_ranks.py`): the lexicographic rank of a combination is a binomial sum, shared by the SII estimator and dense explanation lookups. All-pairs attribution lookup at 100 players: **1.8 s per call → ~2 ms warm**.
- **Mask builders assemble by scatter** instead of Python membership tests: `interaction_masks(200, 2)` cold **14.7 s → 24 ms**; `_powerset_masks` concatenates per-size blocks.
- **SII estimator scatter-adds** windowed derivatives by rank instead of materializing a one-hot `(walks, windows, interactions)` tensor: explain at n=50/220 walks **59 → 10 ms** warm, memory falls from O(samples × interactions) to O(samples + interactions).
- **Regressions take the identifying rank from `lstsq` itself** (one SVD instead of matrix_rank + lstsq). Per-target solves stay sequential deliberately: LAPACK multithreads inside each solve and beats one batched SVD on CPU (measured 4× slower batched via vmap).
- **Unit batches render in power-of-two buckets** (`_schedule.py`), bit-identical by the batching contract, so XLA stops recompiling the render pipeline for every distinct budget. Profiling attributed most dedup-path cost to eager recompiles, not Python: steady-state dedup top-ups **6.4 → ~1.4 s**. A jit boundary over the render path is the noted follow-up.

## 2. Readability round (`7f563e5`)

- The deduplicated classifier returns to the plain per-row dict loop — the vectorized version was fifty subtle lines for a cost the unit buckets had already removed.
- Dense explanation lookups drop the jax fast path and its compile cliff entirely: position resolution is host-side index math in plain NumPy (all pairs at n=100: **69 ms cold / 1.6 ms warm, no compile**). Teaching errors move into the fast path — rows validate vectorized, and the first offending row is handed to `normalize_interaction`, which raises the exact per-row message — so the parallel fallback loop is gone.

## 3. Array API audit fixes (`29e3727`)

- **Chunked lazy `SamplingState`**: `append` shares chunks without copying; `coalitions`/`values` concatenate once on first read and cache. 200 one-walk top-ups: **6.8 s → 0.6 s**, with the single concatenation deferred to `explain()`. `append` now validates the incoming block against the stored layout (the old eager concat's implicit check, restored as a teaching error at the call site); density is checked at construction; `n_samples` derives from chunks; the base-state flags become plain class attributes.
- **Shape math leaves the compute backend**: `broadcast_shapes`, `indexed_shape`, `shape_of`, `expand_ellipsis` live in `_shape.py`; the abstract `Game` and `ChunkedMaskedPredictor` no longer import jax; lookup arrays coerce to NumPy once at `as_interaction_array`.
- **Review-round catches** (eight-finder adversarial pass over the diff): torch coalition masks keep their DLPack device — an intermediate draft pinned them to CPU, a GPU regression flagged by four independent reviewers — with the host fallback restored; `interaction_members` caches the host table with a small bound instead of pinning device arrays and the first call's dtype regime; `expl[...]` works (pre-existing crash from the container's appended axes).

## Behavior notes

- Sampled streams, stored states, and teaching errors are unchanged; dedup state equality and budget-split invariance stay pinned by the suite.
- Estimator values move within float tolerance where reduction order changed (scatter vs one-hot sum).
- Deliberate changes: out-of-range `explanation[i]` now raises `IndexError` where jax silently clamped; `SamplingState.__init__`'s flags are keyword-only; misaligned `append` blocks now error at the call site instead of at a later read.
- One observation, no action taken: two-call dedup vs plain sampling can differ by exactly 1 ulp in float32 (batch-shape-dependent matmul reduction order); present upstream, `allclose`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkyRLRjvHmKRxeqk3vg3Ck

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkyRLRjvHmKRxeqk3vg3Ck)_