### PR TITLE
Remove libomp/DYLD workaround for treelite >= 4.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,16 +151,8 @@ jobs:
                 run: brew install libomp
             -   name: Install test dependencies
                 run: uv sync --all-extras
-            -   if: matrix.os != 'macos-latest'
-                name: Run unit tests
+            -   name: Run unit tests
                 run: uv run pytest "tests/shapiq"
-            -   if: matrix.os == 'macos-latest'
-                name: Run unit tests (macOS)
-                # treelite (needed by the woodelf fast path of the TreeExplainer) does not find
-                # Homebrew's keg-only libomp on its own (https://github.com/dmlc/treelite/issues/678).
-                # The DYLD variable must be set inline: SIP strips DYLD_* from the environment
-                # when the step's protected /bin/bash starts, so `env:`/GITHUB_ENV cannot carry it.
-                run: DYLD_FALLBACK_LIBRARY_PATH="$(brew --prefix libomp)/lib" uv run pytest "tests/shapiq"
     # ----------------------------------------------------------------------------------------------
     # Test Documentation Build
     # ----------------------------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -329,3 +329,9 @@ dev = [
     {include-group = "lint"},
     {include-group = "all_ml"},
 ]
+
+[tool.uv]
+# Not a dependency: treelite only enters the environment through woodelf-explainer.
+# Wheels before 4.7.1 cannot find Homebrew's libomp on macOS
+# (https://github.com/dmlc/treelite/issues/678); drop this once woodelf pins it.
+constraint-dependencies = ["treelite>=4.7.1"]

--- a/src/shapiq/tree/explainer.py
+++ b/src/shapiq/tree/explainer.py
@@ -366,10 +366,6 @@ class TreeExplainer(Explainer):
             The values in the Woodelf format ``{interaction_tuple: ndarray of shape
             (n_instances,)}``, or ``None`` if the configuration is not supported by Woodelf
             (e.g. an unsupported index or a too deep tree).
