### PR TITLE
Remove stale STII/FSII/BII path from TreeSHAPIQ and fix approximator registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - adds the `ConfoundingSHAP` local and global explanation game in `shapiq_games.benchmark.causal_xai` for the first causal machine learning based value functions (Brockschmidt et al., 2026) based on the [paper](https://arxiv.org/abs/2605.10533).
 - adds the `LeverageSHAP` approximator in `shapiq.approximator.regression` for Shapley value estimation via leverage score sampling (Musco and Witter, 2025) [#524](https://github.com/mmschlk/shapiq/pull/524)
 
+### Bugfix
+
+- Removes the stale and broken `STII`/`FSII`/`BII` code path from the path-dependent `TreeSHAPIQ` algorithm, which crashed with broadcasting errors on wider trees. `TreeSHAPIQ` and the `TreeExplainer` in `"pathdependent"` mode now raise a clear `ValueError` for indices other than `SV`, `SII`, and `k-SII`, pointing to `mode="interventional"` which supports `STII`, `FSII`, and `FBII` [#571](https://github.com/mmschlk/shapiq/issues/571)
+- Removes `KernelSHAPIQ` and `InconsistentKernelSHAPIQ` from the `STII_APPROXIMATORS` and `FSII_APPROXIMATORS` registries in `shapiq.approximator`, since both only support the `SV`, `SII`, and `k-SII` indices [#571](https://github.com/mmschlk/shapiq/issues/571)
+
 ## v1.6.0 (2026-07-06)
 
 ### Highlights of new Features

--- a/src/shapiq/approximator/__init__.py
+++ b/src/shapiq/approximator/__init__.py
@@ -98,8 +98,6 @@ SII_APPROXIMATORS: list[Approximator.__class__] = [
 # contains all approximators that can be used for STII
 STII_APPROXIMATORS: list[Approximator.__class__] = [
     PermutationSamplingSTII,
-    KernelSHAPIQ,
-    InconsistentKernelSHAPIQ,
     SVARMIQ,
     SHAPIQ,
     SPEX,
@@ -109,8 +107,6 @@ STII_APPROXIMATORS: list[Approximator.__class__] = [
 # contains all approximators that can be used for FSII
 FSII_APPROXIMATORS: list[Approximator.__class__] = [
     RegressionFSII,
-    KernelSHAPIQ,
-    InconsistentKernelSHAPIQ,
     SVARMIQ,
     SHAPIQ,
     SPEX,

--- a/src/shapiq/tree/explainer.py
+++ b/src/shapiq/tree/explainer.py
@@ -7,7 +7,7 @@ for tree ensembles.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast, get_args
 
 from shapiq.explainer.base import Explainer
 from shapiq.tree.interventional.explainer import InterventionalTreeExplainer
@@ -85,9 +85,10 @@ class TreeExplainer(Explainer):
                 underlying algorithm still computes them internally when required by aggregated
                 indices such as ``"k-SII"``. Defaults to ``0``.
 
-            index: The type of interaction to be computed. It can be one of
-                ``["k-SII", "SII", "STII", "FSII", "BII", "SV"]``. All indices apart from ``"BII"``
-                will reduce to the ``"SV"`` (Shapley value) for order 1. Defaults to ``"SV"``.
+            index: The type of interaction to be computed. In ``"pathdependent"`` mode, only the
+                indices ``["SV", "SII", "k-SII"]`` are supported. In ``"interventional"`` mode,
+                further indices such as ``"STII"``, ``"FSII"``, ``"FBII"``, or ``"BII"`` can be
+                computed. Defaults to ``"SV"``.
 
             class_index: The class index of the model to explain. Defaults to ``None``, which will
                 set the class index to ``1`` per default for classification models and is ignored
@@ -128,15 +129,28 @@ class TreeExplainer(Explainer):
         self._interventional_explainer: InterventionalTreeExplainer | None = None
 
         if self.mode == "pathdependent":
+            # ``self.index`` is the effective index after base-class validation (which may e.g.
+            # downgrade an interaction index with ``max_order=1`` to ``"SV"``), so it is checked
+            # here instead of the raw ``index`` argument.
+            if self.index not in get_args(TreeSHAPIQIndices):
+                msg = (
+                    f"Index '{self.index}' is not supported by the TreeExplainer in "
+                    f"'pathdependent' mode. Supported indices are {get_args(TreeSHAPIQIndices)}. "
+                    "For other indices such as 'STII', 'FSII', or 'FBII', use "
+                    "mode='interventional' with a reference_dataset."
+                )
+                raise ValueError(msg)
             if self._can_use_lineartreeshap():
                 self._lineartreeshap_explainers = [
                     LinearTreeSHAP(model=tree) for tree in self._trees
                 ]
             else:
-                # ``index`` (the local parameter) is already narrowed to ``TreeSHAPIQIndices``;
-                # ``self.index`` is the broader ``ExplainerIndices`` and would not type-check.
                 self._treeshapiq_explainers = [
-                    TreeSHAPIQ(model=tree, max_order=self._max_order, index=index)
+                    TreeSHAPIQ(
+                        model=tree,
+                        max_order=self._max_order,
+                        index=cast("TreeSHAPIQIndices", self.index),
+                    )
                     for tree in self._trees
                 ]
         elif self.mode == "interventional":

--- a/src/shapiq/tree/treeshapiq.py
+++ b/src/shapiq/tree/treeshapiq.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import copy
-from math import factorial
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, get_args
 
 import numpy as np
 import scipy as sp
@@ -71,15 +70,27 @@ class TreeSHAPIQ:
             min_order: The minimum interaction order to be computed. Must be ``>= 1``. Defaults
                 to ``1``.
 
-            index: The type of interaction to be computed.
+            index: The type of interaction to be computed. Must be one of ``"SV"``, ``"SII"``,
+                or ``"k-SII"``.
 
             verbose: Whether to print information about the tree during initialization. Defaults to
                 ``False``.
+
+        Raises:
+            ValueError: If the index is not one of the supported indices or if the interaction
+                orders are invalid.
 
         """
         # set parameters
         self._root_node_id = 0
         self.verbose = verbose
+        if index not in get_args(TreeSHAPIQIndices):
+            msg = (
+                f"Index '{index}' is not supported by TreeSHAP-IQ. Supported indices are "
+                f"{get_args(TreeSHAPIQIndices)}. For other indices such as 'STII', 'FSII', or "
+                "'FBII', use the TreeExplainer in 'interventional' mode."
+            )
+            raise ValueError(msg)
         if max_order < min_order or max_order < 1 or min_order < 1:
             msg = (
                 "The maximum order must be greater than the minimum order and both must be greater "
@@ -147,9 +158,8 @@ class TreeSHAPIQ:
         self.D_powers_store: dict = {}
         self.Ns_id_store: dict = {}
         self.Ns_store: dict = {}
-        self.n_interpolation_size = self._n_features_in_tree
-        if self._index in ("SV", "SII", "k-SII"):  # SP is of order at most d_max
-            self.n_interpolation_size = min(self._edge_tree.max_depth, self._n_features_in_tree)
+        # SP is of order at most d_max
+        self.n_interpolation_size = min(self._edge_tree.max_depth, self._n_features_in_tree)
         if self._n_features_in_tree > 0:
             try:
                 self._init_summary_polynomials()
@@ -393,12 +403,8 @@ class TreeSHAPIQ:
                 self._int_height[node_id][interaction_sets] == order
             ]
             if len(interactions_seen) > 0:
-                if self._index not in ("SV", "SII", "k-SII"):  # for CII
-                    D_power = self.D_powers[self._n_features_in_tree - current_height]
-                    index_quotient = self._n_features_in_tree - order
-                else:  # for SII and k-SII
-                    D_power = self.D_powers[0]
-                    index_quotient = current_height - order
+                D_power = self.D_powers[0]
+                index_quotient = current_height - order
                 interaction_update = np.dot(
                     interaction_poly_down[depth, interactions_seen],
                     self.Ns_id[self.n_interpolation_size, : self.n_interpolation_size],
@@ -428,12 +434,8 @@ class TreeSHAPIQ:
                     ancestor_heights = self._edge_tree.edge_heights[
                         interactions_ancestors[cond_interaction_seen]
                     ]
-                    if self._index not in ("SV", "SII", "k-SII"):  # for CII
-                        D_power = self.D_powers[self._n_features_in_tree - current_height]
-                        index_quotient = self._n_features_in_tree - order
-                    else:  # for SII and k-SII
-                        D_power = self.D_powers[ancestor_heights - current_height]
-                        index_quotient = (ancestor_heights - order)
+                    D_power = self.D_powers[ancestor_heights - current_height]
+                    index_quotient = (ancestor_heights - order)
                     update = np.dot(
                         interaction_poly_down[depth - 1, interactions_with_ancestor_to_update],
                         self.Ns_id[self.n_interpolation_size, : self.n_interpolation_size],
@@ -448,7 +450,7 @@ class TreeSHAPIQ:
                     if to_update.shape == (1, 1):
                         update *= to_update[0]  # cast out shape of (1, 1) to float
                     else:
-                        update *= to_update  # something errors here for CII
+                        update *= to_update
                     # fmt: on
                     self.shapley_interactions[interactions_with_ancestor_to_update] -= update
 
@@ -510,10 +512,7 @@ class TreeSHAPIQ:
             self.D_store[order] = np.polynomial.chebyshev.chebpts2(self.n_interpolation_size)
 
             self.D_powers_store[order] = self._cache(self.D_store[order])
-            if self._index in ("SV", "SII", "k-SII"):
-                self.Ns_store[order] = self._get_n_matrix(self.D_store[order])
-            else:
-                self.Ns_store[order] = self._get_n_cii_matrix(self.D_store[order], order)
+            self.Ns_store[order] = self._get_n_matrix(self.D_store[order])
             self.Ns_id_store[order] = self._get_n_id_matrix(self.D_store[order])
 
     def _get_polynomials(
@@ -716,42 +715,6 @@ class TreeSHAPIQ:
                 1.0 / np.array([sp.special.binom(i - 1, k) for k in range(i)])
             )
         return Ns
-
-    def _get_n_cii_matrix(self, interpolated_poly: np.ndarray, order: int) -> np.ndarray:
-        """Computes the N matrix for the CII index."""
-        depth = interpolated_poly.shape[0]
-        Ns = np.zeros((depth + 1, depth))
-        for i in range(1, depth + 1):
-            Ns[i, :i] = np.linalg.inv(np.vander(interpolated_poly[:i]).T).dot(
-                i * np.array([self._get_subset_weight_cii(j, order) for j in range(i)]),
-            )
-        return Ns
-
-    def _get_subset_weight_cii(self, t: int, order: int) -> float | None:
-        """Computes the weight for a given subset size and interaction order.
-
-        Args:
-            t: The size of the subset.
-            order: The interaction order.
-
-        Returns:
-            float | None: The weight for the subset, or None if the index is not supported.
-        """
-        if self._index == "STII":
-            return self._max_order / (
-                self._n_features_in_tree * sp.special.binom(self._n_features_in_tree - 1, t)
-            )
-        if self._index == "FSII":
-            return (
-                factorial(2 * self._max_order - 1)
-                / factorial(self._max_order - 1) ** 2
-                * factorial(self._max_order + t - 1)
-                * factorial(self._n_features_in_tree - t - 1)
-                / factorial(self._n_features_in_tree + self._max_order - 1)
-            )
-        if self._index == "BII":
-            return 1 / (2 ** (self._n_features_in_tree - order))
-        return None
 
     @staticmethod
     def _get_n_id_matrix(D: np.ndarray) -> np.ndarray:

--- a/tests/shapiq/tests_unit/tests_approximators/test_approximator_registry.py
+++ b/tests/shapiq/tests_unit/tests_approximators/test_approximator_registry.py
@@ -1,0 +1,35 @@
+"""Tests for the per-index approximator registry lists in ``shapiq.approximator``."""
+
+from __future__ import annotations
+
+import pytest
+
+from shapiq import approximator as approximator_module
+from shapiq.approximator import InconsistentKernelSHAPIQ, KernelSHAPIQ
+
+
+@pytest.mark.parametrize(
+    ("registry_name", "index"),
+    [
+        ("SII_APPROXIMATORS", "SII"),
+        ("STII_APPROXIMATORS", "STII"),
+        ("FSII_APPROXIMATORS", "FSII"),
+        ("FBII_APPROXIMATORS", "FBII"),
+    ],
+)
+def test_registry_members_support_their_index(registry_name: str, index: str):
+    """Every approximator listed for an index must declare that index in its valid_indices."""
+    registry = getattr(approximator_module, registry_name)
+    for approximator_class in registry:
+        assert index in approximator_class.valid_indices, (
+            f"{approximator_class.__name__} is listed in {registry_name} but does not "
+            f"support the index '{index}' (valid indices: {approximator_class.valid_indices})."
+        )
+
+
+def test_kernelshapiq_not_listed_for_unsupported_indices():
+    """KernelSHAPIQ variants only support SV/SII/k-SII and must not be listed for STII/FSII."""
+    for registry_name in ("STII_APPROXIMATORS", "FSII_APPROXIMATORS"):
+        registry = getattr(approximator_module, registry_name)
+        assert KernelSHAPIQ not in registry
+        assert InconsistentKernelSHAPIQ not in registry

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_treeshapiq.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_treeshapiq.py
@@ -50,39 +50,6 @@ def test_init(dt_clf_model, background_clf_data):
                 (1, 2): 0,
             },
         ),
-        (
-            "BII",
-            {
-                (0,): -10.18947368,
-                (1,): -13.31052632,
-                (2,): 3.0,
-                (0, 1): -11.77894737,
-                (0, 2): -6.0,
-                (1, 2): 0,
-            },
-        ),
-        (
-            "FSII",
-            {
-                (0,): -39.45789474,
-                (1,): -45.82105263,
-                (2,): 6.0,
-                (0, 1): -11.77894737,
-                (0, 2): -6.0,
-                (1, 2): 0,
-            },
-        ),
-        (
-            "STII",
-            {
-                (0,): -20.37894737,
-                (1,): -26.62105263,
-                (2,): 6.0,
-                (0, 1): -11.77894737,
-                (0, 2): -6.0,
-                (1, 2): 0,
-            },
-        ),
     ],
 )
 def test_against_old_treeshapiq_implementation(index: str, expected: dict):
@@ -113,6 +80,16 @@ def test_against_old_treeshapiq_implementation(index: str, expected: dict):
 
     for key, value in expected.items():
         assert np.isclose(explanation[key], value, atol=1e-5)
+
+
+@pytest.mark.parametrize("index", ["STII", "FSII", "FBII", "BII"])
+def test_unsupported_indices_raise(dt_clf_model, index: str):
+    """Test that unsupported indices raise a clear error instead of crashing internally."""
+    with pytest.raises(ValueError, match="not supported by TreeSHAP-IQ"):
+        _ = TreeSHAPIQ(model=dt_clf_model, max_order=2, index=index)
+
+    with pytest.raises(ValueError, match="'pathdependent' mode"):
+        _ = TreeExplainer(model=dt_clf_model, max_order=2, index=index)
 
 
 def test_edge_case_params():


### PR DESCRIPTION
## Motivation and Context

Fixes #571.

The path-dependent TreeSHAP-IQ algorithm still carried a stale CII code path
(STII/FSII/BII weight matrices and branches) even though `TreeSHAPIQIndices` was
already narrowed to `SV`/`SII`/`k-SII`. Nothing validated the index at runtime, so
`TreeExplainer(..., index="STII")` reached the dead code and crashed with tensor
broadcasting errors on wider trees (e.g. BreastCancer with n=30); tiny trees happened
to survive, which is why the old tests passed. Rather than reviving that path, this PR
removes it entirely: the supported route for `STII`/`FSII`/`FBII` on trees is
`mode="interventional"`, which is validated against the `ExactComputer` in the tests
and remains untouched.

Additionally, `KernelSHAPIQ` and `InconsistentKernelSHAPIQ` were listed in the
`STII_APPROXIMATORS` and `FSII_APPROXIMATORS` registries although both only declare
`valid_indices = ("k-SII", "SII", "SV")`, sending downstream pipelines into invalid
algorithm–index combinations.

---

## Public API Changes

-   [ ] No Public API changes
-   [x] Yes, Public API changes (Details below)

- `TreeSHAPIQ` and `TreeExplainer` (in `"pathdependent"` mode) now raise a clear
  `ValueError` for indices other than `SV`, `SII`, and `k-SII`, pointing users to
  `mode="interventional"` for `STII`/`FSII`/`FBII`. Previously these indices crashed
  with internal broadcasting errors (or silently produced values on trivially small
  trees), so no working behavior is removed.
- `KernelSHAPIQ` and `InconsistentKernelSHAPIQ` are removed from the public
  `STII_APPROXIMATORS` and `FSII_APPROXIMATORS` registry lists in `shapiq.approximator`.
- `TreeExplainer` in `"pathdependent"` mode now forwards the base-class-validated
  index to `TreeSHAPIQ`, so e.g. `index="STII"` with `max_order=1` consistently
  downgrades to `"SV"` (with the usual warning) instead of depending on the tree shape.
- The `TreeExplainer` docstring no longer advertises `STII`/`FSII`/`BII` for the
  path-dependent mode; the private helpers `TreeSHAPIQ._get_n_cii_matrix` and
  `TreeSHAPIQ._get_subset_weight_cii` are deleted.

---

## How Has This Been Tested?

- New parametrized test asserting `TreeSHAPIQ` and path-dependent `TreeExplainer`
  raise the clear `ValueError` for `STII`, `FSII`, `FBII`, and `BII`.
- New registry consistency test asserting every member of `SII_APPROXIMATORS`,
  `STII_APPROXIMATORS`, `FSII_APPROXIMATORS`, and `FBII_APPROXIMATORS` declares the
  registry's index in its `valid_indices`, plus an explicit check that the two
  KernelSHAPIQ variants are no longer listed for STII/FSII.
- Removed the stale `BII`/`FSII`/`STII` expectation tables from
  `test_against_old_treeshapiq_implementation` (they only passed on a hand-built
  3-feature tree; the code path was broken for realistic trees).
- Manually reproduced the issue scenario on a 30-feature BreastCancer tree:
  path-dependent `STII` now raises the clear error, path-dependent `SII` still
  computes, and `mode="interventional"` computes `STII` successfully.
- Full local runs: 222 tree-explainer tests and 536 approximator tests pass;
  `uv run pre-commit run --all-files` is clean for the touched files (ruff,
  ruff-format, `ty`).

---

## Checklist

-   [x] The changes have been tested locally.
-   [x] Documentation has been updated (if the public API or usage changes).
-   [x] An entry has been added to `CHANGELOG.md` (if relevant for users).
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CWursZhiHGukhFG1DddAz