### PR TITLE
🛠️ Declare SV in kADDSHAP's valid_indices to match the SV_APPROXIMATORS registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Removes the stale and broken `STII`/`FSII`/`BII` code path from the path-dependent `TreeSHAPIQ` algorithm, which crashed with broadcasting errors on wider trees. `TreeSHAPIQ` and the `TreeExplainer` in `"pathdependent"` mode now raise a clear `ValueError` for indices other than `SV`, `SII`, and `k-SII`, pointing to `mode="interventional"` which supports `STII`, `FSII`, and `FBII` [#571](https://github.com/mmschlk/shapiq/issues/571)
 - Removes `KernelSHAPIQ` and `InconsistentKernelSHAPIQ` from the `STII_APPROXIMATORS` and `FSII_APPROXIMATORS` registries in `shapiq.approximator`, since both only support the `SV`, `SII`, and `k-SII` indices [#571](https://github.com/mmschlk/shapiq/issues/571)
+- `kADDSHAP` now accepts `index="SV"` and returns the order-1 part of the k-additive solution as the Shapley value estimate, making it consistent with its listing in the `SV_APPROXIMATORS` registry (previously the `index` keyword was silently ignored and the full `kADD-SHAP` solution was returned)
 
 ## v1.6.0 (2026-07-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Removes the stale and broken `STII`/`FSII`/`BII` code path from the path-dependent `TreeSHAPIQ` algorithm, which crashed with broadcasting errors on wider trees. `TreeSHAPIQ` and the `TreeExplainer` in `"pathdependent"` mode now raise a clear `ValueError` for indices other than `SV`, `SII`, and `k-SII`, pointing to `mode="interventional"` which supports `STII`, `FSII`, and `FBII` [#571](https://github.com/mmschlk/shapiq/issues/571)
 - Removes `KernelSHAPIQ` and `InconsistentKernelSHAPIQ` from the `STII_APPROXIMATORS` and `FSII_APPROXIMATORS` registries in `shapiq.approximator`, since both only support the `SV`, `SII`, and `k-SII` indices [#571](https://github.com/mmschlk/shapiq/issues/571)
-- `kADDSHAP` now accepts `index="SV"` and returns the order-1 part of the k-additive solution as the Shapley value estimate, making it consistent with its listing in the `SV_APPROXIMATORS` registry (previously the `index` keyword was silently ignored and the full `kADD-SHAP` solution was returned)
+- `kADDSHAP` now declares `"SV"` in its `valid_indices` (like `RegressionFSII` does): with `max_order=1` it estimates Shapley values, which makes it consistent with its listing in the `SV_APPROXIMATORS` registry; the registry consistency test now also covers `SV_APPROXIMATORS`
 
 ## v1.6.0 (2026-07-06)
 

--- a/src/shapiq/approximator/regression/kadd_shap.py
+++ b/src/shapiq/approximator/regression/kadd_shap.py
@@ -7,9 +7,14 @@ from typing import TYPE_CHECKING, Any, Literal
 from .base import Regression
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import numpy as np
 
-ValidRegressionkADDSHAPIndices = Literal["kADD-SHAP"]
+    from shapiq.game import Game
+    from shapiq.interaction_values import InteractionValues
+
+ValidRegressionkADDSHAPIndices = Literal["kADD-SHAP", "SV"]
 
 
 class kADDSHAP(Regression[ValidRegressionkADDSHAPIndices]):  # noqa: N801
@@ -17,7 +22,9 @@ class kADDSHAP(Regression[ValidRegressionkADDSHAPIndices]):  # noqa: N801
 
     Estimates the kADD-SHAP values using the kADD-SHAP regression algorithm. The Algorithm is
     described in Pelegrina et al. (2023) :cite:t:`Pelegrina.2023` and is related to
-    Inconsistent KernelSHAP-IQ :cite:t:`Fumagalli.2024`.
+    Inconsistent KernelSHAP-IQ :cite:t:`Fumagalli.2024`. With ``index="SV"``, the order-1 part of
+    the k-additive solution is returned as the Shapley value estimate, which is the use case the
+    kADD-SHAP method was introduced for.
 
     See Also:
         - :class:`~shapiq.approximator.regression.kernelshap.KernelSHAP`: The KernelSHAP
@@ -31,7 +38,7 @@ class kADDSHAP(Regression[ValidRegressionkADDSHAPIndices]):  # noqa: N801
 
     """
 
-    valid_indices = ("kADD-SHAP",)
+    valid_indices: tuple[ValidRegressionkADDSHAPIndices, ...] = ("kADD-SHAP", "SV")
     """The valid indices for this approximator."""
 
     def __init__(
@@ -39,6 +46,7 @@ class kADDSHAP(Regression[ValidRegressionkADDSHAPIndices]):  # noqa: N801
         n: int,
         max_order: int = 2,
         *,
+        index: ValidRegressionkADDSHAPIndices = "kADD-SHAP",
         pairing_trick: bool = False,
         sampling_weights: np.ndarray | None = None,
         random_state: int | None = None,
@@ -50,6 +58,10 @@ class kADDSHAP(Regression[ValidRegressionkADDSHAPIndices]):  # noqa: N801
             n: The number of players.
 
             max_order: The interaction order of the approximation. Defaults to ``2``.
+
+            index: The index to estimate. With ``"kADD-SHAP"`` (default), the full k-additive
+                solution up to ``max_order`` is returned. With ``"SV"``, the order-1 part of the
+                k-additive solution is returned as the Shapley value estimate.
 
             pairing_trick: If ``True``, the pairing trick is applied to the sampling procedure.
                 Defaults to ``False``.
@@ -65,8 +77,38 @@ class kADDSHAP(Regression[ValidRegressionkADDSHAPIndices]):  # noqa: N801
         super().__init__(
             n,
             max_order,
-            index="kADD-SHAP",
+            index=index,
             random_state=random_state,
             pairing_trick=pairing_trick,
             sampling_weights=sampling_weights,
         )
+        # the SV estimate is read off the k-additive solution, so the computation always runs
+        # with the kADD-SHAP weights (index="SV" would otherwise dispatch to the SII routine)
+        self.approximation_index = "kADD-SHAP"
+
+    def approximate(
+        self,
+        budget: int,
+        game: Game | Callable[[np.ndarray], np.ndarray],
+        *args: Any | None,
+        **kwargs: Any,
+    ) -> InteractionValues:
+        """Approximates the kADD-SHAP values or, for ``index="SV"``, the Shapley values.
+
+        Args:
+            budget: The budget of the approximation.
+
+            game: The game to be approximated.
+
+            *args: Additional positional arguments (not used for compatibility).
+
+            **kwargs: Additional arguments (not used for compatibility).
+
+        Returns:
+            The estimated interaction values. For ``index="SV"``, only the orders 0 and 1 of the
+            k-additive solution are returned, which finalizes to the ``"SV"`` index.
+        """
+        interaction_values = super().approximate(budget, game, *args, **kwargs)
+        if self.index == "SV":
+            return interaction_values.get_n_order(min_order=0, max_order=1)
+        return interaction_values

--- a/src/shapiq/approximator/regression/kadd_shap.py
+++ b/src/shapiq/approximator/regression/kadd_shap.py
@@ -2,17 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from .base import Regression
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     import numpy as np
-
-    from shapiq.game import Game
-    from shapiq.interaction_values import InteractionValues
 
 ValidRegressionkADDSHAPIndices = Literal["kADD-SHAP", "SV"]
 
@@ -36,7 +31,9 @@ class kADDSHAP(Regression[ValidRegressionkADDSHAPIndices]):  # noqa: N801
 
     """
 
-    valid_indices: tuple[ValidRegressionkADDSHAPIndices, ...] = ("kADD-SHAP", "SV")
+    valid_indices: tuple[ValidRegressionkADDSHAPIndices, ...] = tuple(
+        get_args(ValidRegressionkADDSHAPIndices)
+    )
     """The valid indices for this approximator."""
 
     def __init__(
@@ -44,7 +41,6 @@ class kADDSHAP(Regression[ValidRegressionkADDSHAPIndices]):  # noqa: N801
         n: int,
         max_order: int = 2,
         *,
-        index: ValidRegressionkADDSHAPIndices = "kADD-SHAP",
         pairing_trick: bool = False,
         sampling_weights: np.ndarray | None = None,
         random_state: int | None = None,
@@ -56,10 +52,6 @@ class kADDSHAP(Regression[ValidRegressionkADDSHAPIndices]):  # noqa: N801
             n: The number of players.
 
             max_order: The interaction order of the approximation. Defaults to ``2``.
-
-            index: The index to estimate. With ``"kADD-SHAP"`` (default), the full k-additive
-                solution up to ``max_order`` is returned. With ``"SV"``, the order-1 part of the
-                k-additive solution is returned as the Shapley value estimate.
 
             pairing_trick: If ``True``, the pairing trick is applied to the sampling procedure.
                 Defaults to ``False``.
@@ -75,38 +67,8 @@ class kADDSHAP(Regression[ValidRegressionkADDSHAPIndices]):  # noqa: N801
         super().__init__(
             n,
             max_order,
-            index=index,
+            index="kADD-SHAP",
             random_state=random_state,
             pairing_trick=pairing_trick,
             sampling_weights=sampling_weights,
         )
-        # the SV estimate is read off the k-additive solution, so the computation always runs
-        # with the kADD-SHAP weights (index="SV" would otherwise dispatch to the SII routine)
-        self.approximation_index = "kADD-SHAP"
-
-    def approximate(
-        self,
-        budget: int,
-        game: Game | Callable[[np.ndarray], np.ndarray],
-        *args: Any | None,
-        **kwargs: Any,
-    ) -> InteractionValues:
-        """Approximates the kADD-SHAP values or, for ``index="SV"``, the Shapley values.
-
-        Args:
-            budget: The budget of the approximation.
-
-            game: The game to be approximated.
-
-            *args: Additional positional arguments (not used for compatibility).
-
-            **kwargs: Additional arguments (not used for compatibility).
-
-        Returns:
-            The estimated interaction values. For ``index="SV"``, only the orders 0 and 1 of the
-            k-additive solution are returned, which finalizes to the ``"SV"`` index.
-        """
-        interaction_values = super().approximate(budget, game, *args, **kwargs)
-        if self.index == "SV":
-            return interaction_values.get_n_order(min_order=0, max_order=1)
-        return interaction_values

--- a/src/shapiq/approximator/regression/kadd_shap.py
+++ b/src/shapiq/approximator/regression/kadd_shap.py
@@ -22,9 +22,7 @@ class kADDSHAP(Regression[ValidRegressionkADDSHAPIndices]):  # noqa: N801
 
     Estimates the kADD-SHAP values using the kADD-SHAP regression algorithm. The Algorithm is
     described in Pelegrina et al. (2023) :cite:t:`Pelegrina.2023` and is related to
-    Inconsistent KernelSHAP-IQ :cite:t:`Fumagalli.2024`. With ``index="SV"``, the order-1 part of
-    the k-additive solution is returned as the Shapley value estimate, which is the use case the
-    kADD-SHAP method was introduced for.
+    Inconsistent KernelSHAP-IQ :cite:t:`Fumagalli.2024`.
 
     See Also:
         - :class:`~shapiq.approximator.regression.kernelshap.KernelSHAP`: The KernelSHAP

--- a/tests/shapiq/tests_unit/tests_approximators/test_approximator_k_additive_kernelshap.py
+++ b/tests/shapiq/tests_unit/tests_approximators/test_approximator_k_additive_kernelshap.py
@@ -41,30 +41,18 @@ def test_approximate(budget, order):
     assert sii_estimates[(2,)] == pytest.approx(0.6429, abs=0.1)
 
 
-def test_initialization_with_sv_index():
-    """Tests that the kADDSHAP approximator can be set up to estimate Shapley values."""
-    approximator = kADDSHAP(7, index="SV")
-    assert approximator.index == "SV"
-    assert approximator.approximation_index == "kADD-SHAP"
-    assert approximator.max_order == 2
-
-    with pytest.raises(ValueError, match="Invalid index"):
-        kADDSHAP(7, index="SII")
-
-
-@pytest.mark.parametrize("order", [2, 3])
-def test_approximate_sv(order):
-    """Tests that with index="SV" the order-1 part of the k-additive solution is returned."""
+def test_approximate_sv():
+    """Tests that kADDSHAP with max_order=1 estimates Shapley values."""
     n = 7
     interaction = (1, 2)
     game = DummyGame(n, interaction)
 
-    approximator = kADDSHAP(n, max_order=order, index="SV")
+    approximator = kADDSHAP(n, max_order=1)
+    assert "SV" in approximator.valid_indices
     sv_estimates = approximator.approximate(100, game)
     assert isinstance(sv_estimates, InteractionValues)
     assert sv_estimates.index == "SV"
     assert sv_estimates.max_order == 1
-    assert sv_estimates.min_order == 0
 
     assert sv_estimates[(1,)] == pytest.approx(0.6429, abs=0.1)
     assert sv_estimates[(2,)] == pytest.approx(0.6429, abs=0.1)

--- a/tests/shapiq/tests_unit/tests_approximators/test_approximator_k_additive_kernelshap.py
+++ b/tests/shapiq/tests_unit/tests_approximators/test_approximator_k_additive_kernelshap.py
@@ -39,3 +39,33 @@ def test_approximate(budget, order):
 
     assert sii_estimates[(1,)] == pytest.approx(0.6429, abs=0.1)
     assert sii_estimates[(2,)] == pytest.approx(0.6429, abs=0.1)
+
+
+def test_initialization_with_sv_index():
+    """Tests that the kADDSHAP approximator can be set up to estimate Shapley values."""
+    approximator = kADDSHAP(7, index="SV")
+    assert approximator.index == "SV"
+    assert approximator.approximation_index == "kADD-SHAP"
+    assert approximator.max_order == 2
+
+    with pytest.raises(ValueError, match="Invalid index"):
+        kADDSHAP(7, index="SII")
+
+
+@pytest.mark.parametrize("order", [2, 3])
+def test_approximate_sv(order):
+    """Tests that with index="SV" the order-1 part of the k-additive solution is returned."""
+    n = 7
+    interaction = (1, 2)
+    game = DummyGame(n, interaction)
+
+    approximator = kADDSHAP(n, max_order=order, index="SV")
+    sv_estimates = approximator.approximate(100, game)
+    assert isinstance(sv_estimates, InteractionValues)
+    assert sv_estimates.index == "SV"
+    assert sv_estimates.max_order == 1
+    assert sv_estimates.min_order == 0
+
+    assert sv_estimates[(1,)] == pytest.approx(0.6429, abs=0.1)
+    assert sv_estimates[(2,)] == pytest.approx(0.6429, abs=0.1)
+    assert sv_estimates[(0,)] == pytest.approx(0.1429, abs=0.1)

--- a/tests/shapiq/tests_unit/tests_approximators/test_approximator_registry.py
+++ b/tests/shapiq/tests_unit/tests_approximators/test_approximator_registry.py
@@ -11,6 +11,7 @@ from shapiq.approximator import InconsistentKernelSHAPIQ, KernelSHAPIQ
 @pytest.mark.parametrize(
     ("registry_name", "index"),
     [
+        ("SV_APPROXIMATORS", "SV"),
         ("SII_APPROXIMATORS", "SII"),
         ("STII_APPROXIMATORS", "STII"),
         ("FSII_APPROXIMATORS", "FSII"),


### PR DESCRIPTION
## Motivation and Context

`kADDSHAP` is listed in the public `SV_APPROXIMATORS` registry but only declared `valid_indices = ("kADD-SHAP",)`, breaking the registry consistency contract from #575 (every registry member declares the registry's index in its `valid_indices`). Since the kADD-SHAP method (Pelegrina et al., 2023) is by design a Shapley value estimator — the fitted k-additive surrogate's order-1 parameters are the SV estimate — the fix is to declare the support rather than delist the approximator.

The fix follows the `RegressionFSII` pattern: `valid_indices = ("kADD-SHAP", "SV")`, with no constructor changes. Estimating Shapley values with this estimator means calling it with `max_order=1`, where the `InteractionValues` order-1 finalization already labels the result `"SV"` (kADD-SHAP generalizes SV). This behavior already worked on `main`; the class just never declared it.

---

## Public API Changes

-   [ ] No Public API changes
-   [x] Yes, Public API changes (Details below)

- `kADDSHAP.valid_indices` is now `("kADD-SHAP", "SV")` instead of `("kADD-SHAP",)`; `ValidRegressionkADDSHAPIndices` includes `"SV"` accordingly. No constructor or `approximate` signature changes; default behavior is unchanged.

---

## How Has This Been Tested?

- The registry consistency test from #575 now also covers `SV_APPROXIMATORS`, so every member (including `kADDSHAP`) must declare `"SV"`.
- New `test_approximate_sv` verifies that `kADDSHAP(n, max_order=1)` returns an `InteractionValues` with `index="SV"` and correct Shapley value estimates on `DummyGame`.
- Full local approximator suite passes (538 passed; the `spex`-parametrized tests fail only due to the missing optional `sparse` extra in the environment, identical on `main`); `ruff`/`ruff-format` clean.

---

## Checklist

-   [x] The changes have been tested locally.
-   [x] Documentation has been updated (if the public API or usage changes).
-   [x] An entry has been added to `CHANGELOG.md` (if relevant for users).
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bo4DBU7eH2MamvcZLwiqDG