### PR TITLE
Feature/woodelf stii fsii fbii

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ keywords = [
 [project.optional-dependencies]
 tree = [
     # required by the Woodelf fast path of shapiq.tree.TreeExplainer
-    "woodelf-explainer>=0.4.6",  # imports as `woodelf`; pulls in treelite>=4.0
+    "woodelf-explainer>=0.4.7",  # imports as `woodelf`; pulls in treelite>=4.0
 ]
 sparse = [
     # required by shapiq.approximator.sparse (SPEX and the Sparse base class)

--- a/src/shapiq/tree/explainer.py
+++ b/src/shapiq/tree/explainer.py
@@ -410,12 +410,12 @@ class TreeExplainer(Explainer):
             import pandas as pd
             from woodelf.core.cube_metric import (
                 BanzhafValues,
+                FaithfulBanzhafInteractionValues,
+                FaithfulShapleyInteractionValues,
                 GeneralBanzhafInteractionValues,
                 GeneralShapleyInteractionValues,
+                ShapleyTaylorInteractionValues,
                 ShapleyValues,
-                FaithfulShapleyInteractionValues,
-                FaithfulBanzhafInteractionValues,
-                ShapleyTaylorInteractionValues
             )
             from woodelf.core.trees.parse_models import load_decision_tree_ensemble_model
             from woodelf.woodelf_sparse import hybrid_woodelf
@@ -430,12 +430,12 @@ class TreeExplainer(Explainer):
 
         index_to_metric_class = {
             "SII": GeneralShapleyInteractionValues,
-            "k-SII": GeneralShapleyInteractionValues, # k-SII is a pure aggregation of SII, Woodelf computes the SII base values and
+            "k-SII": GeneralShapleyInteractionValues,  # k-SII is a pure aggregation of SII, Woodelf computes the SII base values and
             # ``_aggregate_batched_sii_to_ksii`` makes them k-SII
             "BII": GeneralBanzhafInteractionValues,
             "STII": ShapleyTaylorInteractionValues,
             "FSII": FaithfulShapleyInteractionValues,
-            "FBII": FaithfulBanzhafInteractionValues
+            "FBII": FaithfulBanzhafInteractionValues,
         }
         if self._index == "SV":
             metric = ShapleyValues()

--- a/src/shapiq/tree/explainer.py
+++ b/src/shapiq/tree/explainer.py
@@ -358,7 +358,7 @@ class TreeExplainer(Explainer):
         Returns:
             A human-readable reason, or ``None`` when Woodelf supports the configuration.
         """
-        if self.index not in ("SV", "BV", "SII", "k-SII", "BII"):
+        if self.index not in ("SV", "BV", "SII", "k-SII", "BII", "STII", "FSII", "FBII"):
             return f"index='{self.index}' is not supported by Woodelf"
 
         cat_boost_classes = [
@@ -413,6 +413,9 @@ class TreeExplainer(Explainer):
                 GeneralBanzhafInteractionValues,
                 GeneralShapleyInteractionValues,
                 ShapleyValues,
+                FaithfulShapleyInteractionValues,
+                FaithfulBanzhafInteractionValues,
+                ShapleyTaylorInteractionValues
             )
             from woodelf.core.trees.parse_models import load_decision_tree_ensemble_model
             from woodelf.woodelf_sparse import hybrid_woodelf
@@ -425,16 +428,22 @@ class TreeExplainer(Explainer):
         if self._reference_dataset is not None and self.mode == "interventional":
             background_dataset = pd.DataFrame(self._reference_dataset)
 
+        index_to_metric_class = {
+            "SII": GeneralShapleyInteractionValues,
+            "k-SII": GeneralShapleyInteractionValues, # k-SII is a pure aggregation of SII, Woodelf computes the SII base values and
+            # ``_aggregate_batched_sii_to_ksii`` makes them k-SII
+            "BII": GeneralBanzhafInteractionValues,
+            "STII": ShapleyTaylorInteractionValues,
+            "FSII": FaithfulShapleyInteractionValues,
+            "FBII": FaithfulBanzhafInteractionValues
+        }
         if self._index == "SV":
             metric = ShapleyValues()
         elif self._index == "BV":
             metric = BanzhafValues()
-        elif self._index in ("SII", "k-SII"):
-            # k-SII is a pure aggregation of SII, Woodelf computes the SII base values and
-            # ``_aggregate_batched_sii_to_ksii`` makes them k-SII
-            metric = GeneralShapleyInteractionValues(max(self._min_order, 1), self._max_order)
-        elif self._index == "BII":
-            metric = GeneralBanzhafInteractionValues(max(self._min_order, 1), self._max_order)
+        elif self._index in index_to_metric_class:
+            metric_class = index_to_metric_class[self._index]
+            metric = metric_class(max(self._min_order, 1), self._max_order)
         else:  # pre-validated in __init__ / _woodelf_unsupported_reason; defensive
             msg = f"index='{self._index}' is not supported by Woodelf."
             raise ValueError(msg)

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -984,6 +984,8 @@ def deep_dt_reg_model(background_reg_dataset):
 
 
 _WOODELF_INTERVENTIONAL_INDICES = ["SII", "BII", "STII", "FSII", "FBII"]
+# As shapiq backend does not support path-dependent STII, FSII, FBII, 
+# only SII and BII are tested for path-dependent mode.
 _WOODELF_PATHDEPENDENT_INDICES = ["SII", "BII"]
 
 

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -984,7 +984,7 @@ def deep_dt_reg_model(background_reg_dataset):
 
 
 _WOODELF_INTERVENTIONAL_INDICES = ["SII", "BII", "STII", "FSII", "FBII"]
-# As shapiq backend does not support path-dependent STII, FSII, FBII, 
+# As the shapiq backend does not support path-dependent STII, FSII and FBII,
 # only SII and BII are tested for path-dependent mode.
 _WOODELF_PATHDEPENDENT_INDICES = ["SII", "BII"]
 

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -968,40 +968,104 @@ def test_explain_X_returns_interaction_values_batch(rf_reg_model, background_reg
             )
 
 
-def test_woodelf_pathdependent_matches_treeshapiq(dt_reg_model, background_reg_data):
-    """Forced path-dependent Woodelf SII with ``min_order=0``, ``max_order=3`` matches shapiq.
+@pytest.fixture
+def deep_dt_reg_model(background_reg_dataset):
+    """A decision tree deep enough that its Moebius sets exceed ``max_order=3``.
 
-    Orders 1-3 must match :class:`TreeSHAPIQ` run directly per tree, and ``min_order=0``
-    must still put the baseline at the empty interaction.
+    The shared depth-3 fixtures cannot tell the interaction indices apart: when no Moebius set
+    is larger than ``max_order``, STII, FSII and FBII all reduce to the plain Moebius transform
+    and become numerically identical. Depth 6 separates them while staying under the depth-16
+    limit of Woodelf's path-dependent kernel.
     """
-    from shapiq.tree import TreeSHAPIQ
-    from shapiq.tree.validation import validate_tree_model
+    from sklearn.tree import DecisionTreeRegressor
 
-    pytest.importorskip("woodelf")
-    x_explain = background_reg_data[0]
+    X, y = background_reg_dataset
+    return DecisionTreeRegressor(random_state=42, max_depth=6).fit(X, y)
 
-    explainer = TreeExplainer(
-        model=dt_reg_model, max_order=3, min_order=0, index="SII", backend="woodelf"
-    )
-    assert explainer._should_use_woodelf(1)  # guard: Woodelf, not the fallback
-    explanation = explainer.explain(x_explain)
 
-    per_tree = [
-        TreeSHAPIQ(model=tree, max_order=3, index="SII").explain(x_explain)
-        for tree in validate_tree_model(dt_reg_model)
-    ]
-    reference = sum(per_tree[1:], start=per_tree[0])
+_WOODELF_INTERVENTIONAL_INDICES = ["SII", "BII", "STII", "FSII", "FBII"]
+_WOODELF_PATHDEPENDENT_INDICES = ["SII", "BII"]
 
-    assert explanation.min_order == 0
-    assert explanation.max_order == 3
-    assert explanation[()] == pytest.approx(explainer.baseline_value)
+
+def _assert_woodelf_matches_shapiq(
+    woodelf_explainer, shapiq_explainer, x_explain, index, min_order, max_order
+):
+    """Assert the two explainers explain ``x_explain`` the same way.
+    """
+    assert woodelf_explainer._should_use_woodelf(1)  # guard: Woodelf on one side ...
+    assert not shapiq_explainer._should_use_woodelf(1)  # ... and the shapiq kernel on the other
+
+    explanation = woodelf_explainer.explain(x_explain)
+    reference_explanation = shapiq_explainer.explain(x_explain)
+
+    assert explanation.index == index
+    assert explanation.min_order == min_order
+    assert explanation.max_order == max_order
+    assert explanation[()] == pytest.approx(woodelf_explainer.baseline_value)
 
     # a subset missing on one side is an exact zero there, so compare over the union
-    interactions = set(explanation.interactions) | set(reference.interactions)
-    assert {len(interaction) for interaction in interactions} == {0, 1, 2, 3}
+    interactions = set(explanation.interactions) | set(reference_explanation.interactions)
+    assert {len(interaction) for interaction in interactions} == set(range(max_order + 1))
     for interaction in interactions:
         if interaction:  # skip the empty interaction, checked against the baseline above
-            assert explanation[interaction] == pytest.approx(reference[interaction], abs=1e-5)
+            assert explanation[interaction] == pytest.approx(
+                reference_explanation[interaction], abs=1e-5
+            )
+
+
+@pytest.mark.parametrize("index", _WOODELF_PATHDEPENDENT_INDICES)
+def test_woodelf_pathdependent_matches_shapiq(deep_dt_reg_model, background_reg_data, index):
+    """Forced path-dependent Woodelf with ``min_order=0``, ``max_order=3`` matches shapiq.
+    """
+    pytest.importorskip("woodelf")
+    woodelf_explainer = TreeExplainer(
+        model=deep_dt_reg_model, max_order=3, min_order=0, index=index, backend="woodelf"
+    )
+    shap_explainer = TreeExplainer(
+        model=deep_dt_reg_model, max_order=3, min_order=0, index=index, backend="shapiq"
+    )
+    _assert_woodelf_matches_shapiq(
+        woodelf_explainer,
+        shap_explainer,
+        background_reg_data[0],
+        index=index,
+        min_order=0,
+        max_order=3,
+    )
+
+
+@pytest.mark.parametrize("index", _WOODELF_INTERVENTIONAL_INDICES)
+def test_woodelf_interventional_matches_shapiq(deep_dt_reg_model, background_reg_data, index):
+    """Forced interventional Woodelf with ``min_order=0``, ``max_order=3`` matches shapiq.
+    """
+    pytest.importorskip("woodelf")
+    reference_dataset = background_reg_data[:10]
+    woodelf_explainer = TreeExplainer(
+        model=deep_dt_reg_model,
+        mode="interventional",
+        reference_dataset=reference_dataset,
+        max_order=3,
+        min_order=0,
+        index=index,
+        backend="woodelf",
+    )
+    shap_explainer = TreeExplainer(
+        model=deep_dt_reg_model,
+        mode="interventional",
+        reference_dataset=reference_dataset,
+        max_order=3,
+        min_order=0,
+        index=index,
+        backend="shapiq",
+    )
+    _assert_woodelf_matches_shapiq(
+        woodelf_explainer,
+        shap_explainer,
+        background_reg_data[10],
+        index=index,
+        min_order=0,
+        max_order=3,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -990,8 +990,7 @@ _WOODELF_PATHDEPENDENT_INDICES = ["SII", "BII"]
 def _assert_woodelf_matches_shapiq(
     woodelf_explainer, shapiq_explainer, x_explain, index, min_order, max_order
 ):
-    """Assert the two explainers explain ``x_explain`` the same way.
-    """
+    """Assert the two explainers explain ``x_explain`` the same way."""
     assert woodelf_explainer._should_use_woodelf(1)  # guard: Woodelf on one side ...
     assert not shapiq_explainer._should_use_woodelf(1)  # ... and the shapiq kernel on the other
 
@@ -1015,8 +1014,7 @@ def _assert_woodelf_matches_shapiq(
 
 @pytest.mark.parametrize("index", _WOODELF_PATHDEPENDENT_INDICES)
 def test_woodelf_pathdependent_matches_shapiq(deep_dt_reg_model, background_reg_data, index):
-    """Forced path-dependent Woodelf with ``min_order=0``, ``max_order=3`` matches shapiq.
-    """
+    """Forced path-dependent Woodelf with ``min_order=0``, ``max_order=3`` matches shapiq."""
     pytest.importorskip("woodelf")
     woodelf_explainer = TreeExplainer(
         model=deep_dt_reg_model, max_order=3, min_order=0, index=index, backend="woodelf"
@@ -1036,8 +1034,7 @@ def test_woodelf_pathdependent_matches_shapiq(deep_dt_reg_model, background_reg_
 
 @pytest.mark.parametrize("index", _WOODELF_INTERVENTIONAL_INDICES)
 def test_woodelf_interventional_matches_shapiq(deep_dt_reg_model, background_reg_data, index):
-    """Forced interventional Woodelf with ``min_order=0``, ``max_order=3`` matches shapiq.
-    """
+    """Forced interventional Woodelf with ``min_order=0``, ``max_order=3`` matches shapiq."""
     pytest.importorskip("woodelf")
     reference_dataset = background_reg_data[:10]
     woodelf_explainer = TreeExplainer(

--- a/uv.lock
+++ b/uv.lock
@@ -3908,7 +3908,7 @@ requires-dist = [
     { name = "tabpfn", marker = "extra == 'benchmark'" },
     { name = "torch", marker = "extra == 'shapleig'", specifier = ">=2.9.1" },
     { name = "tqdm" },
-    { name = "woodelf-explainer", marker = "extra == 'tree'", specifier = ">=0.4.6" },
+    { name = "woodelf-explainer", marker = "extra == 'tree'", specifier = ">=0.4.7" },
     { name = "xgboost", marker = "extra == 'benchmark'" },
     { name = "xgboost", marker = "extra == 'proxy'" },
 ]
@@ -4822,7 +4822,7 @@ wheels = [
 
 [[package]]
 name = "woodelf-explainer"
-version = "0.4.6"
+version = "0.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -4831,9 +4831,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "treelite" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/62/2bc67e6a2d56835d81aa8256086246d63d421e49fab48d81a8cfc69ce442/woodelf_explainer-0.4.6.tar.gz", hash = "sha256:6ec24ba8290d2e545bc28e30cdbf77da34f77b944db2c1f0c5c740ed7fb9f7ca", size = 82701, upload-time = "2026-08-12T10:36:33.568Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/80/dec757c306feef43e085fc525151b020f64d84a9028c0e30c776c10650db/woodelf_explainer-0.4.7.tar.gz", hash = "sha256:6bee99036ca1185624c595901f90cbeabd240218a4921e48ca2312ef37e7d334", size = 85658, upload-time = "2026-08-31T15:58:27.273Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/9c/9beb79b75a87a99f260a6534af404ed6d695d1d9662ecbc7abc1077c36d0/woodelf_explainer-0.4.6-py3-none-any.whl", hash = "sha256:827d014f2d5753d5a337db1a207e2aed1c40c8142e27f771cddefe751ad19c13", size = 82795, upload-time = "2026-08-12T10:36:32.317Z" },
+    { url = "https://files.pythonhosted.org/packages/20/19/c21aabfc28cd6c06a266669d49d7033765232580d61ed3922b27a89ba5f9/woodelf_explainer-0.4.7-py3-none-any.whl", hash = "sha256:e7bd9946810b8f09efe4387e566ae368312d1824ca4831b9d179e07205f7d7af", size = 84461, upload-time = "2026-08-31T15:58:26.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Motivation and Context
I recently supported STII, FSII and FBII indices in Woodelf. 
This PR allow shapiq to use Woodelf also on these indices. 
TreeExplainer will use Woodelf on n*m>100000 for interventional SHAP. 
It can also use Woodelf on STII, FSII and FBII in path dependent when backend="woodelf" (but not by default).

shapiq[tree] now depends on woodelf_explainer=0.4.7 version (instead of 0.4.6).

---

## Public API Changes

-   [X] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
Added tests the compare shapiq's output to Woodelf's on these indices and make sure they are identical. 
Also validated it locally.
The woodelf package also has its own tests for this logic.

---

## Checklist

-   [X] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] An entry has been added to `CHANGELOG.md` (if relevant for users).
-   [X] The code follows the project's style guidelines.
-   [X] I have considered the impact of these changes on the public API.

---
