### PR TITLE
Feature/mobius for trees

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ keywords = [
 [project.optional-dependencies]
 tree = [
     # required by the Woodelf fast path of shapiq.tree.TreeExplainer
-    "woodelf-explainer>=0.4.6",  # imports as `woodelf`; pulls in treelite>=4.0
+    "woodelf-explainer>=0.4.7",  # imports as `woodelf`; pulls in treelite>=4.0
 ]
 sparse = [
     # required by shapiq.approximator.sparse (SPEX and the Sparse base class)

--- a/src/shapiq/tree/explainer.py
+++ b/src/shapiq/tree/explainer.py
@@ -410,12 +410,12 @@ class TreeExplainer(Explainer):
             import pandas as pd
             from woodelf.core.cube_metric import (
                 BanzhafValues,
+                FaithfulBanzhafInteractionValues,
+                FaithfulShapleyInteractionValues,
                 GeneralBanzhafInteractionValues,
                 GeneralShapleyInteractionValues,
+                ShapleyTaylorInteractionValues,
                 ShapleyValues,
-                FaithfulShapleyInteractionValues,
-                FaithfulBanzhafInteractionValues,
-                ShapleyTaylorInteractionValues
             )
             from woodelf.core.trees.parse_models import load_decision_tree_ensemble_model
             from woodelf.woodelf_sparse import hybrid_woodelf
@@ -430,12 +430,12 @@ class TreeExplainer(Explainer):
 
         index_to_metric_class = {
             "SII": GeneralShapleyInteractionValues,
-            "k-SII": GeneralShapleyInteractionValues, # k-SII is a pure aggregation of SII, Woodelf computes the SII base values and
+            "k-SII": GeneralShapleyInteractionValues,  # k-SII is a pure aggregation of SII, Woodelf computes the SII base values and
             # ``_aggregate_batched_sii_to_ksii`` makes them k-SII
             "BII": GeneralBanzhafInteractionValues,
             "STII": ShapleyTaylorInteractionValues,
             "FSII": FaithfulShapleyInteractionValues,
-            "FBII": FaithfulBanzhafInteractionValues
+            "FBII": FaithfulBanzhafInteractionValues,
         }
         if self._index == "SV":
             metric = ShapleyValues()

--- a/src/shapiq/tree/explainer.py
+++ b/src/shapiq/tree/explainer.py
@@ -24,11 +24,12 @@ from .quadrature import QuadratureTreeSHAP, QuadratureTreeSHAPIndices
 from .validation import validate_tree_model
 
 if TYPE_CHECKING:
+    from shapiq.explainer.custom_types import ExplainerIndices
     from shapiq.typing import Model
 
 TREE_MODES = Literal["pathdependent", "interventional"]
 TREE_BACKENDS = Literal["auto", "woodelf", "shapiq"]
-TreeExplainerIndices = Literal["SV", "SII", "k-SII", "BV", "BII", "STII", "FSII", "FBII"]
+TreeExplainerIndices = Literal["SV", "SII", "k-SII", "BV", "BII", "STII", "FSII", "FBII", "Moebius"]
 
 _WOODELF_INSTALL_HINT = "Install it with: pip install shapiq[tree]"
 _WOODELF_REQUIRED = f"requires the optional 'woodelf-explainer' package. {_WOODELF_INSTALL_HINT}"
@@ -81,8 +82,9 @@ class TreeExplainer(Explainer):
       in float64 at any tree depth. The algorithm descends from Linear TreeSHAP
       :cite:t:`Yu.2022` and computes any-order Shapley interactions as introduced for trees
       by TreeSHAP-IQ :cite:t:`Muschalik.2024a`; Banzhaf indices fall out of the same
-      polynomials by evaluation at participation probability 1/2. Supported indices:
-      ``"SV"``, ``"SII"``, ``"k-SII"``, ``"BV"``, and ``"BII"``.
+      polynomials by evaluation at participation probability 1/2, and the Moebius
+      coefficients by evaluation at 0. Supported indices:
+      ``"SV"``, ``"SII"``, ``"k-SII"``, ``"BV"``, ``"BII"``, and ``"Moebius"``.
 
     - In ``"interventional"`` mode an absent feature takes the values it has in a
       ``reference_dataset`` (background SHAP), computed by
@@ -174,7 +176,7 @@ class TreeExplainer(Explainer):
                 indices such as ``"k-SII"``. Defaults to ``0``.
 
             index: The type of interaction to be computed. In ``"pathdependent"`` mode, the
-                indices ``["SV", "SII", "k-SII", "BV", "BII"]`` are supported. In
+                indices ``["SV", "SII", "k-SII", "BV", "BII", "Moebius"]`` are supported. In
                 ``"interventional"`` mode, further indices such as ``"STII"``, ``"FSII"``, or
                 ``"FBII"`` can be computed. Defaults to ``"SV"``.
 
@@ -197,7 +199,9 @@ class TreeExplainer(Explainer):
             **kwargs: Additional keyword arguments are ignored.
 
         """
-        super().__init__(model, index=index, max_order=max_order)
+        # "Moebius" is only computed by TreeExplainer, so it is not part of the shared
+        # ``ExplainerIndices`` the base class (and the approximators) are typed with.
+        super().__init__(model, index=cast("ExplainerIndices", index), max_order=max_order)
 
         if min_order < 0 or min_order > self._max_order:
             msg = (
@@ -233,10 +237,25 @@ class TreeExplainer(Explainer):
             if reason is not None:
                 msg = f"backend='woodelf' cannot be used: {reason}."
                 raise ValueError(msg)
-        if mode == "pathdependent" and self.index not in ("SV", "SII", "k-SII", "BV", "BII"):
+        if mode == "pathdependent" and self.index not in (
+            "SV",
+            "SII",
+            "k-SII",
+            "BV",
+            "BII",
+            "Moebius",
+        ):
             msg = (
                 f"index='{self.index}' is not supported in 'pathdependent' mode; use "
                 "mode='interventional' with a reference_dataset."
+            )
+            raise ValueError(msg)
+        if mode == "interventional" and self.index == "Moebius":
+            # the interventional kernel has no Moebius leaf weight yet; only the
+            # path-dependent quadrature kernel computes this index.
+            msg = (
+                "index='Moebius' is not supported in 'interventional' mode; use "
+                "mode='pathdependent'."
             )
             raise ValueError(msg)
 
@@ -358,7 +377,17 @@ class TreeExplainer(Explainer):
         Returns:
             A human-readable reason, or ``None`` when Woodelf supports the configuration.
         """
-        if self.index not in ("SV", "BV", "SII", "k-SII", "BII", "STII", "FSII", "FBII"):
+        if self.index not in (
+            "SV",
+            "BV",
+            "SII",
+            "k-SII",
+            "BII",
+            "STII",
+            "FSII",
+            "FBII",
+            "Moebius",
+        ):
             return f"index='{self.index}' is not supported by Woodelf"
 
         cat_boost_classes = [
@@ -414,6 +443,7 @@ class TreeExplainer(Explainer):
                 FaithfulShapleyInteractionValues,
                 GeneralBanzhafInteractionValues,
                 GeneralShapleyInteractionValues,
+                MobiusCoefficients,
                 ShapleyTaylorInteractionValues,
                 ShapleyValues,
             )
@@ -436,6 +466,7 @@ class TreeExplainer(Explainer):
             "STII": ShapleyTaylorInteractionValues,
             "FSII": FaithfulShapleyInteractionValues,
             "FBII": FaithfulBanzhafInteractionValues,
+            "Moebius": MobiusCoefficients,
         }
         if self._index == "SV":
             metric = ShapleyValues()

--- a/src/shapiq/tree/explainer.py
+++ b/src/shapiq/tree/explainer.py
@@ -89,7 +89,8 @@ class TreeExplainer(Explainer):
     - In ``"interventional"`` mode an absent feature takes the values it has in a
       ``reference_dataset`` (background SHAP), computed by
       :class:`~shapiq.tree.interventional.computer.InterventionalTreeSHAPIQ`, which
-      additionally supports the ``"STII"``, ``"FSII"``, and ``"FBII"`` indices. Large
+      additionally supports the ``"STII"``, ``"FSII"``, and ``"FBII"`` indices. The
+      ``"Moebius"`` transform is available in both modes. Large
       interventional inputs are routed to the vectorized Woodelf and WOODELF-HD algorithms
       :cite:t:`Nadel.2026` :cite:t:`Wettenstein.2026b` when the optional
       ``woodelf-explainer`` package is installed (``pip install shapiq[tree]``); the
@@ -178,7 +179,7 @@ class TreeExplainer(Explainer):
             index: The type of interaction to be computed. In ``"pathdependent"`` mode, the
                 indices ``["SV", "SII", "k-SII", "BV", "BII", "Moebius"]`` are supported. In
                 ``"interventional"`` mode, further indices such as ``"STII"``, ``"FSII"``, or
-                ``"FBII"`` can be computed. Defaults to ``"SV"``.
+                ``"FBII"`` can be computed on top of those. Defaults to ``"SV"``.
 
             class_index: The class index of the model to explain. Defaults to ``None``, which will
                 set the class index to ``1`` per default for classification models and is ignored
@@ -248,14 +249,6 @@ class TreeExplainer(Explainer):
             msg = (
                 f"index='{self.index}' is not supported in 'pathdependent' mode; use "
                 "mode='interventional' with a reference_dataset."
-            )
-            raise ValueError(msg)
-        if mode == "interventional" and self.index == "Moebius":
-            # the interventional kernel has no Moebius leaf weight yet; only the
-            # path-dependent quadrature kernel computes this index.
-            msg = (
-                "index='Moebius' is not supported in 'interventional' mode; use "
-                "mode='pathdependent'."
             )
             raise ValueError(msg)
 

--- a/src/shapiq/tree/explainer.py
+++ b/src/shapiq/tree/explainer.py
@@ -358,7 +358,7 @@ class TreeExplainer(Explainer):
         Returns:
             A human-readable reason, or ``None`` when Woodelf supports the configuration.
         """
-        if self.index not in ("SV", "BV", "SII", "k-SII", "BII"):
+        if self.index not in ("SV", "BV", "SII", "k-SII", "BII", "STII", "FSII", "FBII"):
             return f"index='{self.index}' is not supported by Woodelf"
 
         cat_boost_classes = [
@@ -413,6 +413,9 @@ class TreeExplainer(Explainer):
                 GeneralBanzhafInteractionValues,
                 GeneralShapleyInteractionValues,
                 ShapleyValues,
+                FaithfulShapleyInteractionValues,
+                FaithfulBanzhafInteractionValues,
+                ShapleyTaylorInteractionValues
             )
             from woodelf.core.trees.parse_models import load_decision_tree_ensemble_model
             from woodelf.woodelf_sparse import hybrid_woodelf
@@ -425,16 +428,22 @@ class TreeExplainer(Explainer):
         if self._reference_dataset is not None and self.mode == "interventional":
             background_dataset = pd.DataFrame(self._reference_dataset)
 
+        index_to_metric_class = {
+            "SII": GeneralShapleyInteractionValues,
+            "k-SII": GeneralShapleyInteractionValues, # k-SII is a pure aggregation of SII, Woodelf computes the SII base values and
+            # ``_aggregate_batched_sii_to_ksii`` makes them k-SII
+            "BII": GeneralBanzhafInteractionValues,
+            "STII": ShapleyTaylorInteractionValues,
+            "FSII": FaithfulShapleyInteractionValues,
+            "FBII": FaithfulBanzhafInteractionValues
+        }
         if self._index == "SV":
             metric = ShapleyValues()
         elif self._index == "BV":
             metric = BanzhafValues()
-        elif self._index in ("SII", "k-SII"):
-            # k-SII is a pure aggregation of SII, Woodelf computes the SII base values and
-            # ``_aggregate_batched_sii_to_ksii`` makes them k-SII
-            metric = GeneralShapleyInteractionValues(max(self._min_order, 1), self._max_order)
-        elif self._index == "BII":
-            metric = GeneralBanzhafInteractionValues(max(self._min_order, 1), self._max_order)
+        elif self._index in index_to_metric_class:
+            metric_class = index_to_metric_class[self._index]
+            metric = metric_class(max(self._min_order, 1), self._max_order)
         else:  # pre-validated in __init__ / _woodelf_unsupported_reason; defensive
             msg = f"index='{self._index}' is not supported by Woodelf."
             raise ValueError(msg)

--- a/src/shapiq/tree/interventional/cext/cext.cc
+++ b/src/shapiq/tree/interventional/cext/cext.cc
@@ -107,6 +107,11 @@ static bool parse_index_type(const std::string &index, IndexType &index_type)
         index_type = IndexType::STII;
         return true;
     }
+    if (index == "Moebius")
+    {
+        index_type = IndexType::MOEBIUS;
+        return true;
+    }
     if (index == "CUSTOM")
     {
         index_type = IndexType::CUSTOM;
@@ -981,6 +986,7 @@ static void compute_order3_leafparallel(
         case IndexType::FBII: FUNC<IndexType::FBII>(__VA_ARGS__); break; \
         case IndexType::FSII: FUNC<IndexType::FSII>(__VA_ARGS__); break; \
         case IndexType::STII: FUNC<IndexType::STII>(__VA_ARGS__); break; \
+        case IndexType::MOEBIUS: FUNC<IndexType::MOEBIUS>(__VA_ARGS__); break; \
         case IndexType::CUSTOM: FUNC<IndexType::CUSTOM>(__VA_ARGS__); break; \
         } \
     } while(0)

--- a/src/shapiq/tree/interventional/cext/utils.cpp
+++ b/src/shapiq/tree/interventional/cext/utils.cpp
@@ -25,6 +25,7 @@ enum class IndexType
     FBII,
     FSII,
     STII,
+    MOEBIUS,
     CUSTOM
 };
 

--- a/src/shapiq/tree/interventional/cext/weights.cpp
+++ b/src/shapiq/tree/interventional/cext/weights.cpp
@@ -98,16 +98,23 @@ namespace inter_weights
         return w;
     }
 
+    inline double moebius_transform_weight(int64_t num_features, int64_t e, int64_t r, int64_t s_cap_e, int64_t s_cap_r, int64_t s, int64_t max_order)
+    {
+        // The Moebius coefficient of S is the discrete derivative at the empty coalition, so
+        // a leaf contributes to S only when S reaches it exactly: a.k.a when s_cap_e == e.
+        return (s_cap_e == e) ? signed_unit(s_cap_r) : 0.0;
+    }
+
     inline double stii_weight(int64_t num_features, int64_t e, int64_t r, int64_t s_cap_e, int64_t s_cap_r, int64_t s, int64_t max_order)
     {
         // Compute the lambda. Unlike the general path (which applies the top-order
         // discrete-derivative weight at every order), STII defines interactions of
-        // size s < max_order as the discrete derivative at the empty coalition:
-        // the leaf contributes iff E is contained in S, with sign (-1)^|S cap R|.
+        // size s < max_order as the discrete derivative at the empty coalition -- that is,
+        // exactly the Moebius transform.
         double w = 0.0;
         if (s < max_order)
         {
-            w = (s_cap_e == e) ? std::pow(-1.0, s_cap_r) : 0.0;
+            w = moebius_transform_weight(num_features, e, r, s_cap_e, s_cap_r, s, max_order);
         }
         else if (s == max_order)
         {
@@ -148,7 +155,7 @@ namespace inter_weights
         }
         throw std::invalid_argument("Unsupported index type in discrete_derivative_weight: " + std::to_string(static_cast<int>(index)));
     }
-    inline double moebius_weight(int64_t coalition_size, int64_t interaction_size, IndexType index)
+    inline double index_from_moebius_weight(int64_t coalition_size, int64_t interaction_size, IndexType index)
     {
         return discrete_derivative_weight(coalition_size - interaction_size, interaction_size, coalition_size, index);
     }
@@ -157,7 +164,7 @@ namespace inter_weights
         double w = 0.0;
         for (int k = 0; k <= r - s_cap_r; k++)
         {
-            w += std::pow(-1, k) * binom(r - s_cap_r, k) * moebius_weight(k + s_cap_r + e, s, index);
+            w += std::pow(-1, k) * binom(r - s_cap_r, k) * index_from_moebius_weight(k + s_cap_r + e, s, index);
         }
         return signed_unit(s_cap_r) * w;
     }
@@ -181,6 +188,8 @@ namespace inter_weights
             return fsii_weight(num_features, e, r, s_cap_e, s_cap_r, s, max_order);
         case IndexType::STII:
             return stii_weight(num_features, e, r, s_cap_e, s_cap_r, s, max_order);
+        case IndexType::MOEBIUS:
+            return moebius_transform_weight(num_features, e, r, s_cap_e, s_cap_r, s, max_order);
         default:
             return general_weight(num_features, e, r, s_cap_e, s_cap_r, s, max_order, index);
         }

--- a/src/shapiq/tree/interventional/computer.py
+++ b/src/shapiq/tree/interventional/computer.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from shapiq.tree.base import TreeModel
 
 InterventionalTreeSHAPIQIndices = Literal[
-    "SV", "SII", "k-SII", "BII", "BV", "CHII", "CV", "FBII", "FSII", "STII", "CUSTOM"
+    "SV", "SII", "k-SII", "BII", "BV", "CHII", "CV", "FBII", "FSII", "STII", "Moebius", "CUSTOM"
 ]
 
 

--- a/src/shapiq/tree/quadrature/computer.py
+++ b/src/shapiq/tree/quadrature/computer.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from shapiq.tree.base import DecisionType, TreeModel
     from shapiq.typing import Model
 
-QuadratureTreeSHAPIndices = Literal["SV", "SII", "k-SII", "BV", "BII"]
+QuadratureTreeSHAPIndices = Literal["SV", "SII", "k-SII", "BV", "BII", "Moebius"]
 
 
 def _collect_cooccurring_subsets(
@@ -98,7 +98,7 @@ class QuadratureTreeSHAP:
     which is numerically exact in float64 for any tree depth and any number of distinct
     features per decision path. Banzhaf indices (``"BV"``/``"BII"``) are obtained from the
     same computation by evaluating the polynomial at participation probability ``1/2``
-    instead of integrating.
+    instead of integrating, and ``"Moebius"`` by evaluating it at ``0``.
 
     The returned :class:`~shapiq.interaction_values.InteractionValues` enumerates exactly the
     interactions whose features co-occur on at least one decision path — every other
@@ -134,8 +134,8 @@ class QuadratureTreeSHAP:
                 to ``1``.
 
             index: The interaction index to compute. ``"SV"``, ``"SII"``, and ``"k-SII"`` are
-                computed from the SII base; ``"BV"`` and ``"BII"`` from the Banzhaf base.
-                Defaults to ``"SV"``.
+                computed from the SII base; ``"BV"`` and ``"BII"`` from the Banzhaf base;
+                ``"Moebius"`` returns the Moebius coefficients. Defaults to ``"SV"``.
 
             class_index: The class index for classification models. Defaults to ``None``.
 
@@ -145,8 +145,8 @@ class QuadratureTreeSHAP:
                 (the rule of Wettenstein et al.) is only useful on trees with more than ~16
                 features per path — below that the default already uses fewer points — where it
                 measured 13-35% faster with deviations from the exact result within ``2e-14``
-                up to ``d = 100``. Ignored for Banzhaf indices, which need a single evaluation
-                point.
+                up to ``d = 100``. Ignored for the Banzhaf indices and the Moebius transform,
+                which need a single evaluation point.
 
         Raises:
             ValueError: If the index or the interaction orders are invalid.
@@ -321,13 +321,14 @@ class QuadratureTreeSHAP:
         self._arrays = {key: np.concatenate(arrs) for key, arrs in parts.items()}
         self._decision_type: DecisionType = self._trees[0].decision_type
 
-        # quadrature rule: exact for the degree-(d - order) integrands; Banzhaf indices are a
-        # single evaluation of the weighted Banzhaf polynomial at p = 1/2
+        # quadrature rule: exact for the degree-(d - order) integrands. Banzhaf indices and the
+        # Moebius transform are single evaluations of the weighted Banzhaf polynomial, at
+        # p = 1/2 and p = 0 respectively.
         if n_quadrature_points is not None and n_quadrature_points < 1:
             msg = f"n_quadrature_points={n_quadrature_points} must be a positive integer."
             raise ValueError(msg)
-        if self._base_index == "BII":
-            self._t = np.array([0.5])
+        if self._base_index in ("BII", "Moebius"):
+            self._t = np.array([0.5 if self._base_index == "BII" else 0.0])
             self._w = np.array([1.0])
         else:
             n_points = n_quadrature_points

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_correct_calculation.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_correct_calculation.py
@@ -9,21 +9,33 @@ from shapiq.tree import InterventionalGame, InterventionalTreeSHAPIQ
 SEED = 1337
 np.random.seed(SEED)
 
+# ``(index, max_order)`` pairs each interventional kernel result is checked against the
+# ExactComputer oracle with. The single-tree regressor below only runs the order-<= 2 half.
+INDICES_AND_ORDERS_UP_TO_2 = [
+    ("SV", 1),
+    ("BV", 1),
+    ("FBII", 1),
+    ("SII", 2),
+    ("BII", 2),
+    ("CHII", 2),
+    ("FBII", 2),
+    ("FSII", 2),
+    ("STII", 2),
+    ("Moebius", 2),
+]
+INDICES_AND_ORDERS = [
+    *INDICES_AND_ORDERS_UP_TO_2,
+    ("SII", 3),
+    ("BII", 3),
+    ("CHII", 3),
+    ("FBII", 3),
+    ("FSII", 3),
+    ("STII", 3),
+    ("Moebius", 3),
+]
 
-@pytest.mark.parametrize(
-    ("index", "order"),
-    [
-        ("SV", 1),
-        ("BV", 1),
-        ("SII", 2),
-        ("BII", 2),
-        ("CHII", 2),
-        ("FBII", 2),
-        ("FBII", 1),
-        ("FSII", 2),
-        ("STII", 2),
-    ],
-)
+
+@pytest.mark.parametrize(("index", "order"), INDICES_AND_ORDERS_UP_TO_2)
 def test_correct_calculation_dt_reg_index_order(dt_reg_model, reg_data, index, order):
     X_train, X_test, _y_train, _y_test = reg_data
     model = dt_reg_model
@@ -52,26 +64,7 @@ def test_correct_calculation_dt_reg_index_order(dt_reg_model, reg_data, index, o
             )
 
 
-@pytest.mark.parametrize(
-    ("index", "order"),
-    [
-        ("SV", 1),
-        ("BV", 1),
-        ("FBII", 1),
-        ("SII", 2),
-        ("BII", 2),
-        ("CHII", 2),
-        ("FBII", 2),
-        ("FSII", 2),
-        ("STII", 2),
-        ("SII", 3),
-        ("BII", 3),
-        ("CHII", 3),
-        ("FBII", 3),
-        ("FSII", 3),
-        ("STII", 3),
-    ],
-)
+@pytest.mark.parametrize(("index", "order"), INDICES_AND_ORDERS)
 def test_correct_calculation_dt_clas_index_order(dt_clf_model, cls_data, index, order):
     CLASS_INDEX = 1
     X_train, X_test, _, _ = cls_data
@@ -108,26 +101,7 @@ def test_correct_calculation_dt_clas_index_order(dt_clf_model, cls_data, index, 
             )
 
 
-@pytest.mark.parametrize(
-    ("index", "order"),
-    [
-        ("SV", 1),
-        ("BV", 1),
-        ("FBII", 1),
-        ("SII", 2),
-        ("BII", 2),
-        ("CHII", 2),
-        ("FBII", 2),
-        ("FSII", 2),
-        ("STII", 2),
-        ("SII", 3),
-        ("BII", 3),
-        ("CHII", 3),
-        ("FBII", 3),
-        ("FSII", 3),
-        ("STII", 3),
-    ],
-)
+@pytest.mark.parametrize(("index", "order"), INDICES_AND_ORDERS)
 def test_correct_calculation_rf_reg_index_order(rf_reg_model, reg_data, index, order):
     X_train, X_test, _y_train, _y_test = reg_data
     model = rf_reg_model
@@ -156,26 +130,7 @@ def test_correct_calculation_rf_reg_index_order(rf_reg_model, reg_data, index, o
             )
 
 
-@pytest.mark.parametrize(
-    ("index", "order"),
-    [
-        ("SV", 1),
-        ("BV", 1),
-        ("FBII", 1),
-        ("SII", 2),
-        ("BII", 2),
-        ("CHII", 2),
-        ("FBII", 2),
-        ("FSII", 2),
-        ("STII", 2),
-        ("SII", 3),
-        ("BII", 3),
-        ("CHII", 3),
-        ("FBII", 3),
-        ("FSII", 3),
-        ("STII", 3),
-    ],
-)
+@pytest.mark.parametrize(("index", "order"), INDICES_AND_ORDERS)
 def test_correct_calculation_rf_clas_index_order(rf_clf_model, cls_data, index, order):
     CLASS_INDEX = 1
     X_train, X_test, _, _ = cls_data
@@ -212,26 +167,7 @@ def test_correct_calculation_rf_clas_index_order(rf_clf_model, cls_data, index, 
             )
 
 
-@pytest.mark.parametrize(
-    ("index", "order"),
-    [
-        ("SV", 1),
-        ("BV", 1),
-        ("FBII", 1),
-        ("SII", 2),
-        ("BII", 2),
-        ("CHII", 2),
-        ("FBII", 2),
-        ("FSII", 2),
-        ("STII", 2),
-        ("SII", 3),
-        ("BII", 3),
-        ("CHII", 3),
-        ("FBII", 3),
-        ("FSII", 3),
-        ("STII", 3),
-    ],
-)
+@pytest.mark.parametrize(("index", "order"), INDICES_AND_ORDERS)
 def test_correct_calculation_xgb_reg_index_order(xgb_reg_model, reg_data, index, order):
     X_train, X_test, _, _ = reg_data
     model = xgb_reg_model
@@ -261,26 +197,7 @@ def test_correct_calculation_xgb_reg_index_order(xgb_reg_model, reg_data, index,
             )
 
 
-@pytest.mark.parametrize(
-    ("index", "order"),
-    [
-        ("SV", 1),
-        ("BV", 1),
-        ("FBII", 1),
-        ("SII", 2),
-        ("BII", 2),
-        ("CHII", 2),
-        ("FBII", 2),
-        ("FSII", 2),
-        ("STII", 2),
-        ("SII", 3),
-        ("BII", 3),
-        ("CHII", 3),
-        ("FBII", 3),
-        ("FSII", 3),
-        ("STII", 3),
-    ],
-)
+@pytest.mark.parametrize(("index", "order"), INDICES_AND_ORDERS)
 def test_correct_calculation_xgb_clas_index_order(xgb_clf_model, cls_data, index, order):
     CLASS_INDEX = 1
     X_train, X_test, _y_train, _y_test = cls_data
@@ -317,26 +234,7 @@ def test_correct_calculation_xgb_clas_index_order(xgb_clf_model, cls_data, index
             )
 
 
-@pytest.mark.parametrize(
-    ("index", "order"),
-    [
-        ("SV", 1),
-        ("BV", 1),
-        ("FBII", 1),
-        ("SII", 2),
-        ("BII", 2),
-        ("CHII", 2),
-        ("FBII", 2),
-        ("FSII", 2),
-        ("STII", 2),
-        ("SII", 3),
-        ("BII", 3),
-        ("CHII", 3),
-        ("FBII", 3),
-        ("FSII", 3),
-        ("STII", 3),
-    ],
-)
+@pytest.mark.parametrize(("index", "order"), INDICES_AND_ORDERS)
 def test_correct_calculation_lgbm_reg_index_order(lightgbm_reg_model, reg_data, index, order):
     X_train, X_test, _y_train, _y_test = reg_data
     model = lightgbm_reg_model
@@ -365,26 +263,7 @@ def test_correct_calculation_lgbm_reg_index_order(lightgbm_reg_model, reg_data, 
             )
 
 
-@pytest.mark.parametrize(
-    ("index", "order"),
-    [
-        ("SV", 1),
-        ("BV", 1),
-        ("FBII", 1),
-        ("SII", 2),
-        ("BII", 2),
-        ("CHII", 2),
-        ("FBII", 2),
-        ("FSII", 2),
-        ("STII", 2),
-        ("SII", 3),
-        ("BII", 3),
-        ("CHII", 3),
-        ("FBII", 3),
-        ("FSII", 3),
-        ("STII", 3),
-    ],
-)
+@pytest.mark.parametrize(("index", "order"), INDICES_AND_ORDERS)
 def test_correct_calculation_lgbm_clas_index_order(lightgbm_clf_model, cls_data, index, order):
     CLASS_INDEX = 1
     X_train, X_test, _, _ = cls_data
@@ -421,7 +300,7 @@ def test_correct_calculation_lgbm_clas_index_order(lightgbm_clf_model, cls_data,
             )
 
 
-@pytest.mark.parametrize(("index", "order"), [("STII", 4), ("FSII", 4)])
+@pytest.mark.parametrize(("index", "order"), [("STII", 4), ("FSII", 4), ("Moebius", 4)])
 def test_correct_calculation_sparse_path_index_order(dt_reg_model, reg_data, index, order):
     """Indices with any-order closed forms match the ExactComputer on the sparse C kernel.
 

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -984,6 +984,8 @@ def deep_dt_reg_model(background_reg_dataset):
 
 
 _WOODELF_INTERVENTIONAL_INDICES = ["SII", "BII", "STII", "FSII", "FBII"]
+# As shapiq backend does not support path-dependent STII, FSII, FBII, 
+# only SII and BII are tested for path-dependent mode.
 _WOODELF_PATHDEPENDENT_INDICES = ["SII", "BII"]
 
 

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -983,7 +983,7 @@ def deep_dt_reg_model(background_reg_dataset):
     return DecisionTreeRegressor(random_state=42, max_depth=6).fit(X, y)
 
 
-_WOODELF_INTERVENTIONAL_INDICES = ["SII", "BII", "STII", "FSII", "FBII"]
+_WOODELF_INTERVENTIONAL_INDICES = ["SII", "BII", "STII", "FSII", "FBII", "Moebius"]
 # As the shapiq backend does not support path-dependent STII, FSII and FBII,
 # only SII, BII and Moebius are tested for path-dependent mode.
 _WOODELF_PATHDEPENDENT_INDICES = ["SII", "BII", "Moebius"]

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -984,7 +984,7 @@ def deep_dt_reg_model(background_reg_dataset):
 
 
 _WOODELF_INTERVENTIONAL_INDICES = ["SII", "BII", "STII", "FSII", "FBII"]
-# As shapiq backend does not support path-dependent STII, FSII, FBII, 
+# As the shapiq backend does not support path-dependent STII, FSII and FBII,
 # only SII and BII are tested for path-dependent mode.
 _WOODELF_PATHDEPENDENT_INDICES = ["SII", "BII"]
 

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -968,40 +968,104 @@ def test_explain_X_returns_interaction_values_batch(rf_reg_model, background_reg
             )
 
 
-def test_woodelf_pathdependent_matches_treeshapiq(dt_reg_model, background_reg_data):
-    """Forced path-dependent Woodelf SII with ``min_order=0``, ``max_order=3`` matches shapiq.
+@pytest.fixture
+def deep_dt_reg_model(background_reg_dataset):
+    """A decision tree deep enough that its Moebius sets exceed ``max_order=3``.
 
-    Orders 1-3 must match :class:`TreeSHAPIQ` run directly per tree, and ``min_order=0``
-    must still put the baseline at the empty interaction.
+    The shared depth-3 fixtures cannot tell the interaction indices apart: when no Moebius set
+    is larger than ``max_order``, STII, FSII and FBII all reduce to the plain Moebius transform
+    and become numerically identical. Depth 6 separates them while staying under the depth-16
+    limit of Woodelf's path-dependent kernel.
     """
-    from shapiq.tree import TreeSHAPIQ
-    from shapiq.tree.validation import validate_tree_model
+    from sklearn.tree import DecisionTreeRegressor
 
-    pytest.importorskip("woodelf")
-    x_explain = background_reg_data[0]
+    X, y = background_reg_dataset
+    return DecisionTreeRegressor(random_state=42, max_depth=6).fit(X, y)
 
-    explainer = TreeExplainer(
-        model=dt_reg_model, max_order=3, min_order=0, index="SII", backend="woodelf"
-    )
-    assert explainer._should_use_woodelf(1)  # guard: Woodelf, not the fallback
-    explanation = explainer.explain(x_explain)
 
-    per_tree = [
-        TreeSHAPIQ(model=tree, max_order=3, index="SII").explain(x_explain)
-        for tree in validate_tree_model(dt_reg_model)
-    ]
-    reference = sum(per_tree[1:], start=per_tree[0])
+_WOODELF_INTERVENTIONAL_INDICES = ["SII", "BII", "STII", "FSII", "FBII"]
+_WOODELF_PATHDEPENDENT_INDICES = ["SII", "BII"]
 
-    assert explanation.min_order == 0
-    assert explanation.max_order == 3
-    assert explanation[()] == pytest.approx(explainer.baseline_value)
+
+def _assert_woodelf_matches_shapiq(
+    woodelf_explainer, shapiq_explainer, x_explain, index, min_order, max_order
+):
+    """Assert the two explainers explain ``x_explain`` the same way.
+    """
+    assert woodelf_explainer._should_use_woodelf(1)  # guard: Woodelf on one side ...
+    assert not shapiq_explainer._should_use_woodelf(1)  # ... and the shapiq kernel on the other
+
+    explanation = woodelf_explainer.explain(x_explain)
+    reference_explanation = shapiq_explainer.explain(x_explain)
+
+    assert explanation.index == index
+    assert explanation.min_order == min_order
+    assert explanation.max_order == max_order
+    assert explanation[()] == pytest.approx(woodelf_explainer.baseline_value)
 
     # a subset missing on one side is an exact zero there, so compare over the union
-    interactions = set(explanation.interactions) | set(reference.interactions)
-    assert {len(interaction) for interaction in interactions} == {0, 1, 2, 3}
+    interactions = set(explanation.interactions) | set(reference_explanation.interactions)
+    assert {len(interaction) for interaction in interactions} == set(range(max_order + 1))
     for interaction in interactions:
         if interaction:  # skip the empty interaction, checked against the baseline above
-            assert explanation[interaction] == pytest.approx(reference[interaction], abs=1e-5)
+            assert explanation[interaction] == pytest.approx(
+                reference_explanation[interaction], abs=1e-5
+            )
+
+
+@pytest.mark.parametrize("index", _WOODELF_PATHDEPENDENT_INDICES)
+def test_woodelf_pathdependent_matches_shapiq(deep_dt_reg_model, background_reg_data, index):
+    """Forced path-dependent Woodelf with ``min_order=0``, ``max_order=3`` matches shapiq.
+    """
+    pytest.importorskip("woodelf")
+    woodelf_explainer = TreeExplainer(
+        model=deep_dt_reg_model, max_order=3, min_order=0, index=index, backend="woodelf"
+    )
+    shap_explainer = TreeExplainer(
+        model=deep_dt_reg_model, max_order=3, min_order=0, index=index, backend="shapiq"
+    )
+    _assert_woodelf_matches_shapiq(
+        woodelf_explainer,
+        shap_explainer,
+        background_reg_data[0],
+        index=index,
+        min_order=0,
+        max_order=3,
+    )
+
+
+@pytest.mark.parametrize("index", _WOODELF_INTERVENTIONAL_INDICES)
+def test_woodelf_interventional_matches_shapiq(deep_dt_reg_model, background_reg_data, index):
+    """Forced interventional Woodelf with ``min_order=0``, ``max_order=3`` matches shapiq.
+    """
+    pytest.importorskip("woodelf")
+    reference_dataset = background_reg_data[:10]
+    woodelf_explainer = TreeExplainer(
+        model=deep_dt_reg_model,
+        mode="interventional",
+        reference_dataset=reference_dataset,
+        max_order=3,
+        min_order=0,
+        index=index,
+        backend="woodelf",
+    )
+    shap_explainer = TreeExplainer(
+        model=deep_dt_reg_model,
+        mode="interventional",
+        reference_dataset=reference_dataset,
+        max_order=3,
+        min_order=0,
+        index=index,
+        backend="shapiq",
+    )
+    _assert_woodelf_matches_shapiq(
+        woodelf_explainer,
+        shap_explainer,
+        background_reg_data[10],
+        index=index,
+        min_order=0,
+        max_order=3,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -985,8 +985,8 @@ def deep_dt_reg_model(background_reg_dataset):
 
 _WOODELF_INTERVENTIONAL_INDICES = ["SII", "BII", "STII", "FSII", "FBII"]
 # As the shapiq backend does not support path-dependent STII, FSII and FBII,
-# only SII and BII are tested for path-dependent mode.
-_WOODELF_PATHDEPENDENT_INDICES = ["SII", "BII"]
+# only SII, BII and Moebius are tested for path-dependent mode.
+_WOODELF_PATHDEPENDENT_INDICES = ["SII", "BII", "Moebius"]
 
 
 def _assert_woodelf_matches_shapiq(
@@ -1009,8 +1009,9 @@ def _assert_woodelf_matches_shapiq(
     assert {len(interaction) for interaction in interactions} == set(range(max_order + 1))
     for interaction in interactions:
         if interaction:  # skip the empty interaction, checked against the baseline above
+            # Woodelf accumulates in float32, so large values need the relative bound
             assert explanation[interaction] == pytest.approx(
-                reference_explanation[interaction], abs=1e-5
+                reference_explanation[interaction], abs=1e-5, rel=1e-6
             )
 
 

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_explainer.py
@@ -990,8 +990,7 @@ _WOODELF_PATHDEPENDENT_INDICES = ["SII", "BII"]
 def _assert_woodelf_matches_shapiq(
     woodelf_explainer, shapiq_explainer, x_explain, index, min_order, max_order
 ):
-    """Assert the two explainers explain ``x_explain`` the same way.
-    """
+    """Assert the two explainers explain ``x_explain`` the same way."""
     assert woodelf_explainer._should_use_woodelf(1)  # guard: Woodelf on one side ...
     assert not shapiq_explainer._should_use_woodelf(1)  # ... and the shapiq kernel on the other
 
@@ -1015,8 +1014,7 @@ def _assert_woodelf_matches_shapiq(
 
 @pytest.mark.parametrize("index", _WOODELF_PATHDEPENDENT_INDICES)
 def test_woodelf_pathdependent_matches_shapiq(deep_dt_reg_model, background_reg_data, index):
-    """Forced path-dependent Woodelf with ``min_order=0``, ``max_order=3`` matches shapiq.
-    """
+    """Forced path-dependent Woodelf with ``min_order=0``, ``max_order=3`` matches shapiq."""
     pytest.importorskip("woodelf")
     woodelf_explainer = TreeExplainer(
         model=deep_dt_reg_model, max_order=3, min_order=0, index=index, backend="woodelf"
@@ -1036,8 +1034,7 @@ def test_woodelf_pathdependent_matches_shapiq(deep_dt_reg_model, background_reg_
 
 @pytest.mark.parametrize("index", _WOODELF_INTERVENTIONAL_INDICES)
 def test_woodelf_interventional_matches_shapiq(deep_dt_reg_model, background_reg_data, index):
-    """Forced interventional Woodelf with ``min_order=0``, ``max_order=3`` matches shapiq.
-    """
+    """Forced interventional Woodelf with ``min_order=0``, ``max_order=3`` matches shapiq."""
     pytest.importorskip("woodelf")
     reference_dataset = background_reg_data[:10]
     woodelf_explainer = TreeExplainer(

--- a/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_quadrature.py
+++ b/tests/shapiq/tests_unit/tests_explainer/tests_tree_explainer/test_tree_quadrature.py
@@ -197,20 +197,26 @@ def _game_value(paths, coalition):
     return total
 
 
-def _brute_interaction(paths, n_features, subset, *, banzhaf):
+def _coalition_weight(index, n_features, order, size):
+    """Weight of a coalition of ``size`` players outside an ``order``-sized subset."""
+    if index == "BII":
+        return 1.0 / 2 ** (n_features - order)
+    if index == "Moebius":  # the Moebius coefficient is the discrete derivative at {}
+        return 1.0 if size == 0 else 0.0
+    return (
+        factorial(size) * factorial(n_features - order - size) / factorial(n_features - order + 1)
+    )
+
+
+def _brute_interaction(paths, n_features, subset, *, index):
     subset = set(subset)
     order = len(subset)
     others = [f for f in range(n_features) if f not in subset]
     total = 0.0
     for size in range(len(others) + 1):
-        if banzhaf:
-            weight = 1.0 / 2 ** (n_features - order)
-        else:
-            weight = (
-                factorial(size)
-                * factorial(n_features - order - size)
-                / factorial(n_features - order + 1)
-            )
+        weight = _coalition_weight(index, n_features, order, size)
+        if weight == 0.0:
+            continue
         for coalition in combinations(others, size):
             derivative = 0.0
             for included in range(order + 1):
@@ -222,9 +228,9 @@ def _brute_interaction(paths, n_features, subset, *, banzhaf):
 
 
 @pytest.mark.parametrize("implementation", IMPLEMENTATIONS)
-@pytest.mark.parametrize("index", ["SII", "BII"])
+@pytest.mark.parametrize("index", ["SII", "BII", "Moebius"])
 def test_matches_brute_force_interactions(index, implementation):
-    """Quadrature SII and BII match exact brute-force enumeration on a small tree."""
+    """Quadrature SII, BII and Moebius match exact brute-force enumeration on a small tree."""
     rng = np.random.default_rng(0)
     X = rng.random((400, 5))
     y = X @ rng.normal(size=5) + np.sin(9 * X[:, 0]) * X[:, 1]
@@ -233,7 +239,7 @@ def test_matches_brute_force_interactions(index, implementation):
     paths = _paths_of_tree(model, x)
     result = _explain(QuadratureTreeSHAP(model, max_order=3, index=index), x, implementation)
     for subset in _all_interactions(5, 1, 3):
-        expected = _brute_interaction(paths, 5, subset, banzhaf=index == "BII")
+        expected = _brute_interaction(paths, 5, subset, index=index)
         assert result[subset] == pytest.approx(expected, abs=1e-12)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3908,7 +3908,7 @@ requires-dist = [
     { name = "tabpfn", marker = "extra == 'benchmark'" },
     { name = "torch", marker = "extra == 'shapleig'", specifier = ">=2.9.1" },
     { name = "tqdm" },
-    { name = "woodelf-explainer", marker = "extra == 'tree'", specifier = ">=0.4.6" },
+    { name = "woodelf-explainer", marker = "extra == 'tree'", specifier = ">=0.4.7" },
     { name = "xgboost", marker = "extra == 'benchmark'" },
     { name = "xgboost", marker = "extra == 'proxy'" },
 ]
@@ -4822,7 +4822,7 @@ wheels = [
 
 [[package]]
 name = "woodelf-explainer"
-version = "0.4.6"
+version = "0.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -4831,9 +4831,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "treelite" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/62/2bc67e6a2d56835d81aa8256086246d63d421e49fab48d81a8cfc69ce442/woodelf_explainer-0.4.6.tar.gz", hash = "sha256:6ec24ba8290d2e545bc28e30cdbf77da34f77b944db2c1f0c5c740ed7fb9f7ca", size = 82701, upload-time = "2026-08-12T10:36:33.568Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/80/dec757c306feef43e085fc525151b020f64d84a9028c0e30c776c10650db/woodelf_explainer-0.4.7.tar.gz", hash = "sha256:6bee99036ca1185624c595901f90cbeabd240218a4921e48ca2312ef37e7d334", size = 85658, upload-time = "2026-08-31T15:58:27.273Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/9c/9beb79b75a87a99f260a6534af404ed6d695d1d9662ecbc7abc1077c36d0/woodelf_explainer-0.4.6-py3-none-any.whl", hash = "sha256:827d014f2d5753d5a337db1a207e2aed1c40c8142e27f771cddefe751ad19c13", size = 82795, upload-time = "2026-08-12T10:36:32.317Z" },
+    { url = "https://files.pythonhosted.org/packages/20/19/c21aabfc28cd6c06a266669d49d7033765232580d61ed3922b27a89ba5f9/woodelf_explainer-0.4.7-py3-none-any.whl", hash = "sha256:e7bd9946810b8f09efe4387e566ae368312d1824ca4831b9d179e07205f7d7af", size = 84461, upload-time = "2026-08-31T15:58:26.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Motivation and Context

TreeExplainer now supports also the "Mobius" index.
Notes:
1. This branch was created from the feature/woodelf_stii_fsii_fbii branch. Both touch similar parts of the code and I wanted to avoid conflicts. So this PR include also the code added in #595. We should first merge the #595 PR and then review this PR.
2. I added Mobius to the supported indices of TreeExplainer. It is not part of the supported indices in the base Explainer class though. I do some casting when calling the super __init__. It this the right behaviour? Do we want to add Mobius to the base Exaplainer class, and maybe use the opportunity to support in in more explainers (It seems that in TabularExplainer Mobius will be easy to compute exactly but hard to estimate, lets talk about it). 


---

## Public API Changes

-   [ ] No Public API changes
-   [X] Yes, Public API changes (Details below)

TreeExplainer now support index="Mobius"

---

## How Has This Been Tested?
Manually and with tests. The test check the QuadratureTreeSHAP and IntervantaionalTreeSHAP implementation and compare it to Woodelf.

---

## Checklist

-   [X] The changes have been tested locally.
-   [X] Documentation has been updated (if the public API or usage changes).
-   [ ] An entry has been added to `CHANGELOG.md` (if relevant for users).
-   [X] The code follows the project's style guidelines.
-   [X] I have considered the impact of these changes on the public API.

---
