### PR TITLE
Feature/quadra product kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 `ProductKernelComputer` now computes Shapley values by Gauss-Legendre quadrature of the product-game integral (Mohammadi et al., 2026) instead of the elementary-symmetric-polynomial recursion of PKeX-Shapley (Mohammadi et al., 2025).
 This reduces the cost per explained instance from `O(n d^3)` to `O(n d^2)`, where `n` is the number of reference points (the support vectors of an SVM, the training set of a Gaussian process) and `d` the number of features.
-In practice we measure speedups of 17x, 26x, 50x and 91x for models with `d = 20, 40, 80, 160` respectively.
+In practice we measure speedups of 27x, 37x, 53x and 95x on the Shapley computation for models with `d = 20, 40, 80, 160` respectively.
 
 The new `n_quadrature_points` argument on `ProductKernelExplainer` and `ProductKernelComputer` trades exactness for speed with a geometrically decaying error; it defaults to the exact bound.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v1.7.1 (TBD)
+
+### QuadraSHAP for `ProductKernelExplainer`
+
+`ProductKernelComputer` now computes Shapley values by Gauss-Legendre quadrature of the product-game integral (Mohammadi et al., 2026) instead of the elementary-symmetric-polynomial recursion of PKeX-Shapley (Mohammadi et al., 2025).
+This reduces the cost per explained instance from `O(n d^3)` to `O(n d^2)`, where `n` is the number of reference points (the support vectors of an SVM, the training set of a Gaussian process) and `d` the number of features.
+In practice we measure speedups of 17x, 26x, 50x and 91x for models with `d = 20, 40, 80, 160` respectively.
+
+The new `n_quadrature_points` argument on `ProductKernelExplainer` and `ProductKernelComputer` trades exactness for speed with a geometrically decaying error; it defaults to the exact bound.
+
+**Public API change:** `ProductKernelComputer.compute_kernel_vectors`, `.compute_shapley_value`, `.compute_elementary_symmetric_polynomials`, and `.precompute_weights` are removed, replaced by `.compute_kernel_matrix(x)` and `.compute_shapley_values(x)`, which return the `(n, d)` kernel factors and all `d` Shapley values at once.
+`ProductKernelExplainer` itself is unchanged.
+
 ## v1.7.0 (2026-08-27)
 
 ### New and Improved Tree support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@
 This reduces the cost per explained instance from `O(n d^3)` to `O(n d^2)`, where `n` is the number of reference points (the support vectors of an SVM, the training set of a Gaussian process) and `d` the number of features.
 In practice we measure speedups of 27x, 37x, 53x and 95x on the Shapley computation for models with `d = 20, 40, 80, 160` respectively.
 
+`ProductKernelExplainer` now also computes Banzhaf values (`index="BV"`, previously `"SV"` only).
+
 The new `n_quadrature_points` argument on `ProductKernelExplainer` and `ProductKernelComputer` trades exactness for speed with a geometrically decaying error; it defaults to the exact bound.
 
-**Public API change:** `ProductKernelComputer.compute_kernel_vectors`, `.compute_shapley_value`, `.compute_elementary_symmetric_polynomials`, and `.precompute_weights` are removed, replaced by `.compute_kernel_matrix(x)` and `.compute_shapley_values(x)`, which return the `(n, d)` kernel factors and all `d` Shapley values at once.
+**Public API change:** `ProductKernelComputer.compute_kernel_vectors`, `.compute_shapley_value`, `.compute_elementary_symmetric_polynomials`, and `.precompute_weights` are removed, replaced by `.compute_kernel_matrix(x)` and `.compute_values(x)`, which return the `(n, d)` kernel factors and all `d` values at once.
 `ProductKernelExplainer` itself is unchanged.
 
 ## v1.7.0 (2026-08-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@
 This reduces the cost per explained instance from `O(n d^3)` to `O(n d^2)`, where `n` is the number of reference points (the support vectors of an SVM, the training set of a Gaussian process) and `d` the number of features.
 In practice we measure speedups of 27x, 37x, 53x and 95x on the Shapley computation for models with `d = 20, 40, 80, 160` respectively.
 
-`ProductKernelExplainer` now also computes Banzhaf values (`index="BV"`, previously `"SV"` only).
+`ProductKernelExplainer` now computes `"BV"`, `"SII"`, `"k-SII"`, `"BII"` and `"Moebius"`. It previously computed only `"SV"` at order 1.
 
 The new `n_quadrature_points` argument on `ProductKernelExplainer` and `ProductKernelComputer` trades exactness for speed with a geometrically decaying error; it defaults to the exact bound.
 
-**Public API change:** `ProductKernelComputer.compute_kernel_vectors`, `.compute_shapley_value`, `.compute_elementary_symmetric_polynomials`, and `.precompute_weights` are removed, replaced by `.compute_kernel_matrix(x)` and `.compute_values(x)`, which return the `(n, d)` kernel factors and all `d` values at once.
-`ProductKernelExplainer` itself is unchanged.
+**Public API change:** `ProductKernelComputer.compute_kernel_vectors`, `.compute_shapley_value`, `.compute_elementary_symmetric_polynomials`, and `.precompute_weights` are removed, replaced by `.compute_kernel_matrix(x)` and `.compute_values(x)`, which return the `(n, d)` kernel factors and all `d` first-order values at once. Interactions of order two and above come from the new `.compute_interaction_values(x)`, which returns a mapping from each feature subset to its value.
+`ProductKernelExplainer` keeps its signature and gains the `index`, `max_order` and `n_quadrature_points` options described above.
 
 ## v1.7.0 (2026-08-27)
 

--- a/src/shapiq/explainer/custom_types.py
+++ b/src/shapiq/explainer/custom_types.py
@@ -6,4 +6,4 @@ from typing import Literal
 
 ExplainerIndices = Literal["SV", "SII", "k-SII", "STII", "FSII", "BV", "BII", "FBII"]
 ValidNNExplainerIndices = Literal["SV"]
-ValidProductKernelExplainerIndices = Literal["SV"]
+ValidProductKernelExplainerIndices = Literal["SV", "BV", "SII", "k-SII", "BII", "Moebius"]

--- a/src/shapiq/explainer/product_kernel/__init__.py
+++ b/src/shapiq/explainer/product_kernel/__init__.py
@@ -2,6 +2,11 @@
 
 from .base import ProductKernelModel
 from .explainer import ProductKernelExplainer
-from .product_kernel import ProductKernelComputer
+from .product_kernel import ProductKernelComputer, ProductKernelInteractionSizeWarning
 
-__all__ = ["ProductKernelModel", "ProductKernelExplainer", "ProductKernelComputer"]
+__all__ = [
+    "ProductKernelComputer",
+    "ProductKernelExplainer",
+    "ProductKernelInteractionSizeWarning",
+    "ProductKernelModel",
+]

--- a/src/shapiq/explainer/product_kernel/explainer.py
+++ b/src/shapiq/explainer/product_kernel/explainer.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from shapiq import InteractionValues
 from shapiq.explainer.base import Explainer
+from shapiq.explainer.custom_types import ExplainerIndices
 from shapiq.game_theory import get_computation_index
 
 from .product_kernel import ProductKernelComputer, ProductKernelSHAPIQIndices
@@ -81,16 +82,12 @@ class ProductKernelExplainer(Explainer):
             **kwargs: Additional keyword arguments are ignored.
 
         """
-        if max_order > 1:
-            msg = "ProductKernelExplainer currently only supports max_order=1."
+        super().__init__(model, index=cast("ExplainerIndices", index), max_order=max_order)
+
+        if min_order > self._max_order:
+            msg = f"min_order must not exceed max_order, got {min_order=}, {self._max_order=}."
             raise ValueError(msg)
-
-        super().__init__(model, index=index, max_order=max_order)
-
         self._min_order = min_order
-        self._max_order = max_order
-
-        self._index = index
         self._base_index: str = get_computation_index(self._index)
 
         # validate model
@@ -98,8 +95,10 @@ class ProductKernelExplainer(Explainer):
 
         self.explainer = ProductKernelComputer(
             model=self.converted_model,
-            max_order=max_order,
-            index=index,
+            max_order=self._max_order,
+            min_order=min_order,
+            # the computer re-checks this at runtime and rejects unsupported indices
+            index=cast("ProductKernelSHAPIQIndices", self._index),
             n_quadrature_points=n_quadrature_points,
         )
 
@@ -121,11 +120,15 @@ class ProductKernelExplainer(Explainer):
         """
         n_players = self.converted_model.d
 