-
-        Raises:
-            RuntimeError: If woodelf is installed but its treelite backend cannot load its
-                native library (e.g. a missing OpenMP runtime on macOS).
         """
         try:
             import pandas as pd
@@ -404,21 +400,9 @@ class TreeExplainer(Explainer):
             return None
 
         class_index = self._class_label if self._class_label is not None else 1
-        try:
-            loaded_model = load_decision_tree_ensemble_model(
-                self.model, range(X.shape[1]), class_index=class_index
-            )
-        except OSError as error:
-            # treelite imports lazily inside woodelf's model parsing, so a macOS wheel that
-            # cannot load libomp surfaces here as an OSError.
-            msg = (
-                "woodelf is installed but its treelite backend failed to load. On macOS this "
-                "usually means the OpenMP runtime is missing: install it with "
-                "`brew install libomp` and set "
-                "`DYLD_FALLBACK_LIBRARY_PATH=$(brew --prefix libomp)/lib`. "
-                "See https://github.com/dmlc/treelite/issues/678 for details."
-            )
-            raise RuntimeError(msg) from error
+        loaded_model = load_decision_tree_ensemble_model(
+            self.model, range(X.shape[1]), class_index=class_index
+        )
 
         # woodelf cannot compute path-dependent SHAP of order >= 3 on trees deeper than 16
         # yet; remove this fallback once it can.

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -879,32 +879,6 @@ def test_backend_validation_raises(dt_reg_model, background_reg_data, monkeypatc
         TreeExplainer(model=dt_reg_model, index="BV", backend="auto")
 
 
-def test_woodelf_broken_backend_raises_with_fix_instructions(
-    dt_reg_model, background_reg_data, monkeypatch
-):
-    """A woodelf whose native backend cannot load (e.g. treelite missing libomp on macOS).
-
-    Loading treelite happens lazily inside woodelf and surfaces as an ``OSError`` at explain
-    time; the explainer must break loudly with instructions on how to fix the installation
-    (see https://github.com/dmlc/treelite/issues/678) instead of silently computing slowly.
-    """
-    pytest.importorskip("woodelf")
-    from woodelf.core.trees import parse_models
-
-    def broken_load(*args, **kwargs):
-        msg = "dlopen(libtreelite.dylib): Library not loaded: @rpath/libomp.dylib"
-        raise OSError(msg)
-
-    monkeypatch.setattr(parse_models, "load_decision_tree_ensemble_model", broken_load)
-
-    # max_order=2 crosses the path-dependent Woodelf cut-off, so this routes to Woodelf
-    explainer = TreeExplainer(model=dt_reg_model, max_order=2, min_order=1, index="SII")
-    with pytest.raises(RuntimeError, match="brew install libomp") as excinfo:
-        explainer.explain(background_reg_data[0])
-    assert "treelite/issues/678" in str(excinfo.value)
-    assert isinstance(excinfo.value.__cause__, OSError)  # the dlopen error stays in the chain
-
-
 def test_woodelf_interventional_matches_direct_explainer(rf_reg_model, background_reg_data):
     """Background SHAP over 20 rows x 10 background rows routes through Woodelf.
 

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,9 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+constraints = [{ name = "treelite", specifier = ">=4.7.1" }]
+
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -4608,20 +4611,20 @@ wheels = [
 
 [[package]]
 name = "treelite"
-version = "4.7.0"
+version = "4.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "packaging" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/dd/78886789f87a6d9cb3d78241fdd750c13123ea4c64df03bcc717ee5b5d26/treelite-4.7.0.tar.gz", hash = "sha256:6d1a0d990f4972e77bad6b42a6e0b7d68527d790564bd42d7d8d48ae1f14dc4c", size = 110239, upload-time = "2026-03-06T23:25:38.477Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/f1/025d77b7de934438a563e4019a4a7f2163629eaa8727fd57c4806ef3554c/treelite-4.7.1.tar.gz", hash = "sha256:afdf9ee8f2deff3b538ebfb72d67e3bdeeff63633ddb36f1ac84f0d39fc9105d", size = 110126, upload-time = "2026-08-25T00:56:30.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/8e/ee9595a6c6a839cc79a919312805af4ed85906a96d3ab1446b0e800805e3/treelite-4.7.0-py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64.macosx_12_0_x86_64.whl", hash = "sha256:dac8a400a3f08ed4b8611289e2f92f589eadd95b97857d118597a5db7b489ecb", size = 445207, upload-time = "2026-03-06T23:25:30.974Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/46/2de9011d8f618dc60087a4cfee2ab4d1caf437b83fc552554b8dd4530b26/treelite-4.7.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:54f8b46a1aaa531d1491a5429cf7ab9816341cefc462096a8c4a2a03acbcf46b", size = 418136, upload-time = "2026-03-06T23:25:32.649Z" },
-    { url = "https://files.pythonhosted.org/packages/60/6a/38c21bea47fd08d82267b36baae23edb610749bf319136fceb6871266207/treelite-4.7.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:adf49cdc004437615468b54255eb04f65e467803e8b0c2f06481fdd873f25f59", size = 939359, upload-time = "2026-03-06T23:25:33.963Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/a2/ac3aad5c77f85f47890dd929b2690c2ba3794ebcbb5384c19aa28d222066/treelite-4.7.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:d616f1df2b8c7c6497cda2b8434fbcefe07fa897d269bdde3b48b11fd62393d9", size = 956840, upload-time = "2026-03-06T23:25:35.207Z" },
-    { url = "https://files.pythonhosted.org/packages/73/a8/bea7cea3ee860ec24d0be304f9a5433f32e80b547db51bfe971fb41b3825/treelite-4.7.0-py3-none-win_amd64.whl", hash = "sha256:c9c5af96685d7636bdaaa5604973ce63cc85d4f47fc2265ab94cf5247511e0cb", size = 515640, upload-time = "2026-03-06T23:25:37.433Z" },
+    { url = "https://files.pythonhosted.org/packages/40/69/e6e4d754d39ca7640afc8c578f3aeb0a6a2f20053a24eaad715b4523553e/treelite-4.7.1-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:54430a3d0ec465479e63cb6a7875882f1d813d048a64963639e4c46cfc4d1189", size = 459839, upload-time = "2026-08-25T00:56:23.572Z" },
+    { url = "https://files.pythonhosted.org/packages/88/67/4f38a812bcf75c5774c054d5bdfd64c6e2d9e091c27f6e7cb1477702fa52/treelite-4.7.1-py3-none-macosx_12_0_arm64.whl", hash = "sha256:519134ad4d67bbfcd1bb4db4a108d95537cffe72ad78b24a3252ceff3ac4b028", size = 427430, upload-time = "2026-08-25T00:56:25.061Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f6/89d9d345f059bc06dffd7494b5edb94dd14e15cf1cc194e66f8a674047da/treelite-4.7.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:7fb8e5a92751342c60be1f3e8ac68d83941c3ae0695506b0ba14679db1f7d1e4", size = 875716, upload-time = "2026-08-25T00:56:26.45Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/80/788798e6f2e7efb502ccfafec38528ae5640a7e22117a75bbd379d2e50d9/treelite-4.7.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:52fb6ee5191a63cb508f6e0af860a24090fae5507fe1228ea801daa0b816da06", size = 921199, upload-time = "2026-08-25T00:56:27.651Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/e8/02e4143863969c4440ca78dbea857deeb26f7d588ecbfc03d253cf437052/treelite-4.7.1-py3-none-win_amd64.whl", hash = "sha256:189aced2a79505e5e23c18495741818ee4700ff2969a5c25cee31f377d91ad87", size = 515978, upload-time = "2026-08-25T00:56:28.921Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
treelite 4.7.1 fixes the macOS rpath for libomp.dylib (dmlc/treelite#681), so the wheel finds Homebrew's libomp on its own:

- drop the custom RuntimeError in TreeExplainer._run_woodelf that explained the DYLD_FALLBACK_LIBRARY_PATH workaround; a treelite that cannot load libomp now surfaces its own OSError
- drop the macOS-specific DYLD_FALLBACK_LIBRARY_PATH test step in CI
- constrain treelite>=4.7.1 via [tool.uv] constraint-dependencies (not a dependency; treelite only enters through woodelf-explainer) until woodelf pins it upstream

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

Touches only unreleased code.
