### PR TITLE
🛠️ delete dead code after `log_space` weight refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Removes the stale and broken `STII`/`FSII`/`BII` code path from the path-dependent `TreeSHAPIQ` algorithm, which crashed with broadcasting errors on wider trees. `TreeSHAPIQ` and the `TreeExplainer` in `"pathdependent"` mode now raise a clear `ValueError` for indices other than `SV`, `SII`, and `k-SII`, pointing to `mode="interventional"` which supports `STII`, `FSII`, and `FBII` [#571](https://github.com/mmschlk/shapiq/issues/571)
 - Removes `KernelSHAPIQ` and `InconsistentKernelSHAPIQ` from the `STII_APPROXIMATORS` and `FSII_APPROXIMATORS` registries in `shapiq.approximator`, since both only support the `SV`, `SII`, and `k-SII` indices [#571](https://github.com/mmschlk/shapiq/issues/571)
 
+### Maintenance
+
+- Removes the dead non-log weight computations from the approximator base classes, which were superseded by their log-space counterparts: `Regression._init_kernel_weights` (superseded by `_init_log_kernel_weights`) and the `MonteCarlo` family `_get_standard_form_weights`/`_weight`/`_sii_weight`/`_bii_weight`/`_chii_weight`/`_stii_weight`/`_fsii_weight`/`_fbii_weight` (superseded by `_get_standard_form_log_weights` and the `_log_*_weight` methods). All were private and unused by the `approximate()` code paths; `ExactComputer` in `shapiq.game_theory.exact` has its own independent `_stii_weight` and is unaffected
+
 ## v1.6.0 (2026-07-06)
 
 ### Highlights of new Features

--- a/src/shapiq/approximator/montecarlo/base.py
+++ b/src/shapiq/approximator/montecarlo/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, get_args
 
 import numpy as np
-from scipy.special import binom, factorial, gammaln
+from scipy.special import gammaln
 
 from shapiq.approximator.base import Approximator
 from shapiq.interaction_values import InteractionValues
@@ -369,166 +369,12 @@ class MonteCarlo(Approximator[TIndices]):
                 )
         return log_sampling_adjustment_weights
 
-    def _sii_weight(self, coalition_size: int, interaction_size: int) -> float:
-        """Returns the SII discrete derivative weight given the coalition size and interaction size.
-
-        Args:
-            coalition_size: The size of the subset.
-            interaction_size: The size of the interaction.
-
-        Returns:
-            float: The weight for the interaction type.
-
-        """
-        return 1 / (
-            (self.n - interaction_size + 1) * binom(self.n - interaction_size, coalition_size)
-        )
-
-    def _bii_weight(self, interaction_size: int) -> float:
-        """Returns the BII discrete derivative weight given the coalition size and interaction size.
-
-        Args:
-            interaction_size: The size of the interaction.
-
-        Returns:
-            The weight for the interaction type.
-
-        """
-        return 1 / 2 ** (self.n - interaction_size)
-
-    def _chii_weight(self, coalition_size: int, interaction_size: int) -> float:
-        """Returns the CHII discrete derivative weight given the coalition size and interaction size.
-
-        Args:
-            coalition_size: The size of the subset.
-            interaction_size: The size of the interaction.
-
-        Returns:
-            The weight for the interaction type.
-
-        """
-        try:
-            return interaction_size / coalition_size
-        except ZeroDivisionError:
-            return 0.0
-
-    def _stii_weight(self, coalition_size: int, interaction_size: int) -> float:
-        """Returns the STII discrete derivative weight given the coalition size and interaction size.
-
-        For details, refer to `Dhamdhere et al. (2020) <https://doi.org/10.48550/arXiv.1902.05622>`_.
-
-        Args:
-            coalition_size: The size of the subset.
-            interaction_size: The size of the interaction.
-
-        Returns:
-            The weight for the interaction type.
-
-        """
-        if interaction_size == self.max_order:
-            return self.max_order / (self.n * binom(self.n - 1, coalition_size))
-        return 1.0 * (coalition_size == 0)
-
-    def _fsii_weight(self, coalition_size: int, interaction_size: int) -> float:
-        """Returns the FSII discrete derivative weight given the coalition size and interaction size.
-
-        The representation is based on the FSII representation according to Theorem 19 by
-        `Tsai et al. (2023) <https://doi.org/10.48550/arXiv.2203.00870>`_.
-
-        Args:
-            coalition_size: The size of the subset.
-            interaction_size: The size of the interaction.
-
-        Returns:
-            The weight for the interaction type.
-
-        """
-        if interaction_size == self.max_order:
-            return (
-                factorial(2 * self.max_order - 1)
-                / factorial(self.max_order - 1) ** 2
-                * factorial(self.n - coalition_size - 1)
-                * factorial(coalition_size + self.max_order - 1)
-                / factorial(self.n + self.max_order - 1)
-            )
-        msg = f"Lower order interactions are not supported for {self.index}."
-        raise ValueError(msg)
-
-    def _fbii_weight(self, interaction_size: int) -> float:
-        """Returns the FSII discrete derivative weight given the coalition size and interaction size.
-
-        The representation is based on the FBII representation according to Theorem 17 by
-        `Tsai et al. (2023) <https://doi.org/10.48550/arXiv.2203.00870>`_.
-
-        Args:
-            interaction_size: The size of the interaction.
-
-        Returns:
-            The weight for the interaction type.
-
-        """
-        if interaction_size == self.max_order:
-            return 1 / 2 ** (self.n - interaction_size)
-        msg = f"Lower order interactions are not supported for {self.index}."
-        raise ValueError(msg)
-
-    def _weight(self, index: str, coalition_size: int, interaction_size: int) -> float:
-        """Returns the weight for each interaction type given coalition and interaction size.
-
-        Args:
-            index: The interaction index
-            coalition_size: The size of the subset.
-            interaction_size: The size of the interaction.
-
-        Returns:
-            The weight for the interaction type.
-
-        """
-        if index == "STII":
-            return self._stii_weight(coalition_size, interaction_size)
-        if index == "FSII":
-            return self._fsii_weight(coalition_size, interaction_size)
-        if index == "FBII":
-            return self._fbii_weight(interaction_size)
-        if index in ["SII", "SV"]:
-            return self._sii_weight(coalition_size, interaction_size)
-        if index in ["BII", "BV"]:
-            return self._bii_weight(interaction_size)
-        if index == "CHII":
-            return self._chii_weight(coalition_size, interaction_size)
-        msg = f"The index {index} is not supported."
-        raise ValueError(msg)
-
-    def _get_standard_form_weights(self, index: str) -> np.ndarray:
-        """Computes the standard form weights for the interaction index.
+    def _get_standard_form_log_weights(self, index: str) -> tuple[np.ndarray, np.ndarray]:
+        """Sign and log-magnitude of the standard form weights, stable for large ``n``.
 
         Initializes the weights for the interaction index re-written from discrete derivatives to
         standard form. Standard form according to Theorem 1 by
         `Fumagalli et al. (2023) <https://doi.org/10.48550/arXiv.2303.01179>`_.
-
-        Args:
-            index: The interaction index
-
-        Returns:
-            The standard form weights.
-
-        """
-        # init data structure
-        weights = np.zeros((self.max_order + 1, self.n + 1, self.max_order + 1))
-        for order in self._order_iterator:
-            # fill with values specific to each index
-            for coalition_size in range(self.n + 1):
-                for intersection_size in range(
-                    max(0, order + coalition_size - self.n),
-                    min(order, coalition_size) + 1,
-                ):
-                    weights[order, coalition_size, intersection_size] = (-1) ** (
-                        order - intersection_size
-                    ) * self._weight(index, coalition_size - intersection_size, order)
-        return weights
-
-    def _get_standard_form_log_weights(self, index: str) -> tuple[np.ndarray, np.ndarray]:
-        """Sign and log-magnitude of :meth:`_get_standard_form_weights`, stable for large ``n``.
 
         The discrete-derivative weights are non-negative, so the standard-form weight
         ``(-1) ** (order - intersection) * w`` factors into a sign and a magnitude. The magnitude is
@@ -540,9 +386,10 @@ class MonteCarlo(Approximator[TIndices]):
             index: The interaction index.
 
         Returns:
-            A tuple ``(sign_weights, log_abs_weights)`` of arrays shaped like
-            :meth:`_get_standard_form_weights`. Unfilled entries have sign ``0`` and log ``-inf``
-            (i.e. weight ``0``).
+            A tuple ``(sign_weights, log_abs_weights)`` of arrays of shape
+            ``(max_order + 1, n + 1, max_order + 1)`` indexed by interaction order, coalition size,
+            and intersection size. Unfilled entries have sign ``0`` and log ``-inf`` (i.e. weight
+            ``0``).
 
         """
         shape = (self.max_order + 1, self.n + 1, self.max_order + 1)
@@ -563,7 +410,10 @@ class MonteCarlo(Approximator[TIndices]):
         return sign_weights, log_abs_weights
 
     def _log_weight(self, index: str, coalition_size: int, interaction_size: int) -> float:
-        """Natural logarithm of the (non-negative) discrete-derivative weight :meth:`_weight`.
+        """Natural logarithm of the (non-negative) discrete-derivative weight for an index.
+
+        Dispatches to the per-index ``_log_*_weight`` method given the coalition size and
+        interaction size.
 
         Args:
             index: The interaction index.
@@ -571,8 +421,8 @@ class MonteCarlo(Approximator[TIndices]):
             interaction_size: The size of the interaction.
 
         Returns:
-            ``log(_weight(index, coalition_size, interaction_size))`` (``-inf`` when the weight is
-            ``0``), computed in log-space so it stays finite for many players.
+            The log of the discrete-derivative weight (``-inf`` when the weight is ``0``),
+            computed in log-space so it stays finite for many players.
 
         """
         if index == "STII":
@@ -591,24 +441,40 @@ class MonteCarlo(Approximator[TIndices]):
         raise ValueError(msg)
 
     def _log_sii_weight(self, coalition_size: int, interaction_size: int) -> float:
-        """Log of :meth:`_sii_weight`."""
+        """Log of the SII discrete derivative weight.
+
+        The weight is ``1 / ((n - s + 1) * binom(n - s, t))`` for interaction size ``s`` and
+        coalition size ``t``.
+        """
         return float(
             -np.log(self.n - interaction_size + 1)
             - log_binom(self.n - interaction_size, coalition_size)
         )
 
     def _log_bii_weight(self, interaction_size: int) -> float:
-        """Log of :meth:`_bii_weight`."""
+        """Log of the BII discrete derivative weight.
+
+        The weight is ``1 / 2 ** (n - s)`` for interaction size ``s``.
+        """
         return float(-(self.n - interaction_size) * np.log(2))
 
     def _log_chii_weight(self, coalition_size: int, interaction_size: int) -> float:
-        """Log of :meth:`_chii_weight`."""
+        """Log of the CHII discrete derivative weight.
+
+        The weight is ``s / t`` for interaction size ``s`` and coalition size ``t`` (``0``,
+        i.e. ``-inf`` in log-space, for empty coalitions).
+        """
         if coalition_size == 0:
             return -np.inf
         return float(np.log(interaction_size) - np.log(coalition_size))
 
     def _log_stii_weight(self, coalition_size: int, interaction_size: int) -> float:
-        """Log of :meth:`_stii_weight`."""
+        """Log of the STII discrete derivative weight.
+
+        The weight is ``max_order / (n * binom(n - 1, t))`` for top-order interactions and
+        coalition size ``t`` (an indicator on the empty coalition for lower orders). For details,
+        refer to `Dhamdhere et al. (2020) <https://doi.org/10.48550/arXiv.1902.05622>`_.
+        """
         if interaction_size == self.max_order:
             return float(
                 np.log(self.max_order) - np.log(self.n) - log_binom(self.n - 1, coalition_size)
@@ -616,7 +482,12 @@ class MonteCarlo(Approximator[TIndices]):
         return 0.0 if coalition_size == 0 else -np.inf
 
     def _log_fsii_weight(self, coalition_size: int, interaction_size: int) -> float:
-        """Log of :meth:`_fsii_weight` (factorial ratio via ``gammaln``)."""
+        """Log of the FSII discrete derivative weight, defined for top-order interactions only.
+
+        The weight is a factorial ratio (computed via ``gammaln``) based on the FSII
+        representation according to Theorem 19 by `Tsai et al. (2023)
+        <https://doi.org/10.48550/arXiv.2203.00870>`_.
+        """
         if interaction_size == self.max_order:
             return float(
                 gammaln(2 * self.max_order)
@@ -629,7 +500,12 @@ class MonteCarlo(Approximator[TIndices]):
         raise ValueError(msg)
 
     def _log_fbii_weight(self, interaction_size: int) -> float:
-        """Log of :meth:`_fbii_weight`."""
+        """Log of the FBII discrete derivative weight, defined for top-order interactions only.
+
+        The weight is ``1 / 2 ** (n - s)`` for interaction size ``s``, based on the FBII
+        representation according to Theorem 17 by `Tsai et al. (2023)
+        <https://doi.org/10.48550/arXiv.2203.00870>`_.
+        """
         if interaction_size == self.max_order:
             return float(-(self.n - interaction_size) * np.log(2))
         msg = f"Lower order interactions are not supported for {self.index}."

--- a/src/shapiq/approximator/regression/base.py
+++ b/src/shapiq/approximator/regression/base.py
@@ -84,51 +84,21 @@ class Regression(Approximator[TIndices]):
         # used for SII, if False, then Inconsistent KernelSHAP-IQ is used
         self._sii_consistent = sii_consistent
 
-    def _init_kernel_weights(self, interaction_size: int) -> FloatVector:
-        """Initializes the kernel weights for the regression in KernelSHAP-IQ.
-
-        The kernel weights are of size n + 1 and indexed by the size of the coalition. The kernel
-        weights depend on the size of the interactions and are set to a large number for the edges.
-
-        Args:
-            interaction_size: The size of the interaction.
-
-        Returns:
-            The weights for sampling subsets of size s in shape (n + 1,).
-
-        """
-        # vector that determines the kernel weights for the regression
-        weight_vector = np.zeros(shape=self.n + 1)
-        if self.approximation_index == "FBII":
-            for coalition_size in range(self.n + 1):
-                weight_vector[coalition_size] = 1 / (2**self.n)
-            return weight_vector
-        if self.approximation_index in ["k-SII", "SII", "kADD-SHAP", "FSII"]:
-            for coalition_size in range(self.n + 1):
-                if (coalition_size < interaction_size) or (
-                    coalition_size > self.n - interaction_size
-                ):
-                    weight_vector[coalition_size] = self._big_M
-                else:
-                    weight_vector[coalition_size] = 1 / (
-                        (self.n - 2 * interaction_size + 1)
-                        * binom(
-                            self.n - 2 * interaction_size,
-                            coalition_size - interaction_size,
-                        )
-                    )
-            return weight_vector
-        msg = f"Index {self.index} not available for Regression Approximator."
-        raise ValueError(msg)  # pragma: no cover
-
     def _init_log_kernel_weights(self, interaction_size: int) -> FloatVector:
-        """Natural logarithm of :meth:`_init_kernel_weights`, stable for large ``n``.
+        """Initializes the log-space kernel weights for the regression in KernelSHAP-IQ.
 
-        Returns the per-coalition-size kernel weights in log-space. This avoids materialising the
-        ``1 / binom`` weight (which underflows to ``0`` once ``binom`` overflows for many players);
-        combined in log-space with the sampler's log adjustment weight, whose binomial cancels the
-        one here, the resulting effective regression weight stays finite and ``O(1)`` for mid-size
-        coalitions instead of collapsing to ``0`` (or ``0 * inf = nan``).
+        The kernel weights are of size ``n + 1`` and indexed by the size of the coalition. They
+        depend on the size of the interaction and are set to (the log of) a large number
+        ``self._big_M`` for the edges (coalition sizes smaller than the interaction size or larger
+        than ``n - interaction_size``); in between, the weight is
+        ``1 / ((n - 2s + 1) * binom(n - 2s, t - s))`` for coalition size ``t`` and interaction
+        size ``s`` (a uniform ``1 / 2 ** n`` for ``FBII``).
+
+        Returning the weights in log-space avoids materialising the ``1 / binom`` weight (which
+        underflows to ``0`` once ``binom`` overflows for many players); combined in log-space with
+        the sampler's log adjustment weight, whose binomial cancels the one here, the resulting
+        effective regression weight stays finite and ``O(1)`` for mid-size coalitions instead of
+        collapsing to ``0`` (or ``0 * inf = nan``).
 
         Args:
             interaction_size: The size of the interaction.

--- a/tests/shapiq/tests_unit/tests_approximators/test_approximator_base_monte_carlo.py
+++ b/tests/shapiq/tests_unit/tests_approximators/test_approximator_base_monte_carlo.py
@@ -48,19 +48,19 @@ def test_initialization(
     assert approximator.index == index
 
     with pytest.raises(ValueError):
-        approximator._get_standard_form_weights(index="wrong_index")
+        approximator._get_standard_form_log_weights(index="wrong_index")
 
     if index == "FSII":
         max_order = approximator.max_order
-        _ = approximator._fsii_weight(interaction_size=max_order, coalition_size=0)  # no error
+        _ = approximator._log_fsii_weight(interaction_size=max_order, coalition_size=0)  # no error
         with pytest.raises(ValueError):  # FSII weights only defined for top order
-            approximator._fsii_weight(interaction_size=max_order - 1, coalition_size=0)  # error
+            approximator._log_fsii_weight(interaction_size=max_order - 1, coalition_size=0)  # error
 
     if index == "FBII":
         max_order = approximator.max_order
-        _ = approximator._fbii_weight(interaction_size=max_order)
+        _ = approximator._log_fbii_weight(interaction_size=max_order)
         with pytest.raises(ValueError):
-            approximator._fbii_weight(interaction_size=max_order - 1)
+            approximator._log_fbii_weight(interaction_size=max_order - 1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Motivation and Context

This PR refactors the weight computation methods in the Monte Carlo approximator to use log-space arithmetic, improving numerical stability for large numbers of players. The changes eliminate direct computation of binomial coefficients and factorials that overflow/underflow, replacing them with log-space equivalents.

Key improvements:
- Removes the `_get_standard_form_weights()` method which computed weights directly (numerically unstable)
- Replaces it with `_get_standard_form_log_weights()` that returns sign and log-magnitude separately
- Removes non-log weight methods (`_sii_weight`, `_bii_weight`, `_chii_weight`, `_stii_weight`, `_fsii_weight`, `_fbii_weight`, `_weight`) that are no longer needed
- Keeps and enhances log-space weight methods (`_log_sii_weight`, `_log_bii_weight`, `_log_chii_weight`, `_log_stii_weight`, `_log_fsii_weight`, `_log_fbii_weight`, `_log_weight`) with improved documentation
- Updates the regression approximator's kernel weight initialization to use log-space computation

The refactoring maintains the same mathematical semantics while avoiding numerical issues that occur when computing with very large binomial coefficients or factorials for realistic problem sizes.

---

## Public API Changes

- [x] No Public API changes

The removed methods (`_sii_weight`, `_bii_weight`, etc.) were private implementation details (prefixed with `_`). The public API remains unchanged.

---

## How Has This Been Tested?

Existing unit tests have been updated to reference the new log-space methods instead of the removed ones. The test file `test_approximator_base_monte_carlo.py` now calls `_log_fsii_weight`, `_log_fbii_weight`, and `_get_standard_form_log_weights` instead of their non-log counterparts. All tests continue to pass with the refactored implementation.

---

## Checklist

- [x] The changes have been tested locally (existing tests updated and passing).
- [x] Documentation has been updated (docstrings enhanced with weight formulas and references).
- [x] An entry has been added to `CHANGELOG.md`.
- [x] The code follows the project's style guidelines.
- [x] I have considered the impact of these changes on the public API (no breaking changes to public API).

https://claude.ai/code/session_01YDwMfcs4XNbGoftCAgkZmF