-        values = self.explainer.compute_values(x)
-        attributions = {(j,): float(values[j]) for j in range(n_players)}
+        if self._max_order == 1:
+            # the first-order route skips building the subset lattice altogether
+            values = self.explainer.compute_values(x)
+            interactions = {(player,): float(values[player]) for player in range(n_players)}
+        else:
+            interactions = self.explainer.compute_interaction_values(x)
 
         return InteractionValues(
-            values=attributions,
+            values=interactions,
             index=self._base_index,
             min_order=self._min_order,
             max_order=self.max_order,

--- a/src/shapiq/explainer/product_kernel/explainer.py
+++ b/src/shapiq/explainer/product_kernel/explainer.py
@@ -25,11 +25,11 @@ class ProductKernelExplainer(Explainer):
     """The ProductKernelExplainer class for product kernel-based models.
 
     The ProductKernelExplainer can be used with a variety of product kernel-based models. The explainer can handle both regression and
-    classification models. See [pkex-shapley]_ for details.
+    classification models. See [quadrashap]_ for details.
 
 
     References:
-        .. [pkex-shapley] Majid Mohammadi and Siu Lun Chau, Krikamol Muandet. (2025). Computing Exact Shapley Values in Polynomial Time for Product-Kernel Methods. https://arxiv.org/abs/2505.16516
+        .. [quadrashap] Majid Mohammadi, Grigory Reznikov, Pavel Sinitcyn, Krikamol Muandet and Siu Lun Chau. (2026). QuadraSHAP: Stable and Scalable Shapley Values for Product Games via Gauss-Legendre Quadrature. https://arxiv.org/abs/2605.05870
 
     Attributes:
         model: The product kernel model to explain. Can be a dictionary, a ProductKernelModel, or a list of ProductKernelModels.
@@ -40,6 +40,7 @@ class ProductKernelExplainer(Explainer):
         max_order: The maximum interaction order to be computed. Defaults to ``1``.
         min_order: The minimum interaction order to be computed. Defaults to ``0``.
         index: The type of interaction to be computed. Currently, only ``"SV"`` is supported.
+        n_quadrature_points: The number of Gauss-Legendre nodes used for the computation.
     """
 
     def __init__(
@@ -51,6 +52,7 @@ class ProductKernelExplainer(Explainer):
         min_order: int = 0,
         max_order: int = 1,
         index: ProductKernelSHAPIQIndices = "SV",
+        n_quadrature_points: int | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
         """Initializes the ProductKernelExplainer.
@@ -64,6 +66,10 @@ class ProductKernelExplainer(Explainer):
                 corresponds to the Shapley value. Defaults to ``1``.
 
             index: The type of interaction to be computed. Currently, only ``"SV"`` is supported.
+
+            n_quadrature_points: The number of Gauss-Legendre nodes. Defaults to ``None``,
+                which uses the exact bound ``ceil(d / 2)`` for ``d`` features. Lower values
+                trade exactness for speed with a geometrically decaying error.
 
             class_index: The class index of the model to explain. Defaults to ``None``, which will
                 set the class index to ``1`` per default for classification models and is ignored
@@ -91,6 +97,7 @@ class ProductKernelExplainer(Explainer):
             model=self.converted_model,
             max_order=max_order,
             index=index,
+            n_quadrature_points=n_quadrature_points,
         )
 
         self.empty_prediction = self._compute_baseline_value()
@@ -111,12 +118,8 @@ class ProductKernelExplainer(Explainer):
         """
         n_players = self.converted_model.d
 
-        # compute the kernel vectors for the instance x
-        kernel_vectors = self.explainer.compute_kernel_vectors(self.converted_model.X_train, x)
-
-        shapley_values = {}
-        for j in range(self.converted_model.d):
-            shapley_values.update({(j,): self.explainer.compute_shapley_value(kernel_vectors, j)})
+        values = self.explainer.compute_shapley_values(x)
+        shapley_values = {(j,): float(values[j]) for j in range(n_players)}
 
         return InteractionValues(
             values=shapley_values,

--- a/src/shapiq/explainer/product_kernel/explainer.py
+++ b/src/shapiq/explainer/product_kernel/explainer.py
@@ -39,7 +39,8 @@ class ProductKernelExplainer(Explainer):
              For further details, see the `validate_pk_model` function in `shapiq.explainer.product_kernel.validation`.
         max_order: The maximum interaction order to be computed. Defaults to ``1``.
         min_order: The minimum interaction order to be computed. Defaults to ``0``.
-        index: The type of interaction to be computed. Currently, only ``"SV"`` is supported.
+        index: The type of value to be computed, either ``"SV"`` (Shapley value) or ``"BV"``
+            (Banzhaf value).
         n_quadrature_points: The number of Gauss-Legendre nodes used for the computation.
     """
 
@@ -65,11 +66,13 @@ class ProductKernelExplainer(Explainer):
             max_order: The maximum interaction order to be computed. An interaction order of ``1``
                 corresponds to the Shapley value. Defaults to ``1``.
 
-            index: The type of interaction to be computed. Currently, only ``"SV"`` is supported.
+            index: The type of value to be computed, either ``"SV"`` (Shapley value) or
+                ``"BV"`` (Banzhaf value). Defaults to ``"SV"``.
 
             n_quadrature_points: The number of Gauss-Legendre nodes. Defaults to ``None``,
                 which uses the exact bound ``ceil(d / 2)`` for ``d`` features. Lower values
-                trade exactness for speed with a geometrically decaying error.
+                trade exactness for speed with a geometrically decaying error. Ignored for
+                ``"BV"``, which is a single evaluation point.
 
             class_index: The class index of the model to explain. Defaults to ``None``, which will
                 set the class index to ``1`` per default for classification models and is ignored
@@ -107,10 +110,10 @@ class ProductKernelExplainer(Explainer):
         x: np.ndarray,
         **kwargs: Any,  # noqa: ARG002
     ) -> InteractionValues:
-        """Compute Shapley values for all features of an instance.
+        """Compute Shapley or Banzhaf values for all features of an instance.
 
         Args:
-           x: The instance (1D array) for which to compute Shapley values.
+           x: The instance (1D array) for which to compute the values.
            **kwargs: Additional keyword arguments are ignored.
 
         Returns:
@@ -118,11 +121,11 @@ class ProductKernelExplainer(Explainer):
         """
         n_players = self.converted_model.d
 
-        values = self.explainer.compute_shapley_values(x)
-        shapley_values = {(j,): float(values[j]) for j in range(n_players)}
+        values = self.explainer.compute_values(x)
+        attributions = {(j,): float(values[j]) for j in range(n_players)}
 
         return InteractionValues(
-            values=shapley_values,
+            values=attributions,
             index=self._base_index,
             min_order=self._min_order,
             max_order=self.max_order,

--- a/src/shapiq/explainer/product_kernel/explainer.py
+++ b/src/shapiq/explainer/product_kernel/explainer.py
@@ -26,10 +26,15 @@ class ProductKernelExplainer(Explainer):
     """The ProductKernelExplainer class for product kernel-based models.
 
     The ProductKernelExplainer can be used with a variety of product kernel-based models. The explainer can handle both regression and
-    classification models. See [quadrashap]_ for details.
+    classification models. The product-kernel game explained here, and the attribution method
+    defined on it, were proposed by [pkex-shapley]_. This explainer computes the same values
+    with the faster algorithm of [quadrashap]_, which replaces that paper's
+    elementary-symmetric-polynomial recursion by Gauss-Legendre quadrature of a one-dimensional
+    integral.
 
 
     References:
+        .. [pkex-shapley] Majid Mohammadi, Siu Lun Chau and Krikamol Muandet. (2025). Computing Exact Shapley Values in Polynomial Time for Product-Kernel Methods. https://arxiv.org/abs/2505.16516
         .. [quadrashap] Majid Mohammadi, Grigory Reznikov, Pavel Sinitcyn, Krikamol Muandet and Siu Lun Chau. (2026). QuadraSHAP: Stable and Scalable Shapley Values for Product Games via Gauss-Legendre Quadrature. https://arxiv.org/abs/2605.05870
 
     Attributes:

--- a/src/shapiq/explainer/product_kernel/explainer.py
+++ b/src/shapiq/explainer/product_kernel/explainer.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, cast
 
 from shapiq import InteractionValues
 from shapiq.explainer.base import Explainer
-from shapiq.explainer.custom_types import ExplainerIndices
 from shapiq.game_theory import get_computation_index
 
 from .product_kernel import ProductKernelComputer, ProductKernelSHAPIQIndices
@@ -17,6 +16,7 @@ if TYPE_CHECKING:
     from sklearn.gaussian_process import GaussianProcessRegressor
     from sklearn.svm import SVC, SVR
 
+    from shapiq.explainer.custom_types import ExplainerIndices
     from shapiq.typing import Model
 
     from .base import ProductKernelModel
@@ -120,6 +120,7 @@ class ProductKernelExplainer(Explainer):
         """
         n_players = self.converted_model.d
 
+        interactions: dict[tuple[int, ...], float] = {}
         if self._max_order == 1:
             # the first-order route skips building the subset lattice altogether
             values = self.explainer.compute_values(x)

--- a/src/shapiq/explainer/product_kernel/product_kernel.py
+++ b/src/shapiq/explainer/product_kernel/product_kernel.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING, Literal
+import warnings
+from itertools import combinations
+from typing import TYPE_CHECKING, Literal, get_args
 
 import numpy as np
 
@@ -10,10 +12,17 @@ from shapiq.game_theory.indices import get_computation_index
 if TYPE_CHECKING:
     from shapiq.explainer.product_kernel.base import ProductKernelModel
 
-ProductKernelSHAPIQIndices = Literal["SV", "BV"]
+ProductKernelSHAPIQIndices = Literal["SV", "BV", "SII", "k-SII", "BII", "Moebius"]
 
 #: Element budget for one quadrature chunk (~32 MiB per float64 temporary).
 _MAX_CHUNK_ELEMENTS = 1 << 22
+
+#: Interaction count above which an explanation becomes slow enough to warn about.
+_INTERACTION_WARNING_THRESHOLD = 10_000
+
+
+class ProductKernelInteractionSizeWarning(UserWarning):
+    """Warns that the requested interaction order enumerates very many interactions."""
 
 
 def _gauss_legendre_unit(n_points: int) -> tuple[np.ndarray, np.ndarray]:
@@ -48,6 +57,7 @@ class ProductKernelComputer:
         model: ProductKernelModel,
         *,
         max_order: int = 1,
+        min_order: int = 1,
         index: ProductKernelSHAPIQIndices = "SV",
         n_quadrature_points: int | None = None,
     ) -> None:
@@ -58,8 +68,12 @@ class ProductKernelComputer:
 
             max_order: The maximum interaction order to be computed. Defaults to ``1``.
 
-            index: The type of value to be computed, either ``"SV"`` (Shapley value) or
-                ``"BV"`` (Banzhaf value). Defaults to ``"SV"``.
+            min_order: The minimum interaction order to be computed. Order ``0`` is treated as
+                ``1``, since the empty interaction carries the baseline value. Defaults to ``1``.
+
+            index: The type of value to be computed. ``"SV"``, ``"SII"`` and ``"k-SII"`` are
+                computed from the Shapley base, ``"BV"`` and ``"BII"`` from the Banzhaf base,
+                and ``"Moebius"`` returns the Moebius coefficients. Defaults to ``"SV"``.
 
             n_quadrature_points: Number of Gauss-Legendre nodes. Defaults to ``None``, which
                 uses the exact bound ``ceil(d / 2)`` for ``d`` features. Smaller values trade
@@ -72,6 +86,12 @@ class ProductKernelComputer:
             ValueError: If ``n_quadrature_points`` is not positive.
 
         """
+        if index not in get_args(ProductKernelSHAPIQIndices):
+            msg = (
+                f"Index '{index}' is not supported by ProductKernelComputer. Supported indices "
+                f"are {get_args(ProductKernelSHAPIQIndices)}."
+            )
+            raise ValueError(msg)
         if n_quadrature_points is not None and n_quadrature_points < 1:
             msg = f"n_quadrature_points must be positive, got {n_quadrature_points}."
             raise ValueError(msg)
@@ -79,14 +99,31 @@ class ProductKernelComputer:
         self.model = model
         self.kernel_type = self.model.kernel_type
         self.max_order = max_order
+        self.min_order = min_order
         self.index = index
         self.d = model.d
 
-        if get_computation_index(index) == "BII":
+        self._orders = tuple(range(max(min_order, 1), max_order + 1))
+
+        base_index = get_computation_index(index)
+        if base_index == "Moebius":
+            # at t = 0 every remaining factor collapses to 1, leaving prod_{j in T} (u_j - 1)
+            self._nodes, self._weights = np.array([0.0]), np.array([1.0])
+        elif base_index == "BII":
             self._nodes, self._weights = np.array([0.5]), np.array([1.0])
         else:
             n_points = n_quadrature_points or math.ceil(self.d / 2)
             self._nodes, self._weights = _gauss_legendre_unit(max(n_points, 1))
+
+        n_interactions = sum(math.comb(self.d, order) for order in self._orders)
+        if n_interactions > _INTERACTION_WARNING_THRESHOLD:
+            msg = (
+                f"Explaining {self.d} features up to order {max_order} enumerates "
+                f"{n_interactions:,} interactions per instance. Every interaction of a product "
+                f"kernel is generically non-zero, so this cannot be sparsified; consider a lower "
+                f"max_order."
+            )
+            warnings.warn(msg, ProductKernelInteractionSizeWarning, stacklevel=3)
 
     def compute_kernel_matrix(self, x: np.ndarray) -> np.ndarray:
         """Compute the per-feature kernel factors of the explained instance.
@@ -110,7 +147,9 @@ class ProductKernelComputer:
         return np.exp(-gamma * (self.model.X_train - np.asarray(x)[None, :]) ** 2)
 
     def compute_values(self, x: np.ndarray) -> np.ndarray:
-        r"""Compute the Shapley or Banzhaf values of all features of an instance.
+        r"""Compute the first-order values of all features of an instance.
+
+        Use :meth:`compute_interaction_values` for interactions of order two and above.
 
         Evaluates the quadrature form of the product-game Shapley value
 
@@ -188,3 +227,78 @@ class ProductKernelComputer:
             # scale by the marginal factor and sum the reference points away: -> (features,)
             values += (integrated * leading).sum(axis=0)
         return values
+
+    def compute_interaction_values(self, x: np.ndarray) -> dict[tuple[int, ...], float]:
+        r"""Compute the interaction values of all feature subsets of an instance.
+
+        Lifts :meth:`compute_values` from single features to every order in
+        ``min_order..max_order``, using the same quadrature rule and the same shared
+        log-space product :math:`P_q`; see that method for the polynomial itself.
+
+        The discrete derivative of a product game with respect to a subset :math:`T` is
+        :math:`\Delta_T v(S) = \prod_{j \in T}(u_j - 1) \prod_{j \in S} u_j`, so an order-k
+        interaction is the first-order expression with two substitutions: the marginal factor
+        :math:`(u_\ell - 1)` becomes :math:`\prod_{j \in T}(u_j - 1)`, and the leave-one-out
+        product becomes the leave-:math:`T`-out product
+
+        .. math::
+            \prod_{j \notin T} T_{q,j} = \frac{P_q}{\prod_{j \in T} T_{q,j}}.
+
+        :math:`P_q` is still formed once per node and shared by every subset, so the extra
+        cost per interaction is one length-k sum in log-space.
+
+        Args:
+            x: The instance (1D array) for which to compute the values.
+
+        Returns:
+            A mapping from each feature subset to its interaction value.
+
+        """
+        # u: (ref_samples x features), u[i, j] = k_j(x_j, X_train[i, j])
+        u = self.compute_kernel_matrix(x)
+        n_samples, n_features = u.shape
+
+        interactions: dict[tuple[int, ...], float] = {}
+        for order in self._orders:
+            # subsets: (interactions x order), every feature subset T of this order
+            subsets = np.array(
+                list(combinations(range(n_features), order)), dtype=np.intp
+            ).reshape(-1, order)
+            # leading: (ref_samples x interactions), alpha_i * prod_{j in T} (u_{i,j} - 1)
+            leading = self.model.alpha[:, None] * np.prod(u[:, subsets] - 1.0, axis=-1)
+            values = np.zeros(len(subsets), dtype=np.float64)  # (interactions,)
+
+            # chunk both axes so the (nodes x ref_samples x ...) temporaries stay in budget
+            node_chunk = max(1, _MAX_CHUNK_ELEMENTS // max(n_samples * n_features, 1))
+            subset_chunk = max(1, _MAX_CHUNK_ELEMENTS // max(n_samples * node_chunk, 1))
+            for node_start in range(0, len(self._nodes), node_chunk):
+                # nodes: (nodes x 1 x 1), tau_q, broadcast over reference points and features
+                nodes = self._nodes[node_start : node_start + node_chunk][:, None, None]
+                # log_factors: (nodes x ref_samples x features), log T_{q,j} for
+                # T_{q,j} = (1 - tau_q) + tau_q u_j
+                log_factors = np.log((1.0 - nodes) + nodes * u[None, :, :])
+                # log_products: (nodes x ref_samples), log P_q, shared by all interactions
+                log_products = log_factors.sum(axis=-1)
+                weights = self._weights[node_start : node_start + node_chunk]  # (nodes,)
+
+                for subset_start in range(0, len(subsets), subset_chunk):
+                    chunk_subsets = subsets[subset_start : subset_start + subset_chunk]
+                    # leave_t_out: (nodes x ref_samples x interactions), the leave-T-out product
+                    # prod_{j not in T} T_{q,j} = P_q / prod_{j in T} T_{q,j}, in log-space.
+                    # log_factors.sum(axis=-1) compute the ``prod_{j in T} T_{q,j}`` expression -
+                    # as we are in log-space the prod is replaced by a sum. 
+                    leave_t_out = np.exp(
+                        log_products[:, :, None] - log_factors[:, :, chunk_subsets].sum(axis=-1)
+                    )
+                    # integrated: (ref_samples x interactions), the quadrature sum over the nodes
+                    integrated = np.tensordot(weights, leave_t_out, axes=(0, 0))
+                    # scale by the marginal factor and sum the reference points away
+                    stop = subset_start + len(chunk_subsets)
+                    values[subset_start:stop] += (
+                        integrated * leading[:, subset_start:stop]
+                    ).sum(axis=0)
+
+            interactions.update(
+                {tuple(int(j) for j in subset): float(v) for subset, v in zip(subsets, values)}
+            )
+        return interactions

--- a/src/shapiq/explainer/product_kernel/product_kernel.py
+++ b/src/shapiq/explainer/product_kernel/product_kernel.py
@@ -1,3 +1,5 @@
+"""Implementation of the ProductKernelComputer for product kernel-based models."""
+
 from __future__ import annotations
 
 import math
@@ -195,7 +197,7 @@ class ProductKernelComputer:
         u = self.compute_kernel_matrix(x)
         n_samples, n_features = u.shape
 
-        # leading: (ref_samples x features), include alpha_i * (u_{i,j} - 1) for each reference 
+        # leading: (ref_samples x features), include alpha_i * (u_{i,j} - 1) for each reference
         # row i and feature j.
         leading = self.model.alpha[:, None] * (u - 1.0)
 
@@ -203,23 +205,23 @@ class ProductKernelComputer:
         chunk = max(1, _MAX_CHUNK_ELEMENTS // max(n_samples * n_features, 1))
         values = np.zeros(n_features, dtype=np.float64)  # (features,)
         for start in range(0, len(self._nodes), chunk):
-            # nodes: (nodes x 1 x 1), tau_q, - the gauss legendre node q, broadcast over 
+            # nodes: (nodes x 1 x 1), tau_q, - the gauss legendre node q, broadcast over
             # reference points and features
             nodes = self._nodes[start : start + chunk][:, None, None]
             # log_factors: (nodes x ref_samples x features)
-            # log T_{q,j} for T_{q,j} = (1 - tau_q) + tau_q u_j; for every node q and feature j, 
-            # computed for every reference point. 
+            # log T_{q,j} for T_{q,j} = (1 - tau_q) + tau_q u_j; for every node q and feature j,
+            # computed for every reference point.
             log_factors = np.log((1.0 - nodes) + nodes * u[None, :, :])
-            # log_products: (nodes x ref_samples), log P_q, for every node q and reference point, 
+            # log_products: (nodes x ref_samples), log P_q, for every node q and reference point,
             # shared by all features.
             log_products = log_factors.sum(axis=-1)
             # leave_one_out: (nodes x ref_samples x features), the leave-one-out product
-            # prod_{j != l} T_{q,j} = P_q / T_{q,l}. We broadcast log_products to 
+            # prod_{j != l} T_{q,j} = P_q / T_{q,l}. We broadcast log_products to
             # (nodes x ref_samples x features), subtract log_factors, then exponentiate.
             leave_one_out = np.exp(log_products[:, :, None] - log_factors)
             # weights: (nodes,), the gauss legendre weights
             weights = self._weights[start : start + chunk]
-            # An inner product between weights (nodes,) and leave_one_out (nodes x ref_samples x features) 
+            # An inner product between weights (nodes,) and leave_one_out (nodes x ref_samples x features)
             # along the nodes axis, yielding (ref_samples x features).
             # integrated: (ref_samples x features) include the quadrature sum over the node axis, i.e.
             # the integral term of the Shapley formula for every (reference point, feature)
@@ -261,9 +263,9 @@ class ProductKernelComputer:
         interactions: dict[tuple[int, ...], float] = {}
         for order in self._orders:
             # subsets: (interactions x order), every feature subset T of this order
-            subsets = np.array(
-                list(combinations(range(n_features), order)), dtype=np.intp
-            ).reshape(-1, order)
+            subsets = np.array(list(combinations(range(n_features), order)), dtype=np.intp).reshape(
+                -1, order
+            )
             # leading: (ref_samples x interactions), alpha_i * prod_{j in T} (u_{i,j} - 1)
             leading = self.model.alpha[:, None] * np.prod(u[:, subsets] - 1.0, axis=-1)
             values = np.zeros(len(subsets), dtype=np.float64)  # (interactions,)
@@ -286,7 +288,7 @@ class ProductKernelComputer:
                     # leave_t_out: (nodes x ref_samples x interactions), the leave-T-out product
                     # prod_{j not in T} T_{q,j} = P_q / prod_{j in T} T_{q,j}, in log-space.
                     # log_factors.sum(axis=-1) compute the ``prod_{j in T} T_{q,j}`` expression -
-                    # as we are in log-space the prod is replaced by a sum. 
+                    # as we are in log-space the prod is replaced by a sum.
                     leave_t_out = np.exp(
                         log_products[:, :, None] - log_factors[:, :, chunk_subsets].sum(axis=-1)
                     )
@@ -294,11 +296,14 @@ class ProductKernelComputer:
                     integrated = np.tensordot(weights, leave_t_out, axes=(0, 0))
                     # scale by the marginal factor and sum the reference points away
                     stop = subset_start + len(chunk_subsets)
-                    values[subset_start:stop] += (
-                        integrated * leading[:, subset_start:stop]
-                    ).sum(axis=0)
+                    values[subset_start:stop] += (integrated * leading[:, subset_start:stop]).sum(
+                        axis=0
+                    )
 
             interactions.update(
-                {tuple(int(j) for j in subset): float(v) for subset, v in zip(subsets, values)}
+                {
+                    tuple(int(j) for j in subset): float(v)
+                    for subset, v in zip(subsets, values, strict=False)
+                }
             )
         return interactions

--- a/src/shapiq/explainer/product_kernel/product_kernel.py
+++ b/src/shapiq/explainer/product_kernel/product_kernel.py
@@ -1,27 +1,34 @@
-"""Implementation of ProductKernelSHAPIQ for computing Shapley values."""
-
 from __future__ import annotations
 
 import math
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
-from sklearn.metrics.pairwise import rbf_kernel
 
 if TYPE_CHECKING:
     from shapiq.explainer.product_kernel.base import ProductKernelModel
 
 ProductKernelSHAPIQIndices = Literal["SV"]
 
+#: Element budget for one quadrature chunk (~32 MiB per float64 temporary).
+_MAX_CHUNK_ELEMENTS = 1 << 22
+
+
+def _gauss_legendre_unit(n_points: int) -> tuple[np.ndarray, np.ndarray]:
+    """Gauss-Legendre nodes and weights on the unit interval ``[0, 1]``."""
+    nodes, weights = np.polynomial.legendre.leggauss(n_points)
+    return 0.5 * (nodes + 1.0), 0.5 * weights
+
 
 class ProductKernelComputer:
     """The Product Kernel Computer for product kernel-based models.
 
     This class computes the Shapley values for product kernel-based models.
-    The functions are obtained from the PKeX-Shapley LocalExplainer. https://github.com/Majeed7/RKHS-ExactSHAP/blob/main/explainer/LocalExplainer.py#L3
+    The Shapley values are computed by Gauss-Legendre quadrature of the product-game integral,
+    which is exact with ``ceil(d / 2)`` nodes for ``d`` features. See [quadrashap]_ for details.
 
     References:
-        -- [pkex-shapley] Majid Mohammadi and Siu Lun Chau, Krikamol Muandet. (2025). Computing Exact Shapley Values in Polynomial Time for Product-Kernel Methods. https://arxiv.org/abs/2505.16516
+        -- [quadrashap] Majid Mohammadi, Grigory Reznikov, Pavel Sinitcyn, Krikamol Muandet and Siu Lun Chau. (2026). QuadraSHAP: Stable and Scalable Shapley Values for Product Games via Gauss-Legendre Quadrature. https://arxiv.org/abs/2605.05870
 
     Attributes:
         model: The product kernel model to explain.
@@ -38,125 +45,134 @@ class ProductKernelComputer:
         *,
         max_order: int = 1,
         index: ProductKernelSHAPIQIndices = "SV",
+        n_quadrature_points: int | None = None,
     ) -> None:
-        """Initializes the ProductKernelSHAPIQ explainer.
+        """Initializes the product kernel computer.
 
         Args:
             model: A product kernel-based model to explain.
+
             max_order: The maximum interaction order to be computed. Defaults to ``1``.
+
             index: The type of interaction to be computed. Defaults to ``"SV"``.
 
-        Returns:
-            None.
+            n_quadrature_points: Number of Gauss-Legendre nodes. Defaults to ``None``, which
+                uses the exact bound ``ceil(d / 2)`` for ``d`` features. Smaller values trade
+                exactness for speed with a geometrically decaying error and are worthwhile
+                only for very high-dimensional models, where a few hundred nodes already
+                reach float64 precision.
+
+        Raises:
+            ValueError: If ``n_quadrature_points`` is not positive.
+
         """
+        if n_quadrature_points is not None and n_quadrature_points < 1:
+            msg = f"n_quadrature_points must be positive, got {n_quadrature_points}."
+            raise ValueError(msg)
+
         self.model = model
         self.kernel_type = self.model.kernel_type
         self.max_order = max_order
         self.index = index
         self.d = model.d
 
-    def precompute_weights(self, num_features: int) -> np.ndarray:
-        """Precompute model weights (mu coefficients) for computing Shapley values.
+        n_points = n_quadrature_points or math.ceil(self.d / 2)
+        self._nodes, self._weights = _gauss_legendre_unit(max(n_points, 1))
+
+    def compute_kernel_matrix(self, x: np.ndarray) -> np.ndarray:
+        """Compute the per-feature kernel factors of the explained instance.
 
         Args:
-            num_features: Number of features.
-
-        Returns:
-            List of precomputed mu coefficients.
-        """
-        unnormalized_factors = [
-            (math.factorial(q) * math.factorial(num_features - q - 1)) for q in range(num_features)
-        ]
-
-        return np.array(unnormalized_factors) / math.factorial(num_features)
-
-    def compute_elementary_symmetric_polynomials(self, kernel_vectors: list) -> list:
-        """Compute elementary symmetric polynomials using a dynamic programming approach.
-
-        Args:
-            kernel_vectors: List of kernel vectors (1D arrays).
-
-        Returns:
-            List of elementary symmetric polynomials.
-        """
-        # Initialize with e_0 = 1
-        max_abs_k = max(np.max(np.abs(k)) for k in kernel_vectors) or 1.0
-        scaled_kernel = [k / max_abs_k for k in kernel_vectors]
-
-        # Initialize polynomial coefficients: P_0(x) = 1
-        e = [np.ones_like(scaled_kernel[0], dtype=np.float64)]
-
-        for k in scaled_kernel:
-            # Prepend and append zeros to handle polynomial multiplication (x - k)
-            new_e = [np.zeros_like(e[0])] * (len(e) + 1)
-            # new_e[0] corresponds to the constant term after multiplying by (x - k)
-            new_e[0] = -k * e[0]
-            # Compute the rest of the terms
-            for i in range(1, len(e)):
-                new_e[i] = e[i - 1] - k * e[i]
-            # The highest degree term is x^{len(e)}, coefficient is e[-1] (which is 1 initially)
-            new_e[len(e)] = e[-1].copy()
-            e = new_e
-
-        # Extract elementary symmetric polynomials from the coefficients
-        n = len(scaled_kernel)
-        elementary = [np.ones_like(e[0])]  # e_0 = 1
-        for r in range(1, n + 1):
-            sign = (-1) ** r
-            elementary_r = sign * e[n - r] * (max_abs_k**r)
-            elementary.append(elementary_r)
-
-        return elementary
-
-    def compute_shapley_value(self, kernel_vectors: list, feature_index: int) -> float:
-        """Compute the Shapley value for a specific feature of an instance.
-
-        Args:
-            kernel_vectors: List of kernel vectors (1D arrays).
-            feature_index: Index of the feature.
-
-        Returns:
-           Shapley value for the specified feature.
-        """
-        alpha = self.model.alpha
-        cZ_minus_j = [kernel_vectors[i] for i in range(self.model.d) if i != feature_index]
-        e_polynomials = self.compute_elementary_symmetric_polynomials(cZ_minus_j)
-        mu_coefficients = self.precompute_weights(self.model.d)
-
-        # Compute kernel vector for the chosen feature
-        k_j = kernel_vectors[feature_index]
-        onevec = np.ones_like(k_j)
-
-        # Compute the Shapley value
-        result = np.zeros_like(k_j)
-        for q in range(self.model.d):
-            if q < len(e_polynomials):
-                result += mu_coefficients[q] * e_polynomials[q]
-
-        shapley_value = alpha.dot((k_j - onevec) * result)
-
-        return shapley_value.item()
-
-    def compute_kernel_vectors(self, X: np.ndarray, x: np.ndarray) -> list:
-        """Compute kernel vectors for a given dataset X and instance x.
-
-        Args:
-            X: The dataset (2D array) used to train the model.
             x: The instance (1D array) for which to compute Shapley values.
 
         Returns:
-            List of kernel vectors corresponding to each feature. Length = number of features.
+            The ``(n, d)`` matrix ``u`` with ``u[i, j] = k_j(x_j, X_train[i, j])``.
+
+        Raises:
+            NotImplementedError: If the kernel type is not supported.
+
         """
-        # Initialize the kernel matrix
-        kernel_vectors = []
+        if self.kernel_type != "rbf":
+            msg = f"Kernel type '{self.kernel_type}' not supported."
+            raise NotImplementedError(msg)
+        # an unset gamma resolves to 1.0, matching what sklearn's rbf_kernel defaulted to when
+        # the previous implementation called it once per single-column feature slice
+        gamma = 1.0 if self.model.gamma is None else self.model.gamma
+        return np.exp(-gamma * (self.model.X_train - np.asarray(x)[None, :]) ** 2)
 
-        # For each sample and each feature, compute k(x_i^j, x^j)
-        for i in range(self.d):
-            kernel_vec = rbf_kernel(
-                X[:, i].reshape(-1, 1),
-                x[..., np.newaxis][i].reshape(1, -1),
-                gamma=self.model.gamma,
-            )
-            kernel_vectors.append(kernel_vec.squeeze())
+    def compute_shapley_values(self, x: np.ndarray) -> np.ndarray:
+        r"""Compute the Shapley values of all features of an instance.
 
-        return kernel_vectors
+        Evaluates the quadrature form of the product-game Shapley value
+
+        .. math::
+            \phi_\ell = (u_\ell - 1) \sum_{q=1}^{m_q} \omega_q
+            \prod_{j \neq \ell} \big((1 - \tau_q) + \tau_q u_j\big),
+
+        where :math:`\{(\tau_q, \omega_q)\}_{q=1}^{m_q}` are the Gauss-Legendre nodes and
+        weights on :math:`[0, 1]`, and :math:`u_j` are the per-feature kernel factors of one
+        reference point. The values of the model are the :math:`\alpha`-weighted sum of these
+        over all reference points.
+
+        Taken literally the formula rebuilds a leave-one-out product for each of the :math:`d`
+        features, costing :math:`O(n d^2 m_q)`. Instead the per-feature factors and their full
+        product
+
+        .. math::
+            T_{q,j} = (1 - \tau_q) + \tau_q u_j, \qquad P_q = \prod_{j=1}^{d} T_{q,j},
+
+        are formed once per node, so that every leave-one-out product is a single division
+
+        .. math::
+            \prod_{j \neq \ell} T_{q,j} = \frac{P_q}{T_{q,\ell}},
+
+        which shares the work across features and brings the cost down to :math:`O(n d m_q)`.
+        For better accuracy, the division is carried out in log-space,
+
+        .. math::
+            \phi_\ell = (u_\ell - 1) \sum_{q=1}^{m_q} \omega_q
+            \exp\big(\log P_q - \log T_{q,\ell}\big),
+
+        Args:
+            x: The instance (1D array) for which to compute Shapley values.
+
+        Returns:
+            The Shapley values as a 1D array of length ``d``.
+
+        """
+        # u: (ref_samples x features), u[i, j] = k_j(x_j, X_train[i, j])
+        u = self.compute_kernel_matrix(x)
+        n_samples, n_features = u.shape
+
+        # leading: (ref_samples x features), include alpha_i * (u_{i,j} - 1) for each reference 
+        # row i and feature j.
+        leading = self.model.alpha[:, None] * (u - 1.0)
+
+        # chunk the nodes so the (nodes x ref_samples x features) temporaries stay in budget
+        chunk = max(1, _MAX_CHUNK_ELEMENTS // max(n_samples * n_features, 1))
+        shapley_values = np.zeros(n_features, dtype=np.float64)  # (features,)
+        for start in range(0, len(self._nodes), chunk):
+            # nodes: (nodes x 1 x 1), tau_q, - the gauss legendre node q, broadcast over 
+            # reference points and features
+            nodes = self._nodes[start : start + chunk][:, None, None]
+            # log_factors: (nodes x ref_samples x features)
+            # log T_{q,j} for T_{q,j} = (1 - tau_q) + tau_q u_j; for every node q and feature j, 
+            # computed for every reference point. 
+            log_factors = np.log((1.0 - nodes) + nodes * u[None, :, :])
+            # log_products: (nodes x ref_samples), log P_q, for every node q and reference point, 
+            # shared by all features.
+            log_products = log_factors.sum(axis=-1)
+            # leave_one_out: (nodes x ref_samples x features), the leave-one-out product
+            # prod_{j != l} T_{q,j} = P_q / T_{q,l}. We broadcast log_products to 
+            # (nodes x ref_samples x features), subtract log_factors, then exponentiate.
+            leave_one_out = np.exp(log_products[:, :, None] - log_factors)
+            # weights: (nodes,), the gauss legendre weights
+            weights = self._weights[start : start + chunk]
+            # An inner product between weights (nodes,) and leave_one_out (nodes x ref_samples x features) 
+            # along the nodes axis, yielding (ref_samples x features).
+            # integrated: (ref_samples x features) include the quadrature sum over the node axis, i.e.
+            # the integral term of the Shapley formula for every (reference point, feature)
+            integrated = np.tensordot(weights, leave_one_out, axes=(0, 0))
+            # scale by the marginal factor and sum the reference points away: -> (features,)
+            shapley_values += (integrated * leading).sum(axis=0)
+        return shapley_values

--- a/src/shapiq/explainer/product_kernel/product_kernel.py
+++ b/src/shapiq/explainer/product_kernel/product_kernel.py
@@ -5,10 +5,12 @@ from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
+from shapiq.game_theory.indices import get_computation_index
+
 if TYPE_CHECKING:
     from shapiq.explainer.product_kernel.base import ProductKernelModel
 
-ProductKernelSHAPIQIndices = Literal["SV"]
+ProductKernelSHAPIQIndices = Literal["SV", "BV"]
 
 #: Element budget for one quadrature chunk (~32 MiB per float64 temporary).
 _MAX_CHUNK_ELEMENTS = 1 << 22
@@ -23,9 +25,11 @@ def _gauss_legendre_unit(n_points: int) -> tuple[np.ndarray, np.ndarray]:
 class ProductKernelComputer:
     """The Product Kernel Computer for product kernel-based models.
 
-    This class computes the Shapley values for product kernel-based models.
+    This class computes the Shapley and Banzhaf values for product kernel-based models.
+
     The Shapley values are computed by Gauss-Legendre quadrature of the product-game integral,
     which is exact with ``ceil(d / 2)`` nodes for ``d`` features. See [quadrashap]_ for details.
+    The Banzhaf values are computed by a single ``t = 1/2`` evaluation of this product-game polynomial.
 
     References:
         -- [quadrashap] Majid Mohammadi, Grigory Reznikov, Pavel Sinitcyn, Krikamol Muandet and Siu Lun Chau. (2026). QuadraSHAP: Stable and Scalable Shapley Values for Product Games via Gauss-Legendre Quadrature. https://arxiv.org/abs/2605.05870
@@ -34,7 +38,7 @@ class ProductKernelComputer:
         model: The product kernel model to explain.
         kernel_type: The type of kernel to be used. Defaults to ``"rbf"``.
         max_order: The maximum interaction order to be computed. Defaults to ``1``.
-        index: The type of interaction to be computed. Defaults to ``"SV"``.
+        index: The type of value to be computed, ``"SV"`` or ``"BV"``. Defaults to ``"SV"``.
         d: The number of features in the model.
 
     """
@@ -54,13 +58,15 @@ class ProductKernelComputer:
 
             max_order: The maximum interaction order to be computed. Defaults to ``1``.
 
-            index: The type of interaction to be computed. Defaults to ``"SV"``.
+            index: The type of value to be computed, either ``"SV"`` (Shapley value) or
+                ``"BV"`` (Banzhaf value). Defaults to ``"SV"``.
 
             n_quadrature_points: Number of Gauss-Legendre nodes. Defaults to ``None``, which
                 uses the exact bound ``ceil(d / 2)`` for ``d`` features. Smaller values trade
                 exactness for speed with a geometrically decaying error and are worthwhile
                 only for very high-dimensional models, where a few hundred nodes already
-                reach float64 precision.
+                reach float64 precision. Ignored for ``"BV"``, which is a single evaluation
+                point rather than a quadrature rule.
 
         Raises:
             ValueError: If ``n_quadrature_points`` is not positive.
@@ -76,14 +82,17 @@ class ProductKernelComputer:
         self.index = index
         self.d = model.d
 
-        n_points = n_quadrature_points or math.ceil(self.d / 2)
-        self._nodes, self._weights = _gauss_legendre_unit(max(n_points, 1))
+        if get_computation_index(index) == "BII":
+            self._nodes, self._weights = np.array([0.5]), np.array([1.0])
+        else:
+            n_points = n_quadrature_points or math.ceil(self.d / 2)
+            self._nodes, self._weights = _gauss_legendre_unit(max(n_points, 1))
 
     def compute_kernel_matrix(self, x: np.ndarray) -> np.ndarray:
         """Compute the per-feature kernel factors of the explained instance.
 
         Args:
-            x: The instance (1D array) for which to compute Shapley values.
+            x: The instance (1D array) for which to compute the values.
 
         Returns:
             The ``(n, d)`` matrix ``u`` with ``u[i, j] = k_j(x_j, X_train[i, j])``.
@@ -100,8 +109,8 @@ class ProductKernelComputer:
         gamma = 1.0 if self.model.gamma is None else self.model.gamma
         return np.exp(-gamma * (self.model.X_train - np.asarray(x)[None, :]) ** 2)
 
-    def compute_shapley_values(self, x: np.ndarray) -> np.ndarray:
-        r"""Compute the Shapley values of all features of an instance.
+    def compute_values(self, x: np.ndarray) -> np.ndarray:
+        r"""Compute the Shapley or Banzhaf values of all features of an instance.
 
         Evaluates the quadrature form of the product-game Shapley value
 
@@ -133,11 +142,14 @@ class ProductKernelComputer:
             \phi_\ell = (u_\ell - 1) \sum_{q=1}^{m_q} \omega_q
             \exp\big(\log P_q - \log T_{q,\ell}\big),
 
+        For ``index="BV"`` the very same expression runs with the single node
+        :math:`\tau = 1/2` and weight :math:`\omega = 1`.
+
         Args:
-            x: The instance (1D array) for which to compute Shapley values.
+            x: The instance (1D array) for which to compute the values.
 
         Returns:
-            The Shapley values as a 1D array of length ``d``.
+            The Shapley (or Banzhaf) values as a 1D array of length ``d``.
 
         """
         # u: (ref_samples x features), u[i, j] = k_j(x_j, X_train[i, j])
@@ -150,7 +162,7 @@ class ProductKernelComputer:
 
         # chunk the nodes so the (nodes x ref_samples x features) temporaries stay in budget
         chunk = max(1, _MAX_CHUNK_ELEMENTS // max(n_samples * n_features, 1))
-        shapley_values = np.zeros(n_features, dtype=np.float64)  # (features,)
+        values = np.zeros(n_features, dtype=np.float64)  # (features,)
         for start in range(0, len(self._nodes), chunk):
             # nodes: (nodes x 1 x 1), tau_q, - the gauss legendre node q, broadcast over 
             # reference points and features
@@ -174,5 +186,5 @@ class ProductKernelComputer:
             # the integral term of the Shapley formula for every (reference point, feature)
             integrated = np.tensordot(weights, leave_one_out, axes=(0, 0))
             # scale by the marginal factor and sum the reference points away: -> (features,)
-            shapley_values += (integrated * leading).sum(axis=0)
-        return shapley_values
+            values += (integrated * leading).sum(axis=0)
+        return values

--- a/tests/shapiq/tests_unit/tests_explainer/test_productkernel_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/test_productkernel_explainer.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import copy
 
+import numpy as np
 import pytest
 from sklearn.gaussian_process import GaussianProcessClassifier
 
-from shapiq.explainer.product_kernel import ProductKernelExplainer
+from shapiq.explainer.product_kernel import (
+    ProductKernelComputer,
+    ProductKernelExplainer,
+    ProductKernelModel,
+)
 from shapiq.explainer.product_kernel.conversion import convert_gp_reg, convert_svm
 from shapiq.explainer.product_kernel.game import (
     ProductKernelGame,
@@ -138,3 +143,67 @@ def test_gp_reg_against_exact_computer(gp_reg_model, background_reg_data):
     model_prediction_scalar = model_prediction.item()
 
     assert model_prediction_scalar == pytest.approx(sum_values)
+
+
+def test_invalid_quadrature_points(svr_model):
+    """Test that a non-positive number of quadrature points is rejected."""
+    with pytest.raises(ValueError, match="n_quadrature_points"):
+        _ = ProductKernelExplainer(model=svr_model, n_quadrature_points=0)
+
+    with pytest.raises(ValueError, match="n_quadrature_points"):
+        _ = ProductKernelExplainer(model=svr_model, n_quadrature_points=-3)
+
+
+def test_svr_quadrature_is_exact(svr_model, background_reg_data):
+    """Test that the default quadrature rule reproduces the exact Shapley values."""
+    x_explain = background_reg_data[0]
+    n_players = svr_model.n_features_in_
+
+    explanation = ProductKernelExplainer(model=svr_model).explain(x_explain)
+
+    game = ProductKernelGame(
+        model=convert_svm(svr_model),
+        n_players=n_players,
+        explain_point=x_explain,
+        normalize=False,
+    )
+    exact = ExactComputer(game=game, n_players=n_players)("SV")
+
+    for player in range(n_players):
+        assert explanation[(player,)] == pytest.approx(exact[(player,)], abs=1e-10)
+
+
+def test_fewer_quadrature_points_stay_close(svr_model, background_reg_data):
+    """Test that dropping below the exactness bound degrades smoothly rather than abruptly."""
+    x_explain = background_reg_data[0]
+    n_players = svr_model.n_features_in_
+
+    exact = ProductKernelExplainer(model=svr_model).explain(x_explain)
+    approx = ProductKernelExplainer(model=svr_model, n_quadrature_points=2).explain(x_explain)
+
+    scale = max(abs(exact[(player,)]) for player in range(n_players))
+    for player in range(n_players):
+        assert approx[(player,)] == pytest.approx(exact[(player,)], abs=0.05 * scale)
+
+
+def test_single_feature_model():
+    """Test a model with a single feature, where the leave-one-out product is empty."""
+    rng = np.random.default_rng(0)
+    x_train, alpha = rng.normal(size=(5, 1)), rng.normal(size=5)
+    model = ProductKernelModel(X_train=x_train, alpha=alpha, n=5, d=1, gamma=1.0)
+    x_explain = rng.normal(size=1)
+
+    values = ProductKernelComputer(model).compute_shapley_values(x_explain)
+
+    # with one player the Shapley value is the full marginal contribution v({0}) - v({})
+    kernel = np.exp(-model.gamma * (x_train[:, 0] - x_explain[0]) ** 2)
+    assert values[0] == pytest.approx(float(alpha @ (kernel - 1.0)))
+
+
+def test_unsupported_kernel_type():
+    """Test that the computer rejects kernels it cannot factorize."""
+    model = ProductKernelModel(
+        X_train=np.zeros((2, 2)), alpha=np.zeros(2), n=2, d=2, gamma=1.0, kernel_type="linear"
+    )
+    with pytest.raises(NotImplementedError, match="linear"):
+        ProductKernelComputer(model).compute_shapley_values(np.zeros(2))

--- a/tests/shapiq/tests_unit/tests_explainer/test_productkernel_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/test_productkernel_explainer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import warnings
 
 import numpy as np
 import pytest
@@ -17,13 +18,20 @@ from shapiq.explainer.product_kernel.conversion import convert_gp_reg, convert_s
 from shapiq.explainer.product_kernel.game import (
     ProductKernelGame,
 )
+from shapiq.explainer.product_kernel.product_kernel import (
+    ProductKernelInteractionSizeWarning,
+)
+from shapiq.explainer.product_kernel.validation import validate_pk_model
 from shapiq.game_theory.exact import ExactComputer
 
 
 def test_invalid_application(bin_svc_model, background_clf_dataset_binary):
     """Test the product kernel explainer with an invalid application."""
-    with pytest.raises(ValueError):
-        _ = ProductKernelExplainer(model=bin_svc_model, max_order=2, index="SV")
+    with pytest.raises(ValueError, match="not supported"):
+        _ = ProductKernelExplainer(model=bin_svc_model, max_order=2, index="FSII")
+
+    with pytest.raises(ValueError, match="min_order"):
+        _ = ProductKernelExplainer(model=bin_svc_model, max_order=2, index="SII", min_order=3)
 
     non_rbf_svm = copy.deepcopy(bin_svc_model)
     non_rbf_svm.kernel = "linear"
@@ -222,3 +230,40 @@ def test_banzhaf_ignores_quadrature_points(svr_model, background_reg_data):
 
     for player in range(n_players):
         assert default[(player,)] == with_points[(player,)]
+
+
+@pytest.mark.parametrize("index", ["SII", "k-SII", "BII", "Moebius"])
+@pytest.mark.parametrize("order", [2, 3])
+def test_interactions_against_exact_computer(svr_model, background_reg_data, index, order):
+    """Test that every interaction index matches the exact computer at any order."""
+    x_explain = background_reg_data[0]
+    n_players = svr_model.n_features_in_
+
+    explanation = ProductKernelExplainer(
+        model=svr_model, index=index, max_order=order
+    ).explain(x_explain)
+
+    game = ProductKernelGame(
+        model=convert_svm(svr_model),
+        n_players=n_players,
+        explain_point=x_explain,
+        normalize=False,
+    )
+    # the k-SII aggregation depends on the truncation order, so the exact computer needs it too
+    exact = ExactComputer(game=game, n_players=n_players)(explanation.index, order=order)
+
+    assert explanation.max_order == order
+    for interaction in explanation.interaction_lookup:
+        if interaction:
+            assert explanation[interaction] == pytest.approx(exact[interaction], abs=1e-10)
+
+
+def test_many_interactions_warns():
+    """Test that an explanation enumerating very many interactions warns."""
+    rng = np.random.default_rng(0)
+    d = 300
+    model = ProductKernelModel(
+        X_train=rng.normal(size=(2, d)), alpha=rng.normal(size=2), n=2, d=d, gamma=0.1
+    )
+    with pytest.warns(ProductKernelInteractionSizeWarning, match="45,150 interactions"):
+        _ = ProductKernelComputer(model, index="SII", max_order=2)

--- a/tests/shapiq/tests_unit/tests_explainer/test_productkernel_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/test_productkernel_explainer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import copy
-import warnings
 
 import numpy as np
 import pytest
@@ -21,7 +20,6 @@ from shapiq.explainer.product_kernel.game import (
 from shapiq.explainer.product_kernel.product_kernel import (
     ProductKernelInteractionSizeWarning,
 )
-from shapiq.explainer.product_kernel.validation import validate_pk_model
 from shapiq.game_theory.exact import ExactComputer
 
 
@@ -239,9 +237,9 @@ def test_interactions_against_exact_computer(svr_model, background_reg_data, ind
     x_explain = background_reg_data[0]
     n_players = svr_model.n_features_in_
 
-    explanation = ProductKernelExplainer(
-        model=svr_model, index=index, max_order=order
-    ).explain(x_explain)
+    explanation = ProductKernelExplainer(model=svr_model, index=index, max_order=order).explain(
+        x_explain
+    )
 
     game = ProductKernelGame(
         model=convert_svm(svr_model),

--- a/tests/shapiq/tests_unit/tests_explainer/test_productkernel_explainer.py
+++ b/tests/shapiq/tests_unit/tests_explainer/test_productkernel_explainer.py
@@ -154,12 +154,13 @@ def test_invalid_quadrature_points(svr_model):
         _ = ProductKernelExplainer(model=svr_model, n_quadrature_points=-3)
 
 
-def test_svr_quadrature_is_exact(svr_model, background_reg_data):
-    """Test that the default quadrature rule reproduces the exact Shapley values."""
+@pytest.mark.parametrize("index", ["SV", "BV"])
+def test_svr_quadrature_is_exact(svr_model, background_reg_data, index):
+    """Test that the default rule reproduces the exact values for both supported indices."""
     x_explain = background_reg_data[0]
     n_players = svr_model.n_features_in_
 
-    explanation = ProductKernelExplainer(model=svr_model).explain(x_explain)
+    explanation = ProductKernelExplainer(model=svr_model, index=index).explain(x_explain)
 
     game = ProductKernelGame(
         model=convert_svm(svr_model),
@@ -167,7 +168,7 @@ def test_svr_quadrature_is_exact(svr_model, background_reg_data):
         explain_point=x_explain,
         normalize=False,
     )
-    exact = ExactComputer(game=game, n_players=n_players)("SV")
+    exact = ExactComputer(game=game, n_players=n_players)(index)
 
     for player in range(n_players):
         assert explanation[(player,)] == pytest.approx(exact[(player,)], abs=1e-10)
@@ -193,7 +194,7 @@ def test_single_feature_model():
     model = ProductKernelModel(X_train=x_train, alpha=alpha, n=5, d=1, gamma=1.0)
     x_explain = rng.normal(size=1)
 
-    values = ProductKernelComputer(model).compute_shapley_values(x_explain)
+    values = ProductKernelComputer(model).compute_values(x_explain)
 
     # with one player the Shapley value is the full marginal contribution v({0}) - v({})
     kernel = np.exp(-model.gamma * (x_train[:, 0] - x_explain[0]) ** 2)
@@ -206,4 +207,18 @@ def test_unsupported_kernel_type():
         X_train=np.zeros((2, 2)), alpha=np.zeros(2), n=2, d=2, gamma=1.0, kernel_type="linear"
     )
     with pytest.raises(NotImplementedError, match="linear"):
-        ProductKernelComputer(model).compute_shapley_values(np.zeros(2))
+        ProductKernelComputer(model).compute_values(np.zeros(2))
+
+
+def test_banzhaf_ignores_quadrature_points(svr_model, background_reg_data):
+    """Test that ``n_quadrature_points`` has no effect on Banzhaf values."""
+    x_explain = background_reg_data[0]
+    n_players = svr_model.n_features_in_
+
+    default = ProductKernelExplainer(model=svr_model, index="BV").explain(x_explain)
+    with_points = ProductKernelExplainer(
+        model=svr_model, index="BV", n_quadrature_points=99
+    ).explain(x_explain)
+
+    for player in range(n_players):
+        assert default[(player,)] == with_points[(player,)]


### PR DESCRIPTION
## Motivation and Context

Improve the ProductKernelExplainer.
1. Speed up the approach by more than an order of magnitude. I implemented the algorithm from the recent paper: https://arxiv.org/pdf/2605.05870. The paper reduce the approach complexity from O(n*d^3) to O(n*d^2) where d is the number of features and n is the number of reference points (the support vectors of an SVM, the training set of a Gaussian process). The new approach implementation is fully vectorized using numpy.
2. I extended the approach in the paper to more indices. The ProductKernelExplainer now support not just SV but also BV and interaction values including SII, k-SII, BII and Mobius.

See the full details, including the math behind the approach and running time results in the attached PDF below:
[product_kernel_computer.pdf](https://github.com/user-attachments/files/31700689/product_kernel_computer.pdf)


---

## Public API Changes

-   [ ] No Public API changes
-   [X] Yes, Public API changes (Details below)

ProductKernelExplainer now support more index options (BV, SII, k-SII, BII, Mobius). It also include a n_quadrature_points parameter that allow the user to use less points then the theoretically exact approach, get a very good approximation and better running times. 

The API of ProductKernelComputer was changed. It's not part of the Public API though, isn't it?

---

## How Has This Been Tested?
Added tests comparing this approach values to exact computation. Also I manually compared the values of the new approach to the ones of the old approach.

---

## Checklist

-   [X] The changes have been tested locally.
-   [X] Documentation has been updated (if the public API or usage changes).
-   [X] An entry has been added to `CHANGELOG.md` (if relevant for users).
-   [X] The code follows the project's style guidelines.
-   [X] I have considered the impact of these changes on the public API.

---